### PR TITLE
fix: make mise bootstrap work without global PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -106,8 +106,8 @@ setup-env: ## Setup selected environment manager (ENV_MANAGER=micromamba|mise|sy
 				echo "Failed to bootstrap mise binary at $(MISE)."; \
 				exit 1; \
 			fi; \
-			$(MISE) install; \
-			$(MISE) tasks run install-tools; \
+			PATH="$(dir $(MISE)):$$PATH" $(MISE) install; \
+			PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools; \
 			if ! command -v xmllint >/dev/null 2>&1; then \
 				echo "Missing required tool: xmllint"; \
 				echo "Install libxml2-utils (or equivalent package) and retry."; \

--- a/templates/languages/agnostic/providers/micromamba/Makefile
+++ b/templates/languages/agnostic/providers/micromamba/Makefile
@@ -75,7 +75,7 @@ setup-env: ## Setup isolated environment with micromamba (skip with USE_MAMBA=0)
 			echo "Bootstrapping project-local micromamba binary..."; \
 			bash scripts/bootstrap-provider-binary.sh micromamba "$(MICROMAMBA)"; \
 		fi; \
-		if ! command -v $(MICROMAMBA) >/dev/null 2>&1; then \
+		if [ ! -x "$(MICROMAMBA)" ]; then \
 				echo "micromamba is required but not installed. Install it from an official package source before running make."; \
 				exit 1; \
 			fi; \

--- a/templates/languages/agnostic/providers/mise/Makefile
+++ b/templates/languages/agnostic/providers/mise/Makefile
@@ -27,8 +27,8 @@ setup-env: ## Setup isolated environment with mise
 		echo "Failed to bootstrap mise binary at $(MISE)."; \
 		exit 1; \
 	fi
-	@$(MISE) install
-	@$(MISE) tasks run install-tools
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) install
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools
 	@if ! command -v xmllint >/dev/null 2>&1; then \
 		echo "Missing required tool: xmllint"; \
 		echo "Install libxml2-utils (or equivalent package) and retry."; \

--- a/templates/languages/golang/providers/micromamba/Makefile
+++ b/templates/languages/golang/providers/micromamba/Makefile
@@ -76,7 +76,7 @@ setup-env: ## Setup isolated environment with micromamba (skip with USE_MAMBA=0)
 			echo "Bootstrapping project-local micromamba binary..."; \
 			bash scripts/bootstrap-provider-binary.sh micromamba "$(MICROMAMBA)"; \
 		fi; \
-		if ! command -v $(MICROMAMBA) >/dev/null 2>&1; then \
+			if [ ! -x "$(MICROMAMBA)" ]; then \
 				echo "micromamba is required but not installed. Install it from an official package source before running make."; \
 				exit 1; \
 			fi; \

--- a/templates/languages/golang/providers/mise/Makefile
+++ b/templates/languages/golang/providers/mise/Makefile
@@ -27,8 +27,8 @@ setup-env: ## Setup isolated environment with mise
 		echo "Failed to bootstrap mise binary at $(MISE)."; \
 		exit 1; \
 	fi
-	@$(MISE) install
-	@$(MISE) tasks run install-tools
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) install
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools
 	@if ! command -v xmllint >/dev/null 2>&1; then \
 		echo "Missing required tool: xmllint"; \
 		echo "Install libxml2-utils (or equivalent package) and retry."; \

--- a/templates/languages/java/providers/micromamba/Makefile
+++ b/templates/languages/java/providers/micromamba/Makefile
@@ -76,7 +76,7 @@ setup-env: ## Setup isolated environment with micromamba (skip with USE_MAMBA=0)
 			echo "Bootstrapping project-local micromamba binary..."; \
 			bash scripts/bootstrap-provider-binary.sh micromamba "$(MICROMAMBA)"; \
 		fi; \
-		if ! command -v $(MICROMAMBA) >/dev/null 2>&1; then \
+		if [ ! -x "$(MICROMAMBA)" ]; then \
 				echo "micromamba is required but not installed. Install it from an official package source before running make."; \
 				exit 1; \
 			fi; \

