### PR TITLE
refactor(tools): migrate tooling updater to Go workspace module

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -22,6 +22,9 @@ indent_style = tab
 [Makefile.*]
 indent_style = tab
 
+[*.go]
+indent_style = tab
+
 [*.md]
 trim_trailing_whitespace = false
 indent_size = unset

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
       pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.WEEKLY_TOOLING_UPDATES_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ github.token }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -67,7 +67,7 @@ jobs:
           CodeRabbit review requirements, and approval rules are satisfied.
           EOF
 
-          if git diff --quiet --exit-code; then
+          if git diff --quiet --exit-code && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No tooling updates detected; skipping PR creation."
             exit 0
           fi
@@ -81,7 +81,7 @@ jobs:
           git commit -m "$commit_msg"
           git push --force-with-lease origin "$branch"
 
-          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')"
+          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"
 
           if [ -z "$pr_number" ]; then
             pr_url="$(gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md --label dependencies --label automation)"

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -1,0 +1,88 @@
+name: Weekly Tooling Updates
+
+on:
+  schedule:
+    - cron: "0 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-tooling:
+    name: Update non-Dependabot tooling
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.26"
+
+      - name: Install updater dependencies
+        shell: bash
+        run: python -m pip install --upgrade pip pre-commit
+
+      - name: Update repository and template tooling
+        shell: bash
+        run: |
+          ENV_MANAGER=micromamba make tooling-update-repo
+          ENV_MANAGER=micromamba make tooling-update-templates
+
+      - name: Create or update tooling update PR (gh CLI)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          branch="chore/weekly-tooling-updates"
+          title="chore(deps): weekly tooling updates"
+          commit_msg="chore(deps): update non-dependabot tooling pins"
+
+          cat > /tmp/weekly-tooling-pr-body.md <<'EOF'
+          ## Summary
+          - update non-Dependabot-managed tooling versions for this repository
+          - update tooling versions in templates used for generated repositories
+          - refresh pre-commit hook revisions via `pre-commit autoupdate`
+
+          ## Auto-merge
+          Auto-merge is enabled for this PR. GitHub will merge only after all required checks,
+          CodeRabbit review requirements, and approval rules are satisfied.
+          EOF
+
+          if git diff --quiet --exit-code; then
+            echo "No tooling updates detected; skipping PR creation."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git checkout -B "$branch"
+          git add -A
+          git commit -m "$commit_msg"
+          git push --force-with-lease origin "$branch"
+
+          pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')"
+
+          if [ -z "$pr_number" ]; then
+            pr_url="$(gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md --label dependencies --label automation)"
+            pr_number="$(gh pr view "$pr_url" --json number --jq '.number')"
+          else
+            gh pr edit "$pr_number" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md --add-label dependencies --add-label automation
+          fi
+
+          gh pr merge "$pr_number" --auto --squash

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -5,16 +5,20 @@ on:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+concurrency:
+  group: weekly-tooling-updates
+  cancel-in-progress: false
 
 jobs:
   update-tooling:
     name: Update non-Dependabot tooling
     runs-on: ubuntu-latest
+    # Required to commit/push changes and create/edit/merge the weekly PR.
+    permissions:
+      contents: write
+      pull-requests: write
     env:
-      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.WEEKLY_TOOLING_UPDATES_TOKEN || secrets.GITHUB_TOKEN }}
 
     steps:
       - name: Checkout code
@@ -24,12 +28,12 @@ jobs:
           persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
         with:
           python-version: "3.14"
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff
         with:
           go-version: "1.26"
 
@@ -70,6 +74,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
 
           git checkout -B "$branch"
           git add -A

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,6 +41,7 @@ repos:
         language: system
         exclude: >
           (?x)^(
+            .*\.go$|
             .*\.(png|jpg|jpeg|gif|ico|svg|pdf|lock)|
             \.git/.*
           )$
@@ -167,14 +168,14 @@ repos:
           - -c
           - |
             if [ "$LINT_MODE" = "check" ]; then
-              unformatted="$(gofmt -l $$(find tools -name '*.go' -type f))"
+              unformatted="$(gofmt -l $(find tools -name '*.go' -type f))"
               if [ -n "$unformatted" ]; then
                 echo "Go files need formatting:" >&2
                 echo "$unformatted" >&2
                 exit 1
               fi
             else
-              gofmt -w $$(find tools -name '*.go' -type f)
+              gofmt -w $(find tools -name '*.go' -type f)
             fi
         language: system
         files: '^tools/.*\.go$'
@@ -183,8 +184,10 @@ repos:
       # ── Go tools module: static analysis (go vet) ─────────────────────────
       - id: tools-go-vet
         name: tools go vet
-        entry: go
-        args: [vet, ./tools/...]
+        entry: bash
+        args:
+          - -c
+          - CGO_ENABLED=0 go vet ./tools/...
         language: system
         files: '^tools/.*\.go$'
         pass_filenames: false
@@ -192,8 +195,10 @@ repos:
       # ── Go tools module: unit tests (go test) ─────────────────────────────
       - id: tools-go-test
         name: tools go test
-        entry: go
-        args: [test, ./tools/...]
+        entry: bash
+        args:
+          - -c
+          - CGO_ENABLED=0 go test ./tools/...
         language: system
         files: '^tools/.*\.go$'
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -159,6 +159,45 @@ repos:
         files: '\.tf$'
         pass_filenames: false
 
+      # ── Go tools module: formatting (gofmt) ───────────────────────────────
+      - id: tools-go-fmt
+        name: tools go fmt
+        entry: bash
+        args:
+          - -c
+          - |
+            if [ "$LINT_MODE" = "check" ]; then
+              unformatted="$(gofmt -l $$(find tools -name '*.go' -type f))"
+              if [ -n "$unformatted" ]; then
+                echo "Go files need formatting:" >&2
+                echo "$unformatted" >&2
+                exit 1
+              fi
+            else
+              gofmt -w $$(find tools -name '*.go' -type f)
+            fi
+        language: system
+        files: '^tools/.*\.go$'
+        pass_filenames: false
+
+      # ── Go tools module: static analysis (go vet) ─────────────────────────
+      - id: tools-go-vet
+        name: tools go vet
+        entry: go
+        args: [vet, ./tools/...]
+        language: system
+        files: '^tools/.*\.go$'
+        pass_filenames: false
+
+      # ── Go tools module: unit tests (go test) ─────────────────────────────
+      - id: tools-go-test
+        name: tools go test
+        entry: go
+        args: [test, ./tools/...]
+        language: system
+        files: '^tools/.*\.go$'
+        pass_filenames: false
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -168,11 +168,12 @@ repos:
           - -c
           - |
             set -euo pipefail
+            lint_mode="${LINT_MODE:-fix}"
             files="$(find tools -name '*.go' -type f)"
             if [ -z "$files" ]; then
               exit 0
             fi
-            if [ "$LINT_MODE" = "check" ]; then
+            if [ "$lint_mode" = "check" ]; then
               unformatted="$(gofmt -l $files)"
               if [ -n "$unformatted" ]; then
                 echo "Go files need formatting:" >&2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,6 @@ repos:
         language: system
         exclude: >
           (?x)^(
-            .*\.go$|
             .*\.(png|jpg|jpeg|gif|ico|svg|pdf|lock)|
             \.git/.*
           )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -167,15 +167,20 @@ repos:
         args:
           - -c
           - |
+            set -euo pipefail
+            files="$(find tools -name '*.go' -type f)"
+            if [ -z "$files" ]; then
+              exit 0
+            fi
             if [ "$LINT_MODE" = "check" ]; then
-              unformatted="$(gofmt -l $(find tools -name '*.go' -type f))"
+              unformatted="$(gofmt -l $files)"
               if [ -n "$unformatted" ]; then
                 echo "Go files need formatting:" >&2
                 echo "$unformatted" >&2
                 exit 1
               fi
             else
-              gofmt -w $(find tools -name '*.go' -type f)
+              gofmt -w $files
             fi
         language: system
         files: '^tools/.*\.go$'

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help install install-hooks setup-env lint test clean
+.PHONY: help install install-hooks setup-env lint test clean tooling-updater-build tooling-update-repo tooling-update-templates tooling-update-all tooling-update-micromamba tooling-update-mise tooling-update-system tooling-update-precommit tooling-verify
 
 # =============================================================================
 # Configuration
@@ -65,6 +65,7 @@ endif
 
 # Build directory for stamp files
 BUILD_DIR := build
+TOOLING_UPDATER_BIN := $(BUILD_DIR)/bin/tooling-updater
 
 define mamba_env_exists
 	$(MICROMAMBA) env list --json 2>/dev/null | grep -q '/$(MAMBA_ENV)"'
@@ -90,7 +91,10 @@ setup-env: ## Setup selected environment manager (ENV_MANAGER=micromamba|mise|sy
 	case "$(ENV_MANAGER)" in \
 		micromamba) \
 			if [ -f "$(ENV_STAMP)" ] && $(call mamba_env_exists) 2>/dev/null; then \
-				: ; \
+				if ! $(MICROMAMBA) run -n $(MAMBA_ENV) -- go version >/dev/null 2>&1; then \
+					echo "Go is missing from micromamba environment; refreshing environment..."; \
+					$(MICROMAMBA) env update -n $(MAMBA_ENV) -f $(MAMBA_SPEC); \
+				fi; \
 			else \
 				if [ ! -x "$(MICROMAMBA)" ]; then \
 					echo "Bootstrapping project-local micromamba binary..."; \
@@ -126,7 +130,7 @@ setup-env: ## Setup selected environment manager (ENV_MANAGER=micromamba|mise|sy
 			;; \
 		system) \
 			missing=0; \
-			for tool in pre-commit ec shellcheck shfmt xmllint taplo yamllint markdownlint prettier terraform; do \
+			for tool in pre-commit ec shellcheck shfmt xmllint taplo yamllint markdownlint prettier terraform go; do \
 				if ! command -v $$tool >/dev/null 2>&1; then \
 					echo "Missing required tool: $$tool"; \
 					missing=1; \
@@ -209,6 +213,38 @@ test: ## Trigger repository creation tests via GitHub Actions
 		--field languages="language-agnostic-only" \
 		--field cleanup_after_test="true"
 	@echo "Test triggered. Check: gh run list --workflow=test-repository-creation.yml"
+
+# =============================================================================
+# Tooling Updates (non-Dependabot-managed)
+# =============================================================================
+tooling-updater-build: setup-env ## Build tooling updater CLI binary from latest source
+	@mkdir -p $(BUILD_DIR)/bin
+	@$(RUN) go build -o $(TOOLING_UPDATER_BIN) ./tools/cmd/tooling-updater
+
+tooling-update-repo: tooling-updater-build ## Update repo tooling pins (pre-commit, mise/micromamba, lint toolchain)
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope repo --updaters all
+
+tooling-update-templates: tooling-updater-build ## Update template tooling pins for generated repositories
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope templates --updaters all
+
+tooling-update-all: tooling-updater-build ## Update repo + template tooling pins
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope all --updaters all
+
+tooling-update-micromamba: tooling-updater-build ## Update micromamba-managed tooling (env files + provider binary pins)
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope all --updaters micromamba
+
+tooling-update-mise: tooling-updater-build ## Update mise-managed tooling (mise.toml files + provider binary pins)
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope all --updaters mise
+
+tooling-update-system: tooling-updater-build ## Run system updater (reserved no-op updater for explicit extension point)
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope all --updaters system
+
+tooling-update-precommit: tooling-updater-build ## Update pre-commit hook revisions for repo and templates
+	@$(RUN) $(TOOLING_UPDATER_BIN) --scope all --updaters pre-commit
+
+tooling-verify: tooling-updater-build ## Verify updater layout assumptions and run updater unit tests
+	@$(RUN) $(TOOLING_UPDATER_BIN) --verify-only
+	@$(RUN) go test ./tools/...
 
 # =============================================================================
 # Clean

--- a/Makefile
+++ b/Makefile
@@ -219,7 +219,7 @@ test: ## Trigger repository creation tests via GitHub Actions
 # =============================================================================
 tooling-updater-build: setup-env ## Build tooling updater CLI binary from latest source
 	@mkdir -p $(BUILD_DIR)/bin
-	@$(RUN) go build -o $(TOOLING_UPDATER_BIN) ./tools/cmd/tooling-updater
+	@$(RUN) env CGO_ENABLED=0 go build -o $(TOOLING_UPDATER_BIN) ./tools/cmd/tooling-updater
 
 tooling-update-repo: tooling-updater-build ## Update repo tooling pins (pre-commit, mise/micromamba, lint toolchain)
 	@$(RUN) $(TOOLING_UPDATER_BIN) --scope repo --updaters all
@@ -244,7 +244,7 @@ tooling-update-precommit: tooling-updater-build ## Update pre-commit hook revisi
 
 tooling-verify: tooling-updater-build ## Verify updater layout assumptions and run updater unit tests
 	@$(RUN) $(TOOLING_UPDATER_BIN) --verify-only
-	@$(RUN) go test ./tools/...
+	@$(RUN) env CGO_ENABLED=0 go test ./tools/...
 
 # =============================================================================
 # Clean

--- a/README.md
+++ b/README.md
@@ -237,6 +237,37 @@ Project readme and AI assistant instructions (Agent, Claude, Copilot) following 
 - **Local and CI** — `make lint` auto-fixes locally; `LINT_MODE=check make lint` fails on violations in CI
 - **Language-specific linters** — Add language linters to `.pre-commit-config.yaml` as needed
 
+### Weekly Tooling Updates (non-Dependabot)
+
+Dependabot does not cover every tooling surface in this repository. For pinned tooling files
+such as `mise.toml`, micromamba `environment.yml`, provider bootstrap binaries, and
+pre-commit hook revisions, use:
+
+- `make tooling-update-repo` — update tooling pins for this repository
+- `make tooling-update-templates` — update tooling pins under `templates/` for generated repos
+- `make tooling-update-all` — run both update paths
+- `make tooling-verify` — verify layout assumptions and run updater unit tests before merging changes
+- `make tooling-update-micromamba` / `make tooling-update-mise` / `make tooling-update-system` / `make tooling-update-precommit` — run explicit modular updaters
+
+Tooling commands automatically build the updater binary from latest source before execution,
+so users and AI agents always run the current implementation.
+
+If Go is not installed on your machine, use `ENV_MANAGER=micromamba` or `ENV_MANAGER=mise`
+and `make` will provision Go/tooling for you. `ENV_MANAGER=system` expects host tools to be
+already installed.
+
+The updater CLI also supports `--verify-only` for fast offline validation of expected
+repository/template layout.
+It also supports `--updaters` to run one or more decoupled updater modules.
+Implementation lives in the monorepo tools module under `tools/cmd/tooling-updater` + `tools/internal/` + `tools/pkg/` and is built/executed from Make targets.
+
+Automation is provided by `.github/workflows/weekly-tooling-updates.yml`:
+
+- runs weekly and on manual dispatch
+- opens or updates one PR with all non-Dependabot tooling updates
+- enables PR auto-merge so GitHub merges only after required checks, required approvals,
+  and branch protection rules are satisfied
+
 ### Conventional Commits
 
 All repositories enforce [conventional commits](https://www.conventionalcommits.org/)

--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime (required by pre-commit) ─────────────────────────────────
   - python=3.13
 
+  # ── Go runtime (required by tooling updater CLI) ─────────────────────────────
+  - go=1.26
+
   # ── Pre-commit framework ────────────────────────────────────────────────────
   - pre-commit=4.6.0
   # ── Linting / formatting tools (used as language: system hooks) ─────────────

--- a/go.work
+++ b/go.work
@@ -1,0 +1,3 @@
+go 1.26
+
+use ./tools

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 python = "3.13"
 node = "24"
+go = "1.26"
 shfmt = "3.13.1"
 terraform = "1.15.6"
 shellcheck = "0.11.0"

--- a/tools/cmd/tooling-updater/main.go
+++ b/tools/cmd/tooling-updater/main.go
@@ -3,18 +3,38 @@ package main
 import (
 	"flag"
 	"fmt"
+	"log/slog"
 	"os"
+	"strings"
 
 	"github-bootstrap/tools/internal/toolingupdater/runner"
+	"github-bootstrap/tools/pkg/toolinglib"
 )
 
+func parseLogLevel() slog.Level {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(toolinglib.EnvLogLevel))) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
 func main() {
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: parseLogLevel()}))
+
 	scope := flag.String("scope", "all", "scope: repo|templates|all")
 	updatersRaw := flag.String("updaters", "all", "comma-separated updaters or 'all'")
 	dryRun := flag.Bool("dry-run", false, "calculate updates without writing files")
 	verifyLayout := flag.Bool("verify-layout", false, "verify workspace layout before updates")
 	verifyOnly := flag.Bool("verify-only", false, "verify workspace layout and exit")
 	flag.Parse()
+
+	logger.Info("tooling updater started", "scope", *scope, "updaters", *updatersRaw, "dry_run", *dryRun, "verify_only", *verifyOnly)
 
 	if *scope != "repo" && *scope != "templates" && *scope != "all" {
 		fmt.Fprintln(os.Stderr, "invalid scope, expected repo|templates|all")
@@ -41,6 +61,7 @@ func main() {
 	}
 
 	if *verifyOnly {
+		logger.Info("workspace layout verification passed")
 		fmt.Println("Workspace layout verification passed")
 		return
 	}
@@ -53,4 +74,5 @@ func main() {
 	for _, path := range changed {
 		fmt.Printf("- %s\n", path)
 	}
+	logger.Info("tooling updater completed", "changed_files", len(changed))
 }

--- a/tools/cmd/tooling-updater/main.go
+++ b/tools/cmd/tooling-updater/main.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github-bootstrap/tools/internal/toolingupdater/runner"
+)
+
+func main() {
+	scope := flag.String("scope", "all", "scope: repo|templates|all")
+	updatersRaw := flag.String("updaters", "all", "comma-separated updaters or 'all'")
+	dryRun := flag.Bool("dry-run", false, "calculate updates without writing files")
+	verifyLayout := flag.Bool("verify-layout", false, "verify workspace layout before updates")
+	verifyOnly := flag.Bool("verify-only", false, "verify workspace layout and exit")
+	flag.Parse()
+
+	if *scope != "repo" && *scope != "templates" && *scope != "all" {
+		fmt.Fprintln(os.Stderr, "invalid scope, expected repo|templates|all")
+		os.Exit(1)
+	}
+
+	root, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tooling update failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	changed, err := runner.Run(runner.Config{
+		Root:         root,
+		Scope:        *scope,
+		UpdatersRaw:  *updatersRaw,
+		DryRun:       *dryRun,
+		VerifyLayout: *verifyLayout,
+		VerifyOnly:   *verifyOnly,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "tooling update failed: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *verifyOnly {
+		fmt.Println("Workspace layout verification passed")
+		return
+	}
+
+	if *dryRun {
+		fmt.Println("Planned tooling file updates:")
+	} else {
+		fmt.Println("Updated tooling files:")
+	}
+	for _, path := range changed {
+		fmt.Printf("- %s\n", path)
+	}
+}

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,0 +1,3 @@
+module github-bootstrap/tools
+
+go 1.26

--- a/tools/internal/toolingupdater/runner/runner.go
+++ b/tools/internal/toolingupdater/runner/runner.go
@@ -84,6 +84,10 @@ func parseUpdaters(raw string) ([]string, error) {
 }
 
 func Run(cfg Config) ([]string, error) {
+	if cfg.Scope != "repo" && cfg.Scope != "templates" && cfg.Scope != "all" {
+		return nil, fmt.Errorf("invalid scope: %s", cfg.Scope)
+	}
+
 	if cfg.VerifyLayout || cfg.VerifyOnly {
 		if err := toolinglib.VerifyWorkspaceLayout(cfg.Root); err != nil {
 			return nil, err

--- a/tools/internal/toolingupdater/runner/runner.go
+++ b/tools/internal/toolingupdater/runner/runner.go
@@ -108,7 +108,7 @@ func Run(cfg Config) ([]string, error) {
 
 	var versions *toolinglib.Versions
 	if needsVersions {
-		resolved, err := toolinglib.CollectVersions()
+		resolved, err := toolinglib.CollectVersions(selected)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/internal/toolingupdater/runner/runner.go
+++ b/tools/internal/toolingupdater/runner/runner.go
@@ -1,0 +1,141 @@
+package runner
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github-bootstrap/tools/internal/toolingupdater/updaters"
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+type Config struct {
+	Root         string
+	Scope        string
+	UpdatersRaw  string
+	DryRun       bool
+	VerifyLayout bool
+	VerifyOnly   bool
+}
+
+type updaterEntry struct {
+	needsVersions bool
+	run           func(root string, scope string, write bool, versions *toolinglib.Versions) ([]string, error)
+}
+
+var registry = map[string]updaterEntry{
+	"micromamba": {
+		needsVersions: true,
+		run: func(root string, scope string, write bool, versions *toolinglib.Versions) ([]string, error) {
+			if versions == nil {
+				return nil, fmt.Errorf("micromamba updater requires version data")
+			}
+			return updaters.RunMicromamba(root, scope, *versions, write)
+		},
+	},
+	"mise": {
+		needsVersions: true,
+		run: func(root string, scope string, write bool, versions *toolinglib.Versions) ([]string, error) {
+			if versions == nil {
+				return nil, fmt.Errorf("mise updater requires version data")
+			}
+			return updaters.RunMise(root, scope, *versions, write)
+		},
+	},
+	"system": {
+		needsVersions: false,
+		run: func(_ string, _ string, _ bool, _ *toolinglib.Versions) ([]string, error) {
+			return updaters.RunSystem()
+		},
+	},
+	"pre-commit": {
+		needsVersions: false,
+		run: func(root string, scope string, write bool, _ *toolinglib.Versions) ([]string, error) {
+			return updaters.RunPreCommit(root, scope, write)
+		},
+	},
+}
+
+func parseUpdaters(raw string) ([]string, error) {
+	if strings.TrimSpace(raw) == "all" {
+		return []string{"micromamba", "mise", "system", "pre-commit"}, nil
+	}
+	parts := strings.Split(raw, ",")
+	selected := make([]string, 0, len(parts))
+	seen := map[string]bool{}
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		if item == "" {
+			continue
+		}
+		if _, ok := registry[item]; !ok {
+			return nil, fmt.Errorf("unknown updater: %s", item)
+		}
+		if !seen[item] {
+			selected = append(selected, item)
+			seen[item] = true
+		}
+	}
+	if len(selected) == 0 {
+		return nil, fmt.Errorf("no updaters selected")
+	}
+	return selected, nil
+}
+
+func Run(cfg Config) ([]string, error) {
+	if cfg.VerifyLayout || cfg.VerifyOnly {
+		if err := toolinglib.VerifyWorkspaceLayout(cfg.Root); err != nil {
+			return nil, err
+		}
+	}
+	if cfg.VerifyOnly {
+		return []string{}, nil
+	}
+
+	selected, err := parseUpdaters(cfg.UpdatersRaw)
+	if err != nil {
+		return nil, err
+	}
+
+	needsVersions := false
+	for _, updaterName := range selected {
+		if registry[updaterName].needsVersions {
+			needsVersions = true
+			break
+		}
+	}
+
+	var versions *toolinglib.Versions
+	if needsVersions {
+		resolved, err := toolinglib.CollectVersions()
+		if err != nil {
+			return nil, err
+		}
+		versions = &resolved
+	}
+
+	changedSet := map[string]bool{}
+	for _, updaterName := range selected {
+		entry := registry[updaterName]
+		paths, err := entry.run(cfg.Root, cfg.Scope, !cfg.DryRun, versions)
+		if err != nil {
+			return nil, err
+		}
+		for _, p := range paths {
+			rel, relErr := filepath.Rel(cfg.Root, p)
+			if relErr == nil {
+				changedSet[rel] = true
+				continue
+			}
+			changedSet[p] = true
+		}
+	}
+
+	ordered := make([]string, 0, len(changedSet))
+	for p := range changedSet {
+		ordered = append(ordered, p)
+	}
+	sort.Strings(ordered)
+	return ordered, nil
+}

--- a/tools/internal/toolingupdater/runner/runner_test.go
+++ b/tools/internal/toolingupdater/runner/runner_test.go
@@ -1,0 +1,60 @@
+package runner
+
+import (
+	"testing"
+)
+
+func TestRun_InvalidScope(t *testing.T) {
+	_, err := Run(Config{
+		Root:        t.TempDir(),
+		Scope:       "invalid",
+		UpdatersRaw: "pre-commit",
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid scope, got nil")
+	}
+}
+
+func TestParseUpdaters_All(t *testing.T) {
+	got, err := parseUpdaters("all")
+	if err != nil {
+		t.Fatalf("parseUpdaters(all) returned error: %v", err)
+	}
+	if len(got) != 4 {
+		t.Fatalf("expected 4 updaters, got %d: %v", len(got), got)
+	}
+}
+
+func TestParseUpdaters_Single(t *testing.T) {
+	got, err := parseUpdaters("pre-commit")
+	if err != nil {
+		t.Fatalf("parseUpdaters(pre-commit) returned error: %v", err)
+	}
+	if len(got) != 1 || got[0] != "pre-commit" {
+		t.Fatalf("expected [pre-commit], got %v", got)
+	}
+}
+
+func TestParseUpdaters_Dedup(t *testing.T) {
+	got, err := parseUpdaters("pre-commit,pre-commit")
+	if err != nil {
+		t.Fatalf("parseUpdaters dedup returned error: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry after dedup, got %d: %v", len(got), got)
+	}
+}
+
+func TestParseUpdaters_Unknown(t *testing.T) {
+	_, err := parseUpdaters("bogus-updater")
+	if err == nil {
+		t.Fatal("expected error for unknown updater, got nil")
+	}
+}
+
+func TestParseUpdaters_Empty(t *testing.T) {
+	_, err := parseUpdaters("  ")
+	if err == nil {
+		t.Fatal("expected error for empty updater list, got nil")
+	}
+}

--- a/tools/internal/toolingupdater/updaters/micromamba.go
+++ b/tools/internal/toolingupdater/updaters/micromamba.go
@@ -1,0 +1,62 @@
+package updaters
+
+import (
+	"path/filepath"
+
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+func RunMicromamba(root string, scope string, versions toolinglib.Versions, write bool) ([]string, error) {
+	changed := make([]string, 0)
+	providerAssets := toolinglib.FilterProviderAssets(versions.Providers, "micromamba:")
+
+	if scope == "repo" || scope == "all" {
+		ok, err := toolinglib.UpdateFile(filepath.Join(root, "environment.yml"), func(content string) (string, error) {
+			return toolinglib.UpdateEnvText(content, versions.Conda)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "environment.yml"))
+		}
+		ok, err = toolinglib.UpdateFile(filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"))
+		}
+	}
+
+	if scope == "templates" || scope == "all" {
+		templates, err := toolinglib.DiscoverTemplateFiles(root)
+		if err != nil {
+			return nil, err
+		}
+		for _, envFile := range templates.EnvFiles {
+			ok, err := toolinglib.UpdateFile(envFile, func(content string) (string, error) {
+				return toolinglib.UpdateEnvText(content, versions.Conda)
+			}, write)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				changed = append(changed, envFile)
+			}
+		}
+		ok, err := toolinglib.UpdateFile(filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"))
+		}
+	}
+
+	return changed, nil
+}

--- a/tools/internal/toolingupdater/updaters/micromamba.go
+++ b/tools/internal/toolingupdater/updaters/micromamba.go
@@ -1,62 +1,26 @@
 package updaters
 
 import (
-	"path/filepath"
-
 	"github-bootstrap/tools/pkg/toolinglib"
 )
 
 func RunMicromamba(root string, scope string, versions toolinglib.Versions, write bool) ([]string, error) {
-	changed := make([]string, 0)
+	templates, err := toolinglib.DiscoverTemplateFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
 	providerAssets := toolinglib.FilterProviderAssets(versions.Providers, "micromamba:")
 
-	if scope == "repo" || scope == "all" {
-		ok, err := toolinglib.UpdateFile(filepath.Join(root, "environment.yml"), func(content string) (string, error) {
+	return runScopedProviderUpdater(root, scope, write, scopedProviderConfig{
+		repoFile:      "environment.yml",
+		templateFiles: templates.EnvFiles,
+		repoUpdate: func(content string) (string, error) {
 			return toolinglib.UpdateEnvText(content, versions.Conda)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "environment.yml"))
-		}
-		ok, err = toolinglib.UpdateFile(filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"))
-		}
-	}
-
-	if scope == "templates" || scope == "all" {
-		templates, err := toolinglib.DiscoverTemplateFiles(root)
-		if err != nil {
-			return nil, err
-		}
-		for _, envFile := range templates.EnvFiles {
-			ok, err := toolinglib.UpdateFile(envFile, func(content string) (string, error) {
-				return toolinglib.UpdateEnvText(content, versions.Conda)
-			}, write)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				changed = append(changed, envFile)
-			}
-		}
-		ok, err := toolinglib.UpdateFile(filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"))
-		}
-	}
-
-	return changed, nil
+		},
+		templateUpdate: func(content string) (string, error) {
+			return toolinglib.UpdateEnvText(content, versions.Conda)
+		},
+		providerAssets: providerAssets,
+	})
 }

--- a/tools/internal/toolingupdater/updaters/mise.go
+++ b/tools/internal/toolingupdater/updaters/mise.go
@@ -1,0 +1,62 @@
+package updaters
+
+import (
+	"path/filepath"
+
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+func RunMise(root string, scope string, versions toolinglib.Versions, write bool) ([]string, error) {
+	changed := make([]string, 0)
+	providerAssets := toolinglib.FilterProviderAssets(versions.Providers, "mise:")
+
+	if scope == "repo" || scope == "all" {
+		ok, err := toolinglib.UpdateFile(filepath.Join(root, "mise.toml"), func(content string) (string, error) {
+			return toolinglib.UpdateMiseText(content, versions.Conda, versions.Python, versions.NPM, nil)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "mise.toml"))
+		}
+		ok, err = toolinglib.UpdateFile(filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"))
+		}
+	}
+
+	if scope == "templates" || scope == "all" {
+		templates, err := toolinglib.DiscoverTemplateFiles(root)
+		if err != nil {
+			return nil, err
+		}
+		for _, miseFile := range templates.MiseFiles {
+			ok, err := toolinglib.UpdateFile(miseFile, func(content string) (string, error) {
+				return toolinglib.UpdateMiseText(content, versions.Conda, versions.Python, versions.NPM, versions.GoModules)
+			}, write)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				changed = append(changed, miseFile)
+			}
+		}
+		ok, err := toolinglib.UpdateFile(filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"))
+		}
+	}
+
+	return changed, nil
+}

--- a/tools/internal/toolingupdater/updaters/mise.go
+++ b/tools/internal/toolingupdater/updaters/mise.go
@@ -1,62 +1,26 @@
 package updaters
 
 import (
-	"path/filepath"
-
 	"github-bootstrap/tools/pkg/toolinglib"
 )
 
 func RunMise(root string, scope string, versions toolinglib.Versions, write bool) ([]string, error) {
-	changed := make([]string, 0)
+	templates, err := toolinglib.DiscoverTemplateFiles(root)
+	if err != nil {
+		return nil, err
+	}
+
 	providerAssets := toolinglib.FilterProviderAssets(versions.Providers, "mise:")
 
-	if scope == "repo" || scope == "all" {
-		ok, err := toolinglib.UpdateFile(filepath.Join(root, "mise.toml"), func(content string) (string, error) {
+	return runScopedProviderUpdater(root, scope, write, scopedProviderConfig{
+		repoFile:      "mise.toml",
+		templateFiles: templates.MiseFiles,
+		repoUpdate: func(content string) (string, error) {
 			return toolinglib.UpdateMiseText(content, versions.Conda, versions.Python, versions.NPM, nil)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "mise.toml"))
-		}
-		ok, err = toolinglib.UpdateFile(filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"))
-		}
-	}
-
-	if scope == "templates" || scope == "all" {
-		templates, err := toolinglib.DiscoverTemplateFiles(root)
-		if err != nil {
-			return nil, err
-		}
-		for _, miseFile := range templates.MiseFiles {
-			ok, err := toolinglib.UpdateFile(miseFile, func(content string) (string, error) {
-				return toolinglib.UpdateMiseText(content, versions.Conda, versions.Python, versions.NPM, versions.GoModules)
-			}, write)
-			if err != nil {
-				return nil, err
-			}
-			if ok {
-				changed = append(changed, miseFile)
-			}
-		}
-		ok, err := toolinglib.UpdateFile(filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"), func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, providerAssets)
-		}, write)
-		if err != nil {
-			return nil, err
-		}
-		if ok {
-			changed = append(changed, filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"))
-		}
-	}
-
-	return changed, nil
+		},
+		templateUpdate: func(content string) (string, error) {
+			return toolinglib.UpdateMiseText(content, versions.Conda, versions.Python, versions.NPM, versions.GoModules)
+		},
+		providerAssets: providerAssets,
+	})
 }

--- a/tools/internal/toolingupdater/updaters/precommit.go
+++ b/tools/internal/toolingupdater/updaters/precommit.go
@@ -1,0 +1,33 @@
+package updaters
+
+import (
+	"path/filepath"
+
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+func RunPreCommit(root string, scope string, write bool) ([]string, error) {
+	changed := make([]string, 0)
+	if scope == "repo" || scope == "all" {
+		config := filepath.Join(root, ".pre-commit-config.yaml")
+		changed = append(changed, config)
+		if write {
+			if err := toolinglib.RunPreCommitAutoupdate([]string{config}); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if scope == "templates" || scope == "all" {
+		templates, err := toolinglib.DiscoverTemplateFiles(root)
+		if err != nil {
+			return nil, err
+		}
+		changed = append(changed, templates.PreCommitFiles...)
+		if write {
+			if err := toolinglib.RunPreCommitAutoupdate(templates.PreCommitFiles); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return changed, nil
+}

--- a/tools/internal/toolingupdater/updaters/precommit.go
+++ b/tools/internal/toolingupdater/updaters/precommit.go
@@ -7,27 +7,29 @@ import (
 )
 
 func RunPreCommit(root string, scope string, write bool) ([]string, error) {
+	if !write {
+		return []string{}, nil
+	}
+
 	changed := make([]string, 0)
 	if scope == "repo" || scope == "all" {
 		config := filepath.Join(root, ".pre-commit-config.yaml")
-		changed = append(changed, config)
-		if write {
-			if err := toolinglib.RunPreCommitAutoupdate([]string{config}); err != nil {
-				return nil, err
-			}
+		changedConfigs, err := toolinglib.RunPreCommitAutoupdate([]string{config})
+		if err != nil {
+			return nil, err
 		}
+		changed = append(changed, changedConfigs...)
 	}
 	if scope == "templates" || scope == "all" {
 		templates, err := toolinglib.DiscoverTemplateFiles(root)
 		if err != nil {
 			return nil, err
 		}
-		changed = append(changed, templates.PreCommitFiles...)
-		if write {
-			if err := toolinglib.RunPreCommitAutoupdate(templates.PreCommitFiles); err != nil {
-				return nil, err
-			}
+		changedConfigs, err := toolinglib.RunPreCommitAutoupdate(templates.PreCommitFiles)
+		if err != nil {
+			return nil, err
 		}
+		changed = append(changed, changedConfigs...)
 	}
 	return changed, nil
 }

--- a/tools/internal/toolingupdater/updaters/precommit.go
+++ b/tools/internal/toolingupdater/updaters/precommit.go
@@ -7,29 +7,16 @@ import (
 )
 
 func RunPreCommit(root string, scope string, write bool) ([]string, error) {
-	if !write {
-		return []string{}, nil
-	}
-
-	changed := make([]string, 0)
+	configs := make([]string, 0)
 	if scope == "repo" || scope == "all" {
-		config := filepath.Join(root, ".pre-commit-config.yaml")
-		changedConfigs, err := toolinglib.RunPreCommitAutoupdate([]string{config})
-		if err != nil {
-			return nil, err
-		}
-		changed = append(changed, changedConfigs...)
+		configs = append(configs, filepath.Join(root, ".pre-commit-config.yaml"))
 	}
 	if scope == "templates" || scope == "all" {
 		templates, err := toolinglib.DiscoverTemplateFiles(root)
 		if err != nil {
 			return nil, err
 		}
-		changedConfigs, err := toolinglib.RunPreCommitAutoupdate(templates.PreCommitFiles)
-		if err != nil {
-			return nil, err
-		}
-		changed = append(changed, changedConfigs...)
+		configs = append(configs, templates.PreCommitFiles...)
 	}
-	return changed, nil
+	return toolinglib.RunPreCommitAutoupdate(configs, write)
 }

--- a/tools/internal/toolingupdater/updaters/scoped_provider.go
+++ b/tools/internal/toolingupdater/updaters/scoped_provider.go
@@ -21,7 +21,7 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 		repoPath := filepath.Join(root, cfg.repoFile)
 		ok, err := toolinglib.UpdateFile(repoPath, cfg.repoUpdate, write)
 		if err != nil {
-			return nil, err
+			return changed, err
 		}
 		if ok {
 			changed = append(changed, repoPath)
@@ -32,7 +32,7 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
 		}, write)
 		if err != nil {
-			return nil, err
+			return changed, err
 		}
 		if ok {
 			changed = append(changed, repoBootstrap)
@@ -43,7 +43,7 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 		for _, templateFile := range cfg.templateFiles {
 			ok, err := toolinglib.UpdateFile(templateFile, cfg.templateUpdate, write)
 			if err != nil {
-				return nil, err
+				return changed, err
 			}
 			if ok {
 				changed = append(changed, templateFile)
@@ -55,7 +55,7 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
 		}, write)
 		if err != nil {
-			return nil, err
+			return changed, err
 		}
 		if ok {
 			changed = append(changed, templateBootstrap)

--- a/tools/internal/toolingupdater/updaters/scoped_provider.go
+++ b/tools/internal/toolingupdater/updaters/scoped_provider.go
@@ -1,0 +1,66 @@
+package updaters
+
+import (
+	"path/filepath"
+
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+type scopedProviderConfig struct {
+	repoFile       string
+	templateFiles  []string
+	repoUpdate     func(string) (string, error)
+	templateUpdate func(string) (string, error)
+	providerAssets map[string]toolinglib.ProviderAsset
+}
+
+func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedProviderConfig) ([]string, error) {
+	changed := make([]string, 0)
+
+	if scope == "repo" || scope == "all" {
+		repoPath := filepath.Join(root, cfg.repoFile)
+		ok, err := toolinglib.UpdateFile(repoPath, cfg.repoUpdate, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, repoPath)
+		}
+
+		repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+		ok, err = toolinglib.UpdateFile(repoBootstrap, func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, repoBootstrap)
+		}
+	}
+
+	if scope == "templates" || scope == "all" {
+		for _, templateFile := range cfg.templateFiles {
+			ok, err := toolinglib.UpdateFile(templateFile, cfg.templateUpdate, write)
+			if err != nil {
+				return nil, err
+			}
+			if ok {
+				changed = append(changed, templateFile)
+			}
+		}
+
+		templateBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+		ok, err := toolinglib.UpdateFile(templateBootstrap, func(content string) (string, error) {
+			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
+		}, write)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			changed = append(changed, templateBootstrap)
+		}
+	}
+
+	return changed, nil
+}

--- a/tools/internal/toolingupdater/updaters/system.go
+++ b/tools/internal/toolingupdater/updaters/system.go
@@ -1,0 +1,5 @@
+package updaters
+
+func RunSystem() ([]string, error) {
+	return []string{}, nil
+}

--- a/tools/internal/toolingupdater/updaters/updaters_integration_test.go
+++ b/tools/internal/toolingupdater/updaters/updaters_integration_test.go
@@ -275,3 +275,38 @@ func TestRunMise_DryRun(t *testing.T) {
 		t.Fatalf("dry-run must not write files: repo mise.toml was modified")
 	}
 }
+
+func TestRunPreCommitAutoupdate_ReturnsPartialChangesOnLaterError(t *testing.T) {
+	root, _ := buildTestWorkspace(t)
+
+	first := filepath.Join(root, ".pre-commit-config.yaml")
+	missing := filepath.Join(root, "templates", "languages", "missing", ".pre-commit-config.yaml")
+
+	changed, err := toolinglib.RunPreCommitAutoupdate([]string{first, missing}, true)
+	if err == nil {
+		t.Fatal("expected error for missing second config, got nil")
+	}
+	if !slices.Contains(changed, first) {
+		t.Fatalf("expected changed to include first successful config, got %v", changed)
+	}
+}
+
+func TestRunMicromamba_ReturnsPartialChangesOnLaterError(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	templateBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	if err := os.Chmod(templateBootstrap, 0o444); err != nil {
+		t.Fatalf("failed to chmod template bootstrap: %v", err)
+	}
+
+	changed, err := RunMicromamba(root, "all", versions, true)
+	if err == nil {
+		t.Fatal("expected error when template bootstrap is not writable")
+	}
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+	if !containsAll(changed, repoEnv, repoBootstrap) {
+		t.Fatalf("expected partial changed set to keep earlier repo updates, got %v", changed)
+	}
+}

--- a/tools/internal/toolingupdater/updaters/updaters_integration_test.go
+++ b/tools/internal/toolingupdater/updaters/updaters_integration_test.go
@@ -66,7 +66,8 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 
 	binDir := filepath.Join(root, "bin")
 	preCommitPath := filepath.Join(binDir, "pre-commit")
-	fakePreCommit := "#!/bin/sh\nset -eu\nconfig=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--config\" ]; then\n    shift\n    config=\"$1\"\n  fi\n  shift\ndone\necho \"# updated-by-fake-pre-commit\" >> \"$config\"\n"
+	// Idempotent: only appends the marker when it is not already present.
+	fakePreCommit := "#!/bin/sh\nset -eu\nconfig=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--config\" ]; then\n    shift\n    config=\"$1\"\n  fi\n  shift\ndone\nif ! grep -q '# updated-by-fake-pre-commit' \"$config\"; then\n  echo '# updated-by-fake-pre-commit' >> \"$config\"\nfi\n"
 	mustWriteFile(t, preCommitPath, fakePreCommit)
 	if err := os.Chmod(preCommitPath, 0o755); err != nil {
 		t.Fatalf("failed to chmod fake pre-commit: %v", err)
@@ -124,8 +125,12 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 		t.Fatalf("RunPreCommit changed mismatch: %v", preChanged)
 	}
 
-	if changed, err := RunPreCommit(root, "all", false); err != nil || len(changed) != 0 {
-		t.Fatalf("RunPreCommit dry-run expected no changes, got %v err=%v", changed, err)
+	// Dry-run: the fake pre-commit already appended its marker in the write pass above,
+	// so autoupdate on the temp copy produces no further change — expect empty result.
+	if dryChanged, err := RunPreCommit(root, "all", false); err != nil {
+		t.Fatalf("RunPreCommit dry-run failed: %v", err)
+	} else if len(dryChanged) != 0 {
+		t.Fatalf("RunPreCommit dry-run expected no changes, got %v", dryChanged)
 	}
 
 	if !strings.Contains(mustReadFile(t, repoEnv), "pre-commit=4.6.0") {

--- a/tools/internal/toolingupdater/updaters/updaters_integration_test.go
+++ b/tools/internal/toolingupdater/updaters/updaters_integration_test.go
@@ -38,8 +38,11 @@ func containsAll(paths []string, want ...string) bool {
 	return true
 }
 
-func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
-	root := t.TempDir()
+// buildTestWorkspace creates a minimal temp workspace and fake pre-commit binary
+// shared by all integration tests. Returns the populated root and versions struct.
+func buildTestWorkspace(t *testing.T) (root string, versions toolinglib.Versions) {
+	t.Helper()
+	root = t.TempDir()
 
 	repoEnv := filepath.Join(root, "environment.yml")
 	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
@@ -64,9 +67,9 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	mustWriteFile(t, repoPre, "repos:\n  - repo: https://example.invalid\n")
 	mustWriteFile(t, tplPre, "repos:\n  - repo: https://example.invalid\n")
 
+	// Fake pre-commit: idempotent — only adds marker when absent.
 	binDir := filepath.Join(root, "bin")
 	preCommitPath := filepath.Join(binDir, "pre-commit")
-	// Idempotent: only appends the marker when it is not already present.
 	fakePreCommit := "#!/bin/sh\nset -eu\nconfig=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--config\" ]; then\n    shift\n    config=\"$1\"\n  fi\n  shift\ndone\nif ! grep -q '# updated-by-fake-pre-commit' \"$config\"; then\n  echo '# updated-by-fake-pre-commit' >> \"$config\"\nfi\n"
 	mustWriteFile(t, preCommitPath, fakePreCommit)
 	if err := os.Chmod(preCommitPath, 0o755); err != nil {
@@ -74,7 +77,7 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	versions := toolinglib.Versions{
+	versions = toolinglib.Versions{
 		Conda: map[string]string{
 			"pre-commit": "4.6.0",
 			"go-shfmt":   "3.13.1",
@@ -100,6 +103,20 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 			"micromamba:linux:x64": {URL: "https://new.example/mamba", SHA256: "mamba-sha"},
 		},
 	}
+	return root, versions
+}
+
+func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
+	repoMise := filepath.Join(root, "mise.toml")
+	tplMise := filepath.Join(root, "templates", "languages", "go", "providers", "mise", "mise.toml")
+	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	repoPre := filepath.Join(root, ".pre-commit-config.yaml")
+	tplPre := filepath.Join(root, "templates", "languages", "go", ".pre-commit-config.yaml")
 
 	mambaChanged, err := RunMicromamba(root, "all", versions, true)
 	if err != nil {
@@ -156,5 +173,105 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	}
 	if !strings.Contains(mustReadFile(t, tplPre), "# updated-by-fake-pre-commit") {
 		t.Fatalf("template pre-commit config was not updated by fake pre-commit")
+	}
+}
+
+// TestRunMicromamba_ScopeRepo verifies that scope="repo" updates only the repo
+// environment.yml and bootstrap script, leaving template equivalents untouched.
+func TestRunMicromamba_ScopeRepo(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
+	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+
+	originalTplEnv := mustReadFile(t, tplEnv)
+	originalTplBootstrap := mustReadFile(t, tplBootstrap)
+
+	changed, err := RunMicromamba(root, "repo", versions, true)
+	if err != nil {
+		t.Fatalf("RunMicromamba scope=repo failed: %v", err)
+	}
+	if len(changed) == 0 {
+		t.Fatal("expected at least one changed file for scope=repo")
+	}
+	if !strings.Contains(mustReadFile(t, repoEnv), "pre-commit=4.6.0") {
+		t.Fatalf("repo environment.yml was not updated")
+	}
+	if mustReadFile(t, tplEnv) != originalTplEnv {
+		t.Fatalf("template environment.yml was modified but should not have been")
+	}
+	if mustReadFile(t, tplBootstrap) != originalTplBootstrap {
+		t.Fatalf("template bootstrap was modified but should not have been")
+	}
+}
+
+// TestRunMicromamba_ScopeTemplates verifies that scope="templates" updates only
+// template files, leaving the repo environment.yml and bootstrap script untouched.
+func TestRunMicromamba_ScopeTemplates(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
+	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+
+	originalRepoEnv := mustReadFile(t, repoEnv)
+	originalRepoBootstrap := mustReadFile(t, repoBootstrap)
+
+	changed, err := RunMicromamba(root, "templates", versions, true)
+	if err != nil {
+		t.Fatalf("RunMicromamba scope=templates failed: %v", err)
+	}
+	if len(changed) == 0 {
+		t.Fatal("expected at least one changed file for scope=templates")
+	}
+	if !strings.Contains(mustReadFile(t, tplEnv), "pre-commit=4.6.0") {
+		t.Fatalf("template environment.yml was not updated")
+	}
+	if mustReadFile(t, repoEnv) != originalRepoEnv {
+		t.Fatalf("repo environment.yml was modified but should not have been")
+	}
+	if mustReadFile(t, repoBootstrap) != originalRepoBootstrap {
+		t.Fatalf("repo bootstrap was modified but should not have been")
+	}
+}
+
+// TestRunMicromamba_DryRun verifies that write=false reports files that would
+// change but does NOT modify them on disk.
+func TestRunMicromamba_DryRun(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	originalContent := mustReadFile(t, repoEnv)
+
+	changed, err := RunMicromamba(root, "all", versions, false)
+	if err != nil {
+		t.Fatalf("RunMicromamba dry-run failed: %v", err)
+	}
+	if len(changed) == 0 {
+		t.Fatal("dry-run expected non-empty changed list")
+	}
+	if mustReadFile(t, repoEnv) != originalContent {
+		t.Fatalf("dry-run must not write files: repo environment.yml was modified")
+	}
+}
+
+// TestRunMise_DryRun verifies that write=false reports files that would change
+// but does NOT modify them on disk.
+func TestRunMise_DryRun(t *testing.T) {
+	root, versions := buildTestWorkspace(t)
+
+	repoMise := filepath.Join(root, "mise.toml")
+	originalContent := mustReadFile(t, repoMise)
+
+	changed, err := RunMise(root, "all", versions, false)
+	if err != nil {
+		t.Fatalf("RunMise dry-run failed: %v", err)
+	}
+	if len(changed) == 0 {
+		t.Fatal("dry-run expected non-empty changed list")
+	}
+	if mustReadFile(t, repoMise) != originalContent {
+		t.Fatalf("dry-run must not write files: repo mise.toml was modified")
 	}
 }

--- a/tools/internal/toolingupdater/updaters/updaters_integration_test.go
+++ b/tools/internal/toolingupdater/updaters/updaters_integration_test.go
@@ -1,0 +1,155 @@
+package updaters
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github-bootstrap/tools/pkg/toolinglib"
+)
+
+func mustWriteFile(t *testing.T, path string, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("failed to create parent dir for %s: %v", path, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write %s: %v", path, err)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", path, err)
+	}
+	return string(payload)
+}
+
+func containsAll(paths []string, want ...string) bool {
+	for _, target := range want {
+		if !slices.Contains(paths, target) {
+			return false
+		}
+	}
+	return true
+}
+
+func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
+	root := t.TempDir()
+
+	repoEnv := filepath.Join(root, "environment.yml")
+	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
+	repoMise := filepath.Join(root, "mise.toml")
+	tplMise := filepath.Join(root, "templates", "languages", "go", "providers", "mise", "mise.toml")
+	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	repoPre := filepath.Join(root, ".pre-commit-config.yaml")
+	tplPre := filepath.Join(root, "templates", "languages", "go", ".pre-commit-config.yaml")
+
+	mustWriteFile(t, repoEnv, "dependencies:\n  - pre-commit=1.0.0\n  - go-shfmt=1.0.0\n  - terraform=1.0.0\n")
+	mustWriteFile(t, tplEnv, "dependencies:\n  - pre-commit=1.0.0\n  - go-shfmt=1.0.0\n")
+
+	miseSource := "[tools]\nshellcheck = \"0.1.0\"\nshfmt = \"0.1.0\"\nterraform = \"0.1.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n  \"go install github.com/daixiang0/gci@v0.1.0\",\n  \"go install github.com/golangci/golangci-lint/cmd/golangci-lint@v0.1.0\",\n]\n"
+	mustWriteFile(t, repoMise, miseSource)
+	mustWriteFile(t, tplMise, miseSource)
+
+	bootstrap := "case \"$provider:$os:$arch\" in\n  mise:linux:x64)\n    url=\"https://old.example/mise\"\n    sha256=\"old\"\n    ;;\n  micromamba:linux:x64)\n    url=\"https://old.example/mamba\"\n    sha256=\"old\"\n    ;;\nesac\n"
+	mustWriteFile(t, repoBootstrap, bootstrap)
+	mustWriteFile(t, tplBootstrap, bootstrap)
+
+	mustWriteFile(t, repoPre, "repos:\n  - repo: https://example.invalid\n")
+	mustWriteFile(t, tplPre, "repos:\n  - repo: https://example.invalid\n")
+
+	binDir := filepath.Join(root, "bin")
+	preCommitPath := filepath.Join(binDir, "pre-commit")
+	fakePreCommit := "#!/bin/sh\nset -eu\nconfig=\"\"\nwhile [ $# -gt 0 ]; do\n  if [ \"$1\" = \"--config\" ]; then\n    shift\n    config=\"$1\"\n  fi\n  shift\ndone\necho \"# updated-by-fake-pre-commit\" >> \"$config\"\n"
+	mustWriteFile(t, preCommitPath, fakePreCommit)
+	if err := os.Chmod(preCommitPath, 0o755); err != nil {
+		t.Fatalf("failed to chmod fake pre-commit: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	versions := toolinglib.Versions{
+		Conda: map[string]string{
+			"pre-commit": "4.6.0",
+			"go-shfmt":   "3.13.1",
+			"terraform":  "1.15.6",
+			"shellcheck": "0.11.0",
+			"taplo":      "0.9.3",
+		},
+		Python: map[string]string{
+			"pre-commit":           "4.6.0",
+			"editorconfig-checker": "3.6.1",
+			"yamllint":             "1.38.0",
+		},
+		NPM: map[string]string{
+			"prettier":         "3.9.3",
+			"markdownlint-cli": "0.49.0",
+		},
+		GoModules: map[string]string{
+			"github.com/daixiang0/gci":                            "v0.13.7",
+			"github.com/golangci/golangci-lint/cmd/golangci-lint": "v1.64.8",
+		},
+		Providers: map[string]toolinglib.ProviderAsset{
+			"mise:linux:x64":       {URL: "https://new.example/mise", SHA256: "mise-sha"},
+			"micromamba:linux:x64": {URL: "https://new.example/mamba", SHA256: "mamba-sha"},
+		},
+	}
+
+	mambaChanged, err := RunMicromamba(root, "all", versions, true)
+	if err != nil {
+		t.Fatalf("RunMicromamba failed: %v", err)
+	}
+	if !containsAll(mambaChanged, repoEnv, tplEnv, repoBootstrap, tplBootstrap) {
+		t.Fatalf("RunMicromamba changed mismatch: %v", mambaChanged)
+	}
+
+	miseChanged, err := RunMise(root, "all", versions, true)
+	if err != nil {
+		t.Fatalf("RunMise failed: %v", err)
+	}
+	if !containsAll(miseChanged, repoMise, tplMise, repoBootstrap, tplBootstrap) {
+		t.Fatalf("RunMise changed mismatch: %v", miseChanged)
+	}
+
+	preChanged, err := RunPreCommit(root, "all", true)
+	if err != nil {
+		t.Fatalf("RunPreCommit failed: %v", err)
+	}
+	if !containsAll(preChanged, repoPre, tplPre) {
+		t.Fatalf("RunPreCommit changed mismatch: %v", preChanged)
+	}
+
+	if changed, err := RunPreCommit(root, "all", false); err != nil || len(changed) != 0 {
+		t.Fatalf("RunPreCommit dry-run expected no changes, got %v err=%v", changed, err)
+	}
+
+	if !strings.Contains(mustReadFile(t, repoEnv), "pre-commit=4.6.0") {
+		t.Fatalf("repo environment.yml was not updated")
+	}
+	if !strings.Contains(mustReadFile(t, tplEnv), "go-shfmt=3.13.1") {
+		t.Fatalf("template environment.yml was not updated")
+	}
+	if !strings.Contains(mustReadFile(t, repoMise), "shellcheck = \"0.11.0\"") {
+		t.Fatalf("repo mise.toml tool pins were not updated")
+	}
+	if !strings.Contains(mustReadFile(t, tplMise), "github.com/daixiang0/gci@v0.13.7") {
+		t.Fatalf("template mise.toml go module pins were not updated")
+	}
+	if !strings.Contains(mustReadFile(t, repoBootstrap), "url=\"https://new.example/mamba\"") {
+		t.Fatalf("repo bootstrap script was not updated")
+	}
+	if !strings.Contains(mustReadFile(t, tplBootstrap), "sha256=\"mise-sha\"") {
+		t.Fatalf("template bootstrap script was not updated")
+	}
+	if !strings.Contains(mustReadFile(t, repoPre), "# updated-by-fake-pre-commit") {
+		t.Fatalf("repo pre-commit config was not updated by fake pre-commit")
+	}
+	if !strings.Contains(mustReadFile(t, tplPre), "# updated-by-fake-pre-commit") {
+		t.Fatalf("template pre-commit config was not updated by fake pre-commit")
+	}
+}

--- a/tools/pkg/toolinglib/env.go
+++ b/tools/pkg/toolinglib/env.go
@@ -1,0 +1,18 @@
+package toolinglib
+
+import "os"
+
+const (
+	EnvGitHubTokenPrimary  = "GH_TOKEN"
+	EnvGitHubTokenFallback = "GITHUB_TOKEN"
+	EnvLogLevel            = "TOOLING_UPDATER_LOG_LEVEL"
+)
+
+func FirstNonEmptyEnv(names ...string) string {
+	for _, name := range names {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/tools/pkg/toolinglib/layout.go
+++ b/tools/pkg/toolinglib/layout.go
@@ -1,0 +1,67 @@
+package toolinglib
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func DiscoverTemplateFiles(root string) (TemplateFiles, error) {
+	templatesRoot := filepath.Join(root, "templates")
+	envFiles, err := filepath.Glob(filepath.Join(templatesRoot, "languages", "*", "providers", "micromamba", "environment.yml"))
+	if err != nil {
+		return TemplateFiles{}, err
+	}
+	miseFiles, err := filepath.Glob(filepath.Join(templatesRoot, "languages", "*", "providers", "mise", "mise.toml"))
+	if err != nil {
+		return TemplateFiles{}, err
+	}
+	preCommitFiles, err := filepath.Glob(filepath.Join(templatesRoot, "languages", "*", ".pre-commit-config.yaml"))
+	if err != nil {
+		return TemplateFiles{}, err
+	}
+	sort.Strings(envFiles)
+	sort.Strings(miseFiles)
+	sort.Strings(preCommitFiles)
+	return TemplateFiles{EnvFiles: envFiles, MiseFiles: miseFiles, PreCommitFiles: preCommitFiles}, nil
+}
+
+func VerifyWorkspaceLayout(root string) error {
+	requiredFiles := []string{
+		filepath.Join(root, "environment.yml"),
+		filepath.Join(root, "mise.toml"),
+		filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"),
+		filepath.Join(root, ".pre-commit-config.yaml"),
+		filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"),
+	}
+	missing := make([]string, 0)
+	for _, p := range requiredFiles {
+		if _, err := os.Stat(p); err != nil {
+			if os.IsNotExist(err) {
+				rel, _ := filepath.Rel(root, p)
+				missing = append(missing, rel)
+			} else {
+				return err
+			}
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("workspace layout verification failed, missing files: %s", strings.Join(missing, ", "))
+	}
+	templateFiles, err := DiscoverTemplateFiles(root)
+	if err != nil {
+		return err
+	}
+	if len(templateFiles.EnvFiles) == 0 {
+		return fmt.Errorf("workspace layout verification failed: no template micromamba environment.yml files found")
+	}
+	if len(templateFiles.MiseFiles) == 0 {
+		return fmt.Errorf("workspace layout verification failed: no template mise.toml files found")
+	}
+	if len(templateFiles.PreCommitFiles) == 0 {
+		return fmt.Errorf("workspace layout verification failed: no template .pre-commit-config.yaml files found")
+	}
+	return nil
+}

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -1,6 +1,8 @@
 package toolinglib
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -171,19 +173,40 @@ func UpdateMiseText(text string, envVersions map[string]string, pythonVersions m
 	return out, nil
 }
 
-func RunPreCommitAutoupdate(configs []string) error {
-	if err := EnsureCommandAvailable("pre-commit"); err != nil {
-		return err
+func fileSHA256(path string) (string, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
 	}
+	digest := sha256.Sum256(payload)
+	return hex.EncodeToString(digest[:]), nil
+}
+
+func RunPreCommitAutoupdate(configs []string) ([]string, error) {
+	if err := EnsureCommandAvailable("pre-commit"); err != nil {
+		return nil, err
+	}
+	changed := make([]string, 0)
 	for _, config := range configs {
+		beforeHash, err := fileSHA256(config)
+		if err != nil {
+			return nil, err
+		}
 		cmd := exec.Command("pre-commit", "autoupdate", "--config", config)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
-			return err
+			return nil, err
+		}
+		afterHash, err := fileSHA256(config)
+		if err != nil {
+			return nil, err
+		}
+		if beforeHash != afterHash {
+			changed = append(changed, config)
 		}
 	}
-	return nil
+	return changed, nil
 }
 
 func FilterProviderAssets(providerAssets map[string]ProviderAsset, prefix string) map[string]ProviderAsset {

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -1,6 +1,7 @@
 package toolinglib
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var MiseToolSource = map[string]string{
@@ -83,6 +85,14 @@ func ReplaceIfPresent(pattern string, replacement string, text string) (string, 
 	return re.ReplaceAllString(text, replacement), true, nil
 }
 
+func requireVersion(versions map[string]string, key string, source string) (string, error) {
+	value, ok := versions[key]
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("missing %s version for %s", source, key)
+	}
+	return value, nil
+}
+
 func UpdateEnvText(text string, versions map[string]string) (string, error) {
 	updated := text
 	for pkg, version := range versions {
@@ -137,7 +147,11 @@ func UpdateBootstrapScriptText(text string, providerData map[string]ProviderAsse
 func UpdateMiseText(text string, envVersions map[string]string, pythonVersions map[string]string, npmVersions map[string]string, goVersions map[string]string) (string, error) {
 	updated := text
 	for miseKey, condaSource := range MiseToolSource {
-		next, err := UpdateTOMLAssignment(updated, miseKey, envVersions[condaSource])
+		value, err := requireVersion(envVersions, condaSource, "conda")
+		if err != nil {
+			return "", fmt.Errorf("missing conda version for %s (source %s)", miseKey, condaSource)
+		}
+		next, err := UpdateTOMLAssignment(updated, miseKey, value)
 		if err != nil {
 			return "", err
 		}
@@ -146,14 +160,26 @@ func UpdateMiseText(text string, envVersions map[string]string, pythonVersions m
 
 	replacements := make([][2]string, 0)
 	for pkg, pattern := range PipVersionPatterns {
-		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s==%s", pkg, pythonVersions[pkg])})
+		value, err := requireVersion(pythonVersions, pkg, "python")
+		if err != nil {
+			return "", err
+		}
+		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s==%s", pkg, value)})
 	}
 	for pkg, pattern := range NPMVersionPatterns {
-		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s@%s", pkg, npmVersions[pkg])})
+		value, err := requireVersion(npmVersions, pkg, "npm")
+		if err != nil {
+			return "", err
+		}
+		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s@%s", pkg, value)})
 	}
 	if goVersions != nil {
 		for pkg, pattern := range GoVersionPatterns {
-			replacement := fmt.Sprintf("%s@%s", pkg, goVersions[pkg])
+			value, err := requireVersion(goVersions, pkg, "go")
+			if err != nil {
+				return "", err
+			}
+			replacement := fmt.Sprintf("%s@%s", pkg, value)
 			next, _, err := ReplaceIfPresent(pattern, replacement, updated)
 			if err != nil {
 				return "", err
@@ -188,23 +214,28 @@ func RunPreCommitAutoupdate(configs []string) ([]string, error) {
 	}
 	changed := make([]string, 0)
 	for _, config := range configs {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		beforeHash, err := fileSHA256(config)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
-		cmd := exec.Command("pre-commit", "autoupdate", "--config", config)
+		cmd := exec.CommandContext(ctx, "pre-commit", "autoupdate", "--config", config)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {
+			cancel()
 			return nil, err
 		}
 		afterHash, err := fileSHA256(config)
 		if err != nil {
+			cancel()
 			return nil, err
 		}
 		if beforeHash != afterHash {
 			changed = append(changed, config)
 		}
+		cancel()
 	}
 	return changed, nil
 }

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -70,12 +70,23 @@ func ReplaceOrFail(pattern string, replacement string, text string) (string, err
 	return re.ReplaceAllString(text, replacement), nil
 }
 
+func ReplaceIfPresent(pattern string, replacement string, text string) (string, bool, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", false, err
+	}
+	if !re.MatchString(text) {
+		return text, false, nil
+	}
+	return re.ReplaceAllString(text, replacement), true, nil
+}
+
 func UpdateEnvText(text string, versions map[string]string) (string, error) {
 	updated := text
 	for pkg, version := range versions {
 		pattern := fmt.Sprintf(`(?m)(^\s*-\s*%s=)[^ \n#]+`, regexp.QuoteMeta(pkg))
 		replacement := fmt.Sprintf(`${1}%s`, version)
-		next, err := ReplaceOrFail(pattern, replacement, updated)
+		next, _, err := ReplaceIfPresent(pattern, replacement, updated)
 		if err != nil {
 			return "", err
 		}
@@ -140,7 +151,12 @@ func UpdateMiseText(text string, envVersions map[string]string, pythonVersions m
 	}
 	if goVersions != nil {
 		for pkg, pattern := range GoVersionPatterns {
-			replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s@%s", pkg, goVersions[pkg])})
+			replacement := fmt.Sprintf("%s@%s", pkg, goVersions[pkg])
+			next, _, err := ReplaceIfPresent(pattern, replacement, updated)
+			if err != nil {
+				return "", err
+			}
+			updated = next
 		}
 	}
 

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -1,9 +1,8 @@
 package toolinglib
 
 import (
+	"bytes"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"os"
 	"os/exec"
@@ -203,43 +202,64 @@ func UpdateMiseText(text string, envVersions map[string]string, pythonVersions m
 	return out, nil
 }
 
-func fileSHA256(path string) (string, error) {
-	payload, err := os.ReadFile(path)
-	if err != nil {
-		return "", err
-	}
-	digest := sha256.Sum256(payload)
-	return hex.EncodeToString(digest[:]), nil
-}
-
-func RunPreCommitAutoupdate(configs []string) ([]string, error) {
+// RunPreCommitAutoupdate runs "pre-commit autoupdate" on each config via a temp
+// copy, preventing partial writes to the originals on failure. When write is
+// false (dry-run) the originals are not modified; the returned list still
+// contains every config that would have changed.
+func RunPreCommitAutoupdate(configs []string, write bool) ([]string, error) {
 	if err := EnsureCommandAvailable("pre-commit"); err != nil {
 		return nil, err
 	}
 	changed := make([]string, 0)
 	for _, config := range configs {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-		beforeHash, err := fileSHA256(config)
+		original, err := os.ReadFile(config)
 		if err != nil {
-			cancel()
-			return nil, err
+			return changed, err
 		}
-		cmd := exec.CommandContext(ctx, "pre-commit", "autoupdate", "--config", config)
+
+		tmp, err := os.CreateTemp("", "pre-commit-autoupdate-*.yaml")
+		if err != nil {
+			return changed, err
+		}
+		tmpPath := tmp.Name()
+		if _, err := tmp.Write(original); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmpPath)
+			return changed, err
+		}
+		_ = tmp.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		cmd := exec.CommandContext(ctx, "pre-commit", "autoupdate", "--config", tmpPath)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
-		if err := cmd.Run(); err != nil {
-			cancel()
-			return nil, err
-		}
-		afterHash, err := fileSHA256(config)
-		if err != nil {
-			cancel()
-			return nil, err
-		}
-		if beforeHash != afterHash {
-			changed = append(changed, config)
-		}
+		runErr := cmd.Run()
 		cancel()
+
+		if runErr != nil {
+			_ = os.Remove(tmpPath)
+			return changed, runErr
+		}
+
+		updated, err := os.ReadFile(tmpPath)
+		_ = os.Remove(tmpPath)
+		if err != nil {
+			return changed, err
+		}
+
+		if bytes.Equal(original, updated) {
+			continue
+		}
+		changed = append(changed, config)
+		if write {
+			mode := os.FileMode(0o644)
+			if info, err := os.Stat(config); err == nil {
+				mode = info.Mode().Perm()
+			}
+			if err := os.WriteFile(config, updated, mode); err != nil {
+				return changed, err
+			}
+		}
 	}
 	return changed, nil
 }

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -16,9 +16,9 @@ var MiseToolSource = map[string]string{
 }
 
 var PipVersionPatterns = map[string]string{
-	"pre-commit":          `pre-commit==[0-9A-Za-z.\-]+`,
+	"pre-commit":           `pre-commit==[0-9A-Za-z.\-]+`,
 	"editorconfig-checker": `editorconfig-checker==[0-9A-Za-z.\-]+`,
-	"yamllint":            `yamllint==[0-9A-Za-z.\-]+`,
+	"yamllint":             `yamllint==[0-9A-Za-z.\-]+`,
 }
 
 var NPMVersionPatterns = map[string]string{
@@ -27,7 +27,7 @@ var NPMVersionPatterns = map[string]string{
 }
 
 var GoVersionPatterns = map[string]string{
-	"github.com/daixiang0/gci":                               `github.com/daixiang0/gci@[0-9A-Za-z.\-]+`,
+	"github.com/daixiang0/gci":                            `github.com/daixiang0/gci@[0-9A-Za-z.\-]+`,
 	"github.com/golangci/golangci-lint/cmd/golangci-lint": `github.com/golangci/golangci-lint/cmd/golangci-lint@[0-9A-Za-z.\-]+`,
 }
 

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -47,6 +47,10 @@ func UpdateFile(path string, updater func(string) (string, error), write bool) (
 	if err != nil {
 		return false, err
 	}
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
 	original := string(payload)
 	updated, err := updater(original)
 	if err != nil {
@@ -56,7 +60,7 @@ func UpdateFile(path string, updater func(string) (string, error), write bool) (
 		return false, nil
 	}
 	if write {
-		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+		if err := os.WriteFile(path, []byte(updated), mode); err != nil {
 			return false, err
 		}
 	}

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -227,7 +227,10 @@ func RunPreCommitAutoupdate(configs []string, write bool) ([]string, error) {
 			_ = os.Remove(tmpPath)
 			return changed, err
 		}
-		_ = tmp.Close()
+		if err := tmp.Close(); err != nil {
+			_ = os.Remove(tmpPath)
+			return changed, err
+		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 		cmd := exec.CommandContext(ctx, "pre-commit", "autoupdate", "--config", tmpPath)

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -1,0 +1,181 @@
+package toolinglib
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var MiseToolSource = map[string]string{
+	"shellcheck": "shellcheck",
+	"shfmt":      "go-shfmt",
+	"terraform":  "terraform",
+	"taplo":      "taplo",
+}
+
+var PipVersionPatterns = map[string]string{
+	"pre-commit":          `pre-commit==[0-9A-Za-z.\-]+`,
+	"editorconfig-checker": `editorconfig-checker==[0-9A-Za-z.\-]+`,
+	"yamllint":            `yamllint==[0-9A-Za-z.\-]+`,
+}
+
+var NPMVersionPatterns = map[string]string{
+	"prettier":         `prettier@[0-9A-Za-z.\-]+`,
+	"markdownlint-cli": `markdownlint-cli@[0-9A-Za-z.\-]+`,
+}
+
+var GoVersionPatterns = map[string]string{
+	"github.com/daixiang0/gci":                               `github.com/daixiang0/gci@[0-9A-Za-z.\-]+`,
+	"github.com/golangci/golangci-lint/cmd/golangci-lint": `github.com/golangci/golangci-lint/cmd/golangci-lint@[0-9A-Za-z.\-]+`,
+}
+
+func EnsureCommandAvailable(command string) error {
+	if _, err := exec.LookPath(command); err != nil {
+		return fmt.Errorf("missing required command: %s", command)
+	}
+	return nil
+}
+
+func UpdateFile(path string, updater func(string) (string, error), write bool) (bool, error) {
+	payload, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	original := string(payload)
+	updated, err := updater(original)
+	if err != nil {
+		return false, err
+	}
+	if updated == original {
+		return false, nil
+	}
+	if write {
+		if err := os.WriteFile(path, []byte(updated), 0o644); err != nil {
+			return false, err
+		}
+	}
+	return true, nil
+}
+
+func ReplaceOrFail(pattern string, replacement string, text string) (string, error) {
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	if !re.MatchString(text) {
+		return "", fmt.Errorf("expected pattern not found: %s", pattern)
+	}
+	return re.ReplaceAllString(text, replacement), nil
+}
+
+func UpdateEnvText(text string, versions map[string]string) (string, error) {
+	updated := text
+	for pkg, version := range versions {
+		pattern := fmt.Sprintf(`(?m)(^\s*-\s*%s=)[^ \n#]+`, regexp.QuoteMeta(pkg))
+		replacement := fmt.Sprintf(`${1}%s`, version)
+		next, err := ReplaceOrFail(pattern, replacement, updated)
+		if err != nil {
+			return "", err
+		}
+		updated = next
+	}
+	return updated, nil
+}
+
+func UpdateTOMLAssignment(text string, key string, value string) (string, error) {
+	pattern := fmt.Sprintf(`(?m)(^\s*%s\s*=\s*")([^"]+)("\s*$)`, regexp.QuoteMeta(key))
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", err
+	}
+	if !re.MatchString(text) {
+		return "", fmt.Errorf("expected TOML key not found: %s", key)
+	}
+	updated := re.ReplaceAllStringFunc(text, func(match string) string {
+		sub := re.FindStringSubmatch(match)
+		if len(sub) != 4 {
+			return match
+		}
+		if strings.Contains(sub[2], "{{") {
+			return match
+		}
+		return sub[1] + value + sub[3]
+	})
+	return updated, nil
+}
+
+func UpdateBootstrapScriptText(text string, providerData map[string]ProviderAsset) (string, error) {
+	updated := text
+	for key, values := range providerData {
+		caseLabel := regexp.QuoteMeta(key)
+		pattern := fmt.Sprintf(`(%s\)\n\s*url=")[^"]+("\n\s*sha256=")[^"]+(")`, caseLabel)
+		replacement := fmt.Sprintf(`${1}%s${2}%s${3}`, values.URL, values.SHA256)
+		next, err := ReplaceOrFail(pattern, replacement, updated)
+		if err != nil {
+			return "", err
+		}
+		updated = next
+	}
+	return updated, nil
+}
+
+func UpdateMiseText(text string, envVersions map[string]string, pythonVersions map[string]string, npmVersions map[string]string, goVersions map[string]string) (string, error) {
+	updated := text
+	for miseKey, condaSource := range MiseToolSource {
+		next, err := UpdateTOMLAssignment(updated, miseKey, envVersions[condaSource])
+		if err != nil {
+			return "", err
+		}
+		updated = next
+	}
+
+	replacements := make([][2]string, 0)
+	for pkg, pattern := range PipVersionPatterns {
+		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s==%s", pkg, pythonVersions[pkg])})
+	}
+	for pkg, pattern := range NPMVersionPatterns {
+		replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s@%s", pkg, npmVersions[pkg])})
+	}
+	if goVersions != nil {
+		for pkg, pattern := range GoVersionPatterns {
+			replacements = append(replacements, [2]string{pattern, fmt.Sprintf("%s@%s", pkg, goVersions[pkg])})
+		}
+	}
+
+	out := updated
+	for _, pair := range replacements {
+		next, err := ReplaceOrFail(pair[0], pair[1], out)
+		if err != nil {
+			return "", err
+		}
+		out = next
+	}
+	return out, nil
+}
+
+func RunPreCommitAutoupdate(configs []string) error {
+	if err := EnsureCommandAvailable("pre-commit"); err != nil {
+		return err
+	}
+	for _, config := range configs {
+		cmd := exec.Command("pre-commit", "autoupdate", "--config", config)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func FilterProviderAssets(providerAssets map[string]ProviderAsset, prefix string) map[string]ProviderAsset {
+	out := make(map[string]ProviderAsset)
+	for key, value := range providerAssets {
+		if strings.HasPrefix(key, prefix) {
+			out[key] = value
+		}
+	}
+	return out
+}

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -1,0 +1,67 @@
+package toolinglib
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestUpdateEnvText(t *testing.T) {
+	source := "dependencies:\n  - pre-commit=4.0.0\n  - prettier=1.0.0\n"
+	updated, err := UpdateEnvText(source, map[string]string{"pre-commit": "4.6.0", "prettier": "3.9.3"})
+	if err != nil {
+		t.Fatalf("UpdateEnvText returned error: %v", err)
+	}
+	if !strings.Contains(updated, "pre-commit=4.6.0") {
+		t.Fatalf("expected updated pre-commit version, got: %s", updated)
+	}
+	if !strings.Contains(updated, "prettier=3.9.3") {
+		t.Fatalf("expected updated prettier version, got: %s", updated)
+	}
+}
+
+func TestUpdateMiseTextKeepsTemplatePlaceholders(t *testing.T) {
+	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		map[string]string{"shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.9.3"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	expects := []string{
+		`python = "{{PYTHON_VERSION}}"`,
+		`shellcheck = "0.11.0"`,
+		`shfmt = "3.13.1"`,
+		`terraform = "1.15.6"`,
+		`taplo = "0.9.3"`,
+		"pre-commit==4.6.0",
+		"editorconfig-checker==3.6.1",
+		"yamllint==1.38.0",
+		"prettier@3.9.3",
+		"markdownlint-cli@0.49.0",
+	}
+	for _, expected := range expects {
+		if !strings.Contains(updated, expected) {
+			t.Fatalf("expected %q in output", expected)
+		}
+	}
+}
+
+func TestUpdateBootstrapScriptText(t *testing.T) {
+	source := "case \"$provider:$os:$arch\" in\n    mise:linux:x64)\n        url=\"https://example.invalid/old\"\n        sha256=\"old\"\n        ;;\nesac\n"
+	updated, err := UpdateBootstrapScriptText(source, map[string]ProviderAsset{
+		"mise:linux:x64": {URL: "https://example.invalid/new", SHA256: "abc123"},
+	})
+	if err != nil {
+		t.Fatalf("UpdateBootstrapScriptText returned error: %v", err)
+	}
+	if !strings.Contains(updated, `url="https://example.invalid/new"`) {
+		t.Fatalf("expected updated url, got: %s", updated)
+	}
+	if !strings.Contains(updated, `sha256="abc123"`) {
+		t.Fatalf("expected updated sha256, got: %s", updated)
+	}
+}

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -19,6 +19,17 @@ func TestUpdateEnvText(t *testing.T) {
 	}
 }
 
+func TestUpdateEnvTextIgnoresMissingPackage(t *testing.T) {
+	source := "dependencies:\n  - pre-commit=4.0.0\n"
+	updated, err := UpdateEnvText(source, map[string]string{"pre-commit": "4.6.0", "terraform": "1.2.3"})
+	if err != nil {
+		t.Fatalf("UpdateEnvText returned error: %v", err)
+	}
+	if !strings.Contains(updated, "pre-commit=4.6.0") {
+		t.Fatalf("expected updated pre-commit version, got: %s", updated)
+	}
+}
+
 func TestUpdateMiseTextKeepsTemplatePlaceholders(t *testing.T) {
 	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
 	updated, err := UpdateMiseText(
@@ -47,6 +58,23 @@ func TestUpdateMiseTextKeepsTemplatePlaceholders(t *testing.T) {
 		if !strings.Contains(updated, expected) {
 			t.Fatalf("expected %q in output", expected)
 		}
+	}
+}
+
+func TestUpdateMiseTextIgnoresMissingGoModulePatterns(t *testing.T) {
+	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		map[string]string{"shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.9.3"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		map[string]string{"github.com/daixiang0/gci": "v0.1.0", "github.com/golangci/golangci-lint/cmd/golangci-lint": "v1.2.3"},
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	if !strings.Contains(updated, "pre-commit==4.6.0") {
+		t.Fatalf("expected updated pre-commit version, got: %s", updated)
 	}
 }
 

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -1,6 +1,7 @@
 package toolinglib
 
 import (
+	"os"
 	"strings"
 	"testing"
 )
@@ -91,5 +92,37 @@ func TestUpdateBootstrapScriptText(t *testing.T) {
 	}
 	if !strings.Contains(updated, `sha256="abc123"`) {
 		t.Fatalf("expected updated sha256, got: %s", updated)
+	}
+}
+
+func TestUpdateFilePreservesPermissions(t *testing.T) {
+	tmp, err := os.CreateTemp(t.TempDir(), "bootstrap-*.sh")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	if _, err := tmp.WriteString("#!/bin/sh\necho old\n"); err != nil {
+		t.Fatalf("WriteString: %v", err)
+	}
+	_ = tmp.Close()
+	if err := os.Chmod(tmp.Name(), 0o755); err != nil {
+		t.Fatalf("Chmod: %v", err)
+	}
+
+	changed, err := UpdateFile(tmp.Name(), func(content string) (string, error) {
+		return strings.ReplaceAll(content, "old", "new"), nil
+	}, true)
+	if err != nil {
+		t.Fatalf("UpdateFile failed: %v", err)
+	}
+	if !changed {
+		t.Fatal("expected file to be reported changed")
+	}
+
+	info, err := os.Stat(tmp.Name())
+	if err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("expected permission 0755, got %o", info.Mode().Perm())
 	}
 }

--- a/tools/pkg/toolinglib/types.go
+++ b/tools/pkg/toolinglib/types.go
@@ -1,0 +1,20 @@
+package toolinglib
+
+type ProviderAsset struct {
+	URL    string
+	SHA256 string
+}
+
+type Versions struct {
+	Conda     map[string]string
+	Python    map[string]string
+	NPM       map[string]string
+	GoModules map[string]string
+	Providers map[string]ProviderAsset
+}
+
+type TemplateFiles struct {
+	EnvFiles       []string
+	MiseFiles      []string
+	PreCommitFiles []string
+}

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -188,16 +188,13 @@ func latestPyPIVersion(pkg string) (string, error) {
 }
 
 func latestNPMVersion(pkg string) (string, error) {
+	// Use the /latest endpoint to avoid fetching the full package document.
 	encoded := strings.ReplaceAll(url.PathEscape(pkg), "%2F", "/")
-	data, err := httpGetJSON("https://registry.npmjs.org/" + encoded)
+	data, err := httpGetJSON("https://registry.npmjs.org/" + encoded + "/latest")
 	if err != nil {
 		return "", err
 	}
-	distTags, ok := data["dist-tags"].(map[string]any)
-	if !ok {
-		return "", fmt.Errorf("unable to parse npm response for %s", pkg)
-	}
-	version, ok := distTags["latest"].(string)
+	version, ok := data["version"].(string)
 	if !ok || version == "" {
 		return "", fmt.Errorf("unable to resolve npm latest version for %s", pkg)
 	}

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -245,10 +245,10 @@ func CollectVersions() (Versions, error) {
 	}
 
 	providerURLs := map[string]string{
-		"mise:linux:x64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-x64",
-		"mise:linux:arm64":     "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-arm64",
-		"mise:macos:x64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-x64",
-		"mise:macos:arm64":     "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64",
+		"mise:linux:x64":         "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-x64",
+		"mise:linux:arm64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-arm64",
+		"mise:macos:x64":         "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-x64",
+		"mise:macos:arm64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64",
 		"micromamba:linux:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-64",
 		"micromamba:linux:arm64": "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-aarch64",
 		"micromamba:macos:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-64",

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -1,0 +1,268 @@
+package toolinglib
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	userAgent          = "github-bootstrap-tooling-updater"
+	httpTimeoutSeconds = 60
+	httpRetries        = 3
+	hashChunkSize      = 1024 * 1024
+)
+
+var condaPackages = []string{
+	"pre-commit",
+	"prettier",
+	"markdownlint-cli",
+	"yamllint",
+	"taplo",
+	"go-shfmt",
+	"shellcheck",
+	"libxml2",
+	"terraform",
+	"jq",
+	"coreutils",
+}
+
+func readURLBytes(rawURL string, timeoutSeconds int) ([]byte, error) {
+	client := &http.Client{Timeout: time.Duration(timeoutSeconds) * time.Second}
+	var lastErr error
+	for range httpRetries {
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		body, readErr := io.ReadAll(resp.Body)
+		closeErr := resp.Body.Close()
+		if readErr != nil {
+			lastErr = readErr
+			continue
+		}
+		if closeErr != nil {
+			lastErr = closeErr
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("http status %d for %s", resp.StatusCode, rawURL)
+			continue
+		}
+		return body, nil
+	}
+	return nil, fmt.Errorf("failed to fetch URL after retries: %s: %w", rawURL, lastErr)
+}
+
+func httpGetJSON(rawURL string) (map[string]any, error) {
+	payload, err := readURLBytes(rawURL, httpTimeoutSeconds)
+	if err != nil {
+		return nil, err
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(payload, &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}
+
+func fetchSHA256(rawURL string) (string, error) {
+	client := &http.Client{Timeout: 120 * time.Second}
+	var lastErr error
+	for range httpRetries {
+		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		if err != nil {
+			return "", err
+		}
+		req.Header.Set("User-Agent", userAgent)
+		resp, err := client.Do(req)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+			lastErr = fmt.Errorf("http status %d for %s", resp.StatusCode, rawURL)
+			_ = resp.Body.Close()
+			continue
+		}
+		hasher := sha256.New()
+		buffer := make([]byte, hashChunkSize)
+		for {
+			count, readErr := resp.Body.Read(buffer)
+			if count > 0 {
+				if _, err := hasher.Write(buffer[:count]); err != nil {
+					lastErr = err
+					_ = resp.Body.Close()
+					break
+				}
+			}
+			if readErr == io.EOF {
+				if closeErr := resp.Body.Close(); closeErr != nil {
+					lastErr = closeErr
+					break
+				}
+				return hex.EncodeToString(hasher.Sum(nil)), nil
+			}
+			if readErr != nil {
+				lastErr = readErr
+				_ = resp.Body.Close()
+				break
+			}
+		}
+	}
+	return "", fmt.Errorf("failed to fetch binary for checksum after retries: %s: %w", rawURL, lastErr)
+}
+
+func latestCondaVersion(pkg string) (string, error) {
+	encoded := url.PathEscape(pkg)
+	data, err := httpGetJSON("https://api.anaconda.org/package/conda-forge/" + encoded)
+	if err != nil {
+		return "", err
+	}
+	version, ok := data["latest_version"].(string)
+	if !ok || version == "" {
+		return "", fmt.Errorf("unable to resolve conda-forge latest version for %s", pkg)
+	}
+	return version, nil
+}
+
+func latestPyPIVersion(pkg string) (string, error) {
+	encoded := url.PathEscape(pkg)
+	data, err := httpGetJSON("https://pypi.org/pypi/" + encoded + "/json")
+	if err != nil {
+		return "", err
+	}
+	info, ok := data["info"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("unable to parse PyPI response for %s", pkg)
+	}
+	version, ok := info["version"].(string)
+	if !ok || version == "" {
+		return "", fmt.Errorf("unable to resolve PyPI latest version for %s", pkg)
+	}
+	return version, nil
+}
+
+func latestNPMVersion(pkg string) (string, error) {
+	encoded := strings.ReplaceAll(url.PathEscape(pkg), "%2F", "/")
+	data, err := httpGetJSON("https://registry.npmjs.org/" + encoded)
+	if err != nil {
+		return "", err
+	}
+	distTags, ok := data["dist-tags"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("unable to parse npm response for %s", pkg)
+	}
+	version, ok := distTags["latest"].(string)
+	if !ok || version == "" {
+		return "", fmt.Errorf("unable to resolve npm latest version for %s", pkg)
+	}
+	return version, nil
+}
+
+func latestGoModuleVersion(module string) (string, error) {
+	encoded := strings.ReplaceAll(url.PathEscape(module), "%2F", "/")
+	data, err := httpGetJSON("https://proxy.golang.org/" + encoded + "/@latest")
+	if err != nil {
+		return "", err
+	}
+	version, ok := data["Version"].(string)
+	if !ok || version == "" {
+		return "", fmt.Errorf("unable to resolve Go module latest version for %s", module)
+	}
+	return version, nil
+}
+
+func latestGitHubReleaseTag(repo string) (string, error) {
+	data, err := httpGetJSON("https://api.github.com/repos/" + repo + "/releases/latest")
+	if err != nil {
+		return "", err
+	}
+	tag, ok := data["tag_name"].(string)
+	if !ok || tag == "" {
+		return "", fmt.Errorf("unable to resolve latest GitHub release tag for %s", repo)
+	}
+	return tag, nil
+}
+
+func CollectVersions() (Versions, error) {
+	conda := make(map[string]string)
+	for _, pkg := range condaPackages {
+		v, err := latestCondaVersion(pkg)
+		if err != nil {
+			return Versions{}, err
+		}
+		conda[pkg] = v
+	}
+
+	python := map[string]string{}
+	for _, pkg := range []string{"pre-commit", "editorconfig-checker", "yamllint"} {
+		v, err := latestPyPIVersion(pkg)
+		if err != nil {
+			return Versions{}, err
+		}
+		python[pkg] = v
+	}
+
+	npm := map[string]string{}
+	for _, pkg := range []string{"prettier", "markdownlint-cli"} {
+		v, err := latestNPMVersion(pkg)
+		if err != nil {
+			return Versions{}, err
+		}
+		npm[pkg] = v
+	}
+
+	goModules := map[string]string{}
+	for _, module := range []string{"github.com/daixiang0/gci", "github.com/golangci/golangci-lint/cmd/golangci-lint"} {
+		v, err := latestGoModuleVersion(module)
+		if err != nil {
+			return Versions{}, err
+		}
+		goModules[module] = v
+	}
+
+	miseTag, err := latestGitHubReleaseTag("jdx/mise")
+	if err != nil {
+		return Versions{}, err
+	}
+	micromambaTag, err := latestGitHubReleaseTag("mamba-org/micromamba-releases")
+	if err != nil {
+		return Versions{}, err
+	}
+
+	providerURLs := map[string]string{
+		"mise:linux:x64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-x64",
+		"mise:linux:arm64":     "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-arm64",
+		"mise:macos:x64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-x64",
+		"mise:macos:arm64":     "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64",
+		"micromamba:linux:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-64",
+		"micromamba:linux:arm64": "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-aarch64",
+		"micromamba:macos:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-64",
+		"micromamba:macos:arm64": "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-arm64",
+	}
+
+	providers := map[string]ProviderAsset{}
+	for key, rawURL := range providerURLs {
+		digest, err := fetchSHA256(rawURL)
+		if err != nil {
+			return Versions{}, err
+		}
+		providers[key] = ProviderAsset{URL: rawURL, SHA256: digest}
+	}
+
+	return Versions{Conda: conda, Python: python, NPM: npm, GoModules: goModules, Providers: providers}, nil
+}

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -45,7 +46,12 @@ func retryBackoff(attempt int) {
 }
 
 func githubAPIToken() string {
-	return strings.TrimSpace(FirstNonEmptyEnv(EnvGitHubTokenPrimary, EnvGitHubTokenFallback))
+	for _, name := range []string{EnvGitHubTokenPrimary, EnvGitHubTokenFallback} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 func newRequest(rawURL string, acceptJSON bool) (*http.Request, error) {

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"time"
 )
@@ -33,16 +34,41 @@ var condaPackages = []string{
 	"coreutils",
 }
 
+func githubAPIToken() string {
+	if token := strings.TrimSpace(os.Getenv("GH_TOKEN")); token != "" {
+		return token
+	}
+	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
+		return token
+	}
+	return ""
+}
+
+func newRequest(rawURL string, acceptJSON bool) (*http.Request, error) {
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+	if acceptJSON {
+		req.Header.Set("Accept", "application/json")
+	}
+	if strings.HasPrefix(rawURL, "https://api.github.com/") {
+		if token := githubAPIToken(); token != "" {
+			req.Header.Set("Authorization", "Bearer "+token)
+		}
+	}
+	return req, nil
+}
+
 func readURLBytes(rawURL string, timeoutSeconds int) ([]byte, error) {
 	client := &http.Client{Timeout: time.Duration(timeoutSeconds) * time.Second}
 	var lastErr error
 	for range httpRetries {
-		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		req, err := newRequest(rawURL, true)
 		if err != nil {
 			return nil, err
 		}
-		req.Header.Set("Accept", "application/json")
-		req.Header.Set("User-Agent", userAgent)
 		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = err
@@ -83,11 +109,10 @@ func fetchSHA256(rawURL string) (string, error) {
 	client := &http.Client{Timeout: 120 * time.Second}
 	var lastErr error
 	for range httpRetries {
-		req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+		req, err := newRequest(rawURL, false)
 		if err != nil {
 			return "", err
 		}
-		req.Header.Set("User-Agent", userAgent)
 		resp, err := client.Do(req)
 		if err != nil {
 			lastErr = err
@@ -198,7 +223,22 @@ func latestGitHubReleaseTag(repo string) (string, error) {
 	return tag, nil
 }
 
-func CollectVersions() (Versions, error) {
+func CollectVersions(selectedUpdaters []string) (Versions, error) {
+	needsMicromamba := false
+	needsMise := false
+	for _, updater := range selectedUpdaters {
+		if updater == "micromamba" {
+			needsMicromamba = true
+		}
+		if updater == "mise" {
+			needsMise = true
+		}
+	}
+	if !needsMicromamba && !needsMise {
+		needsMicromamba = true
+		needsMise = true
+	}
+
 	conda := make(map[string]string)
 	for _, pkg := range condaPackages {
 		v, err := latestCondaVersion(pkg)
@@ -209,50 +249,54 @@ func CollectVersions() (Versions, error) {
 	}
 
 	python := map[string]string{}
-	for _, pkg := range []string{"pre-commit", "editorconfig-checker", "yamllint"} {
-		v, err := latestPyPIVersion(pkg)
-		if err != nil {
-			return Versions{}, err
-		}
-		python[pkg] = v
-	}
-
 	npm := map[string]string{}
-	for _, pkg := range []string{"prettier", "markdownlint-cli"} {
-		v, err := latestNPMVersion(pkg)
-		if err != nil {
-			return Versions{}, err
-		}
-		npm[pkg] = v
-	}
-
 	goModules := map[string]string{}
-	for _, module := range []string{"github.com/daixiang0/gci", "github.com/golangci/golangci-lint/cmd/golangci-lint"} {
-		v, err := latestGoModuleVersion(module)
+	if needsMise {
+		for _, pkg := range []string{"pre-commit", "editorconfig-checker", "yamllint"} {
+			v, err := latestPyPIVersion(pkg)
+			if err != nil {
+				return Versions{}, err
+			}
+			python[pkg] = v
+		}
+
+		for _, pkg := range []string{"prettier", "markdownlint-cli"} {
+			v, err := latestNPMVersion(pkg)
+			if err != nil {
+				return Versions{}, err
+			}
+			npm[pkg] = v
+		}
+
+		for _, module := range []string{"github.com/daixiang0/gci", "github.com/golangci/golangci-lint/cmd/golangci-lint"} {
+			v, err := latestGoModuleVersion(module)
+			if err != nil {
+				return Versions{}, err
+			}
+			goModules[module] = v
+		}
+	}
+
+	providerURLs := map[string]string{}
+	if needsMise {
+		miseTag, err := latestGitHubReleaseTag("jdx/mise")
 		if err != nil {
 			return Versions{}, err
 		}
-		goModules[module] = v
+		providerURLs["mise:linux:x64"] = "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-x64"
+		providerURLs["mise:linux:arm64"] = "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-arm64"
+		providerURLs["mise:macos:x64"] = "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-x64"
+		providerURLs["mise:macos:arm64"] = "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64"
 	}
-
-	miseTag, err := latestGitHubReleaseTag("jdx/mise")
-	if err != nil {
-		return Versions{}, err
-	}
-	micromambaTag, err := latestGitHubReleaseTag("mamba-org/micromamba-releases")
-	if err != nil {
-		return Versions{}, err
-	}
-
-	providerURLs := map[string]string{
-		"mise:linux:x64":         "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-x64",
-		"mise:linux:arm64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-linux-arm64",
-		"mise:macos:x64":         "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-x64",
-		"mise:macos:arm64":       "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64",
-		"micromamba:linux:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-64",
-		"micromamba:linux:arm64": "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-aarch64",
-		"micromamba:macos:x64":   "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-64",
-		"micromamba:macos:arm64": "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-arm64",
+	if needsMicromamba {
+		micromambaTag, err := latestGitHubReleaseTag("mamba-org/micromamba-releases")
+		if err != nil {
+			return Versions{}, err
+		}
+		providerURLs["micromamba:linux:x64"] = "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-64"
+		providerURLs["micromamba:linux:arm64"] = "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-linux-aarch64"
+		providerURLs["micromamba:macos:x64"] = "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-64"
+		providerURLs["micromamba:macos:arm64"] = "https://github.com/mamba-org/micromamba-releases/releases/download/" + micromambaTag + "/micromamba-osx-arm64"
 	}
 
 	providers := map[string]ProviderAsset{}

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 )
@@ -46,13 +45,7 @@ func retryBackoff(attempt int) {
 }
 
 func githubAPIToken() string {
-	if token := strings.TrimSpace(os.Getenv("GH_TOKEN")); token != "" {
-		return token
-	}
-	if token := strings.TrimSpace(os.Getenv("GITHUB_TOKEN")); token != "" {
-		return token
-	}
-	return ""
+	return strings.TrimSpace(FirstNonEmptyEnv(EnvGitHubTokenPrimary, EnvGitHubTokenFallback))
 }
 
 func newRequest(rawURL string, acceptJSON bool) (*http.Request, error) {

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -34,6 +34,17 @@ var condaPackages = []string{
 	"coreutils",
 }
 
+func retryBackoff(attempt int) {
+	if attempt <= 0 {
+		return
+	}
+	delay := time.Second * time.Duration(1<<uint(attempt-1))
+	if delay > 8*time.Second {
+		delay = 8 * time.Second
+	}
+	time.Sleep(delay)
+}
+
 func githubAPIToken() string {
 	if token := strings.TrimSpace(os.Getenv("GH_TOKEN")); token != "" {
 		return token
@@ -64,7 +75,8 @@ func newRequest(rawURL string, acceptJSON bool) (*http.Request, error) {
 func readURLBytes(rawURL string, timeoutSeconds int) ([]byte, error) {
 	client := &http.Client{Timeout: time.Duration(timeoutSeconds) * time.Second}
 	var lastErr error
-	for range httpRetries {
+	for attempt := range httpRetries {
+		retryBackoff(attempt)
 		req, err := newRequest(rawURL, true)
 		if err != nil {
 			return nil, err
@@ -108,7 +120,8 @@ func httpGetJSON(rawURL string) (map[string]any, error) {
 func fetchSHA256(rawURL string) (string, error) {
 	client := &http.Client{Timeout: 120 * time.Second}
 	var lastErr error
-	for range httpRetries {
+	for attempt := range httpRetries {
+		retryBackoff(attempt)
 		req, err := newRequest(rawURL, false)
 		if err != nil {
 			return "", err


### PR DESCRIPTION
## Summary
- migrate non-Dependabot tooling updater from Python scripts to a Go workspace/module structure
- add monorepo-style layout for tooling (`tools/cmd`, `tools/internal`, `tools/pkg`) with Go 1.26 (`go.work`, `tools/go.mod`)
- split updater responsibilities into dedicated units: `micromamba`, `mise`, `pre-commit`, and `system`
- update Make targets to build the updater binary before each tooling command, then execute that latest binary
- improve environment setup so micromamba refreshes when Go is missing and system mode validates `go` presence
- add Go quality gates to pre-commit for tooling module (`gofmt`, `go vet`, `go test`)
- update weekly tooling workflow to run through managed environment and include Go setup

## Validation
- `make tooling-verify`
- `ENV_MANAGER=mise make tooling-verify`
- `ENV_MANAGER=micromamba make lint LINT_MODE=check`
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/weekly-tooling-updates.yml')"`

## Notes
- tooling commands now auto-build the updater binary before use, so users and AI agents run latest source without manual build steps


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a scheduled and manually triggerable weekly tooling-updates workflow that opens/updates and auto-merges a PR.
  * Introduced a tooling updater CLI plus new `make tooling-*` commands to refresh non-Dependabot pins/assets and verify workspace layout.
  * Added automated repo/template updates for environment, Mise, micromamba, and pre-commit configurations (including template-based pre-commit autoupdate).
* **Bug Fixes**
  * Improved environment setup by ensuring Go is available and updating the micromamba environment when missing.
* **Documentation**
  * Documented the weekly workflow and available tooling update/verify commands in the README.
* **Tests**
  * Added unit and end-to-end coverage for tooling text transformations and updater behavior.
* **Chores**
  * Added Go tooling format/vet/test checks via pre-commit hooks and updated Go/tooling versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->