### PR TITLE
fix: address remaining unresolved PR #33 Copilot comments

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -671,7 +671,9 @@ jobs:
           cp "templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
           mkdir -p "$REPO_DIR/scripts"
           cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
+          cp "templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
           chmod +x "$REPO_DIR/scripts/provider-run.sh"
+          chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
 
           # Substitute repository placeholders in generated tooling files
           if [ -f "$REPO_DIR/environment.yml" ]; then

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -597,7 +597,9 @@ jobs:
           cp "templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
           mkdir -p "$REPO_DIR/scripts"
           cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
+          cp "templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
           chmod +x "$REPO_DIR/scripts/provider-run.sh"
+          chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
 
           # Substitute repository placeholders in generated tooling files
           if [ -f "$REPO_DIR/environment.yml" ]; then

--- a/templates/providers/micromamba/provider-run.sh
+++ b/templates/providers/micromamba/provider-run.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MICROMAMBA_BIN="$ROOT_DIR/.provider/bin/micromamba"
 
+if [[ $# -eq 0 ]]; then
+    echo "Usage: scripts/provider-run.sh <command> [args...]" >&2
+    exit 1
+fi
+
 if [[ ! -x "$MICROMAMBA_BIN" ]]; then
     bash "$ROOT_DIR/scripts/bootstrap-provider-binary.sh" micromamba "$MICROMAMBA_BIN"
 fi

--- a/templates/providers/mise/provider-run.sh
+++ b/templates/providers/mise/provider-run.sh
@@ -4,6 +4,11 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 MISE_BIN="$ROOT_DIR/.provider/bin/mise"
 
+if [[ $# -eq 0 ]]; then
+    echo "Usage: scripts/provider-run.sh <command> [args...]" >&2
+    exit 1
+fi
+
 if [[ ! -x "$MISE_BIN" ]]; then
     bash "$ROOT_DIR/scripts/bootstrap-provider-binary.sh" mise "$MISE_BIN"
 fi


### PR DESCRIPTION
## Summary\n- copy  into generated repositories in both create workflows\n- mark copied bootstrap script executable in generated repositories\n- add explicit usage validation to provider runner templates for  and Version: 2.8.1



/opt/homebrew/opt/micromamba/bin/micromamba [OPTIONS] [SUBCOMMAND]


OPTIONS:
  -h,     --help              Print this help message and exit
          --version           

Configuration options:
          --rc-file FILE1 FILE2... 
                              Paths to the configuration files to use
          --no-rc             Disable the use of configuration files
          --no-env            Disable the use of environment variables

Global options:
  -v,     --verbose           Set verbosity (higher verbosity with multiple -v, e.g. -vvv)
          --log-level ENUM:value in {critical->5,debug->1,error->4,info->2,off->6,trace->0,warning->3} OR {5,1,4,2,6,0,3} 
                              Set the log level
  -q,     --quiet             Set quiet mode (print less output)
  -y,     --yes               Automatically answer yes on prompted questions
          --json              Report all output as json
          --offline           Force use cached repodata
          --dry-run           Only display what would have been done
          --download-only     Only download and extract packages, do not link them into
                              environment.
          --experimental      Enable experimental features
          --use-uv            Whether to use uv for installing pip dependencies. Defaults to
                              false.

Prefix options:
  -r,     --root-prefix PATH  Path to the root prefix
  -p,     --prefix PATH       Path to the target prefix
          --relocate-prefix PATH 
                              Path to the relocation prefix
  -n,     --name NAME         Name of the target prefix

SUBCOMMANDS:
  shell                       Generate shell init scripts
  create                      Create new environment
  install                     Install packages in active environment
  update                      Update packages in active environment
  repoquery                   Find and analyze packages in active environment or channels
  remove, uninstall           Remove packages from active environment
  list                        List packages in active environment
  package                     Extract a package or bundle files into an archive
  clean                       Clean package cache
  config                      Configuration of micromamba
  info                        Information about micromamba
  constructor                 Commands to support using micromamba in constructor
  env                         See `mamba/micromamba env --help`
  activate                    Activate an environment
  run                         Run an executable in an environment
  ps                          Show, inspect or kill running processes
  auth                        Login or logout of a given host
  search                      Find packages in active environment or channels
                              This is equivalent to `repoquery search` command when invoked without command args\n\n## Why\nThese changes address the still-unresolved Copilot review threads on PR #33 about:\n- missing bootstrap helper script in generated repos\n- unclear failure mode when  is called without arguments\n\n## Validation\n- \n- \n- YAML parse check via Ruby stdlib for both edited workflows