--- a/templates/languages/java/providers/mise/Makefile
+++ b/templates/languages/java/providers/mise/Makefile
@@ -27,8 +27,8 @@ setup-env: ## Setup isolated environment with mise
 		echo "Failed to bootstrap mise binary at $(MISE)."; \
 		exit 1; \
 	fi
-	@$(MISE) install
-	@$(MISE) tasks run install-tools
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) install
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools
 	@if ! command -v xmllint >/dev/null 2>&1; then \
 		echo "Missing required tool: xmllint"; \
 		echo "Install libxml2-utils (or equivalent package) and retry."; \

--- a/templates/languages/python/providers/micromamba/Makefile
+++ b/templates/languages/python/providers/micromamba/Makefile
@@ -76,7 +76,7 @@ setup-env: ## Setup isolated environment with micromamba (skip with USE_MAMBA=0)
 			echo "Bootstrapping project-local micromamba binary..."; \
 			bash scripts/bootstrap-provider-binary.sh micromamba "$(MICROMAMBA)"; \
 		fi; \
-		if ! command -v $(MICROMAMBA) >/dev/null 2>&1; then \
+		if [ ! -x "$(MICROMAMBA)" ]; then \
 				echo "micromamba is required but not installed. Install it from an official package source before running make."; \
 				exit 1; \
 			fi; \

--- a/templates/languages/python/providers/mise/Makefile
+++ b/templates/languages/python/providers/mise/Makefile
@@ -27,8 +27,8 @@ setup-env: ## Setup isolated environment with mise
 		echo "Failed to bootstrap mise binary at $(MISE)."; \
 		exit 1; \
 	fi
-	@$(MISE) install
-	@$(MISE) tasks run install-tools
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) install
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools
 	@if ! command -v xmllint >/dev/null 2>&1; then \
 		echo "Missing required tool: xmllint"; \
 		echo "Install libxml2-utils (or equivalent package) and retry."; \

--- a/templates/languages/typescript/providers/micromamba/Makefile
+++ b/templates/languages/typescript/providers/micromamba/Makefile
@@ -77,7 +77,7 @@ setup-env: ## Setup isolated environment with micromamba (skip with USE_MAMBA=0)
 			echo "Bootstrapping project-local micromamba binary..."; \
 			bash scripts/bootstrap-provider-binary.sh micromamba "$(MICROMAMBA)"; \
 		fi; \
-		if ! command -v $(MICROMAMBA) >/dev/null 2>&1; then \
+		if [ ! -x "$(MICROMAMBA)" ]; then \
 				echo "micromamba is required but not installed. Install it from an official package source before running make."; \
 				exit 1; \
 			fi; \

--- a/templates/languages/typescript/providers/mise/Makefile
+++ b/templates/languages/typescript/providers/mise/Makefile
@@ -27,8 +27,8 @@ setup-env: ## Setup isolated environment with mise
 		echo "Failed to bootstrap mise binary at $(MISE)."; \
 		exit 1; \
 	fi
-	@$(MISE) install
-	@$(MISE) tasks run install-tools
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) install
+	@PATH="$(dir $(MISE)):$$PATH" $(MISE) tasks run install-tools
 	@if ! command -v xmllint >/dev/null 2>&1; then \
 		echo "Missing required tool: xmllint"; \
 		echo "Install libxml2-utils (or equivalent package) and retry."; \


### PR DESCRIPTION
## Summary
- prepend project-local mise binary directory to PATH when running `$(MISE) install`
- prepend project-local mise binary directory to PATH when running `$(MISE) tasks run install-tools`
- apply this consistently in root `Makefile` and all template mise provider Makefiles

## Why
On machines without globally installed mise, first-run setup could fail during npm reshim with `mise: command not found` even though `.provider/bin/mise` was bootstrapped correctly.

## Verification
- Isolated temp repo test (no global mise, no manual PATH export) succeeded:
  - `make setup-env` completed successfully
  - observed marker: `SETUP_OK_WITHOUT_PATH_EXPORT`
- Full repo lint passed:
  - `LINT_MODE=check make lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment setup reliability across project templates.
  * Local tool installation now works more consistently when using bundled environment managers.
  * Bootstrapping now better detects when a local binary needs to be installed, reducing unnecessary setup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->