### PR TITLE
feat(tools): decouple runtime/tool updater and extend runtime coverage

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime (required by pre-commit) ─────────────────────────────────
   - python=3.13
 
+  # ── Node.js runtime (required by npm tooling tasks) ───────────────────────
+  - nodejs=24
+
   # ── Go runtime (required by tooling updater CLI) ─────────────────────────────
   - go=1.26
 

--- a/templates/languages/agnostic/providers/micromamba/environment.yml
+++ b/templates/languages/agnostic/providers/micromamba/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime (required by pre-commit) ─────────────────────────────────
   - python={{PYTHON_VERSION}}
 
+  # ── Node.js runtime (required by npm tooling tasks) ───────────────────────
+  - nodejs={{NODE_VERSION}}
+
   # ── Pre-commit framework ────────────────────────────────────────────────────
   - pre-commit=4.6.0
   # ── Linting / formatting tools (used as language: system hooks) ─────────────

--- a/templates/languages/golang/providers/micromamba/environment.yml
+++ b/templates/languages/golang/providers/micromamba/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime (required by pre-commit) ─────────────────────────────────
   - python={{PYTHON_VERSION}}
 
+  # ── Node.js runtime (required by npm tooling tasks) ───────────────────────
+  - nodejs={{NODE_VERSION}}
+
   # ── Pre-commit framework ────────────────────────────────────────────────────
   - pre-commit=4.6.0
   # ── Linting / formatting tools (used as language: system hooks) ─────────────

--- a/templates/languages/java/providers/micromamba/environment.yml
+++ b/templates/languages/java/providers/micromamba/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime (required by pre-commit) ─────────────────────────────────
   - python={{PYTHON_VERSION}}
 
+  # ── Node.js runtime (required by npm tooling tasks) ───────────────────────
+  - nodejs={{NODE_VERSION}}
+
   # ── Pre-commit framework ────────────────────────────────────────────────────
   - pre-commit=4.6.0
   # ── Linting / formatting tools (used as language: system hooks) ─────────────

--- a/templates/languages/python/providers/micromamba/environment.yml
+++ b/templates/languages/python/providers/micromamba/environment.yml
@@ -7,6 +7,9 @@ dependencies:
   # ── Python runtime ──────────────────────────────────────────────────────────
   - python={{PYTHON_VERSION}}
 
+  # ── Node.js runtime (required by npm tooling tasks) ───────────────────────
+  - nodejs={{NODE_VERSION}}
+
   # ── Pre-commit framework ────────────────────────────────────────────────────
   - pre-commit=4.6.0
   # ── Linting / formatting tools (used as language: system hooks) ─────────────

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -11,11 +11,31 @@ import (
 	"time"
 )
 
+// MiseToolSource maps mise.toml tool keys to their conda-forge package names.
+// Tool value in TOML is a plain version string (e.g. python = "3.13.1").
+// Add new entries here to extend runtime version management to new languages.
 var MiseToolSource = map[string]string{
+	"python":     "python",
+	"node":       "nodejs",
+	"go":         "go",
+	"rust":       "rust",
+	"ruby":       "ruby",
 	"shellcheck": "shellcheck",
 	"shfmt":      "go-shfmt",
 	"terraform":  "terraform",
 	"taplo":      "taplo",
+}
+
+// MisePrefixedToolSource maps mise.toml tool keys whose value carries a
+// non-version prefix to their conda-forge package names.
+// Example: java = "temurin-21" — prefix "temurin-" is preserved, only the
+// numeric version part is updated.
+// Add new entries here for languages with prefixed mise version strings.
+var MisePrefixedToolSource = map[string]struct {
+	CondaPackage string
+	Prefix       string
+}{
+	"java": {CondaPackage: "openjdk", Prefix: "temurin-"},
 }
 
 var PipVersionPatterns = map[string]string{
@@ -99,12 +119,22 @@ func requireVersion(versions map[string]string, key string, source string) (stri
 func UpdateEnvText(text string, versions map[string]string) (string, error) {
 	updated := text
 	for pkg, version := range versions {
-		pattern := fmt.Sprintf(`(?m)(^\s*-\s*%s=)[^ \n#]+`, regexp.QuoteMeta(pkg))
-		replacement := fmt.Sprintf(`${1}%s`, version)
-		next, _, err := ReplaceIfPresent(pattern, replacement, updated)
+		pattern := fmt.Sprintf(`(?m)(^\s*-\s*%s=)([^ \n#]+)`, regexp.QuoteMeta(pkg))
+		re, err := regexp.Compile(pattern)
 		if err != nil {
 			return "", err
 		}
+		next := re.ReplaceAllStringFunc(updated, func(match string) string {
+			sub := re.FindStringSubmatch(match)
+			if len(sub) != 3 {
+				return match
+			}
+			// Keep template placeholders intact in template provider files.
+			if strings.Contains(sub[2], "{{") {
+				return match
+			}
+			return sub[1] + version
+		})
 		updated = next
 	}
 	return updated, nil
@@ -132,6 +162,37 @@ func UpdateTOMLAssignment(text string, key string, value string) (string, error)
 	return updated, nil
 }
 
+func UpdateTOMLAssignmentIfPresent(text string, key string, value string) (string, bool, error) {
+	pattern := fmt.Sprintf(`(?m)(^\s*%s\s*=\s*")([^"]+)("\s*$)`, regexp.QuoteMeta(key))
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return "", false, err
+	}
+	if !re.MatchString(text) {
+		return text, false, nil
+	}
+	updated := re.ReplaceAllStringFunc(text, func(match string) string {
+		sub := re.FindStringSubmatch(match)
+		if len(sub) != 4 {
+			return match
+		}
+		if strings.Contains(sub[2], "{{") {
+			return match
+		}
+		return sub[1] + value + sub[3]
+	})
+	return updated, true, nil
+}
+
+func HasTOMLAssignment(text string, key string) (bool, error) {
+	pattern := fmt.Sprintf(`(?m)^\s*%s\s*=\s*"[^"]+"\s*$`, regexp.QuoteMeta(key))
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return false, err
+	}
+	return re.MatchString(text), nil
+}
+
 func UpdateBootstrapScriptText(text string, providerData map[string]ProviderAsset) (string, error) {
 	updated := text
 	for key, values := range providerData {
@@ -149,16 +210,52 @@ func UpdateBootstrapScriptText(text string, providerData map[string]ProviderAsse
 
 func UpdateMiseText(text string, envVersions map[string]string, pythonVersions map[string]string, npmVersions map[string]string, goVersions map[string]string) (string, error) {
 	updated := text
+
+	// Plain version tools: mise key → conda package, e.g. python = "3.13.1"
 	for miseKey, condaSource := range MiseToolSource {
+		hasKey, err := HasTOMLAssignment(updated, miseKey)
+		if err != nil {
+			return "", err
+		}
+		if !hasKey {
+			continue
+		}
 		value, err := requireVersion(envVersions, condaSource, "conda")
 		if err != nil {
 			return "", fmt.Errorf("missing conda version for %s (source %s)", miseKey, condaSource)
 		}
-		next, err := UpdateTOMLAssignment(updated, miseKey, value)
+		next, _, err := UpdateTOMLAssignmentIfPresent(updated, miseKey, value)
 		if err != nil {
 			return "", err
 		}
 		updated = next
+	}
+
+	// Prefixed version tools: mise key → conda package with a preserved prefix,
+	// e.g. java = "temurin-21" — only the numeric portion is updated.
+	for miseKey, spec := range MisePrefixedToolSource {
+		version, ok := envVersions[spec.CondaPackage]
+		if !ok || strings.TrimSpace(version) == "" {
+			continue
+		}
+		pattern := fmt.Sprintf(`(?m)(^\s*%s\s*=\s*"%s)([^"]+)("\s*$)`, regexp.QuoteMeta(miseKey), regexp.QuoteMeta(spec.Prefix))
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return "", err
+		}
+		if !re.MatchString(updated) {
+			continue
+		}
+		updated = re.ReplaceAllStringFunc(updated, func(match string) string {
+			sub := re.FindStringSubmatch(match)
+			if len(sub) != 4 {
+				return match
+			}
+			if strings.Contains(sub[2], "{{") {
+				return match
+			}
+			return sub[1] + version + sub[3]
+		})
 	}
 
 	replacements := make([][2]string, 0)

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -162,14 +162,14 @@ func UpdateTOMLAssignment(text string, key string, value string) (string, error)
 	return updated, nil
 }
 
-func UpdateTOMLAssignmentIfPresent(text string, key string, value string) (string, bool, error) {
+func UpdateTOMLAssignmentIfPresent(text string, key string, value string) (string, error) {
 	pattern := fmt.Sprintf(`(?m)(^\s*%s\s*=\s*")([^"]+)("\s*$)`, regexp.QuoteMeta(key))
 	re, err := regexp.Compile(pattern)
 	if err != nil {
-		return "", false, err
+		return "", err
 	}
 	if !re.MatchString(text) {
-		return text, false, nil
+		return text, nil
 	}
 	updated := re.ReplaceAllStringFunc(text, func(match string) string {
 		sub := re.FindStringSubmatch(match)
@@ -181,7 +181,7 @@ func UpdateTOMLAssignmentIfPresent(text string, key string, value string) (strin
 		}
 		return sub[1] + value + sub[3]
 	})
-	return updated, true, nil
+	return updated, nil
 }
 
 func HasTOMLAssignment(text string, key string) (bool, error) {
@@ -220,11 +220,12 @@ func UpdateMiseText(text string, envVersions map[string]string, pythonVersions m
 		if !hasKey {
 			continue
 		}
-		value, err := requireVersion(envVersions, condaSource, "conda")
-		if err != nil {
-			return "", fmt.Errorf("missing conda version for %s (source %s)", miseKey, condaSource)
+		value, ok := envVersions[condaSource]
+		if !ok || strings.TrimSpace(value) == "" {
+			// Version not collected (e.g. runtime-only template with placeholder) — skip.
+			continue
 		}
-		next, _, err := UpdateTOMLAssignmentIfPresent(updated, miseKey, value)
+		next, err := UpdateTOMLAssignmentIfPresent(updated, miseKey, value)
 		if err != nil {
 			return "", err
 		}

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -31,11 +31,28 @@ func TestUpdateEnvTextIgnoresMissingPackage(t *testing.T) {
 	}
 }
 
+func TestUpdateEnvTextKeepsTemplatePlaceholders(t *testing.T) {
+	source := "dependencies:\n  - python={{PYTHON_VERSION}}\n  - nodejs={{NODE_VERSION}}\n  - pre-commit=4.0.0\n"
+	updated, err := UpdateEnvText(source, map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "pre-commit": "4.6.0"})
+	if err != nil {
+		t.Fatalf("UpdateEnvText returned error: %v", err)
+	}
+	if !strings.Contains(updated, "python={{PYTHON_VERSION}}") {
+		t.Fatalf("expected python placeholder to remain, got: %s", updated)
+	}
+	if !strings.Contains(updated, "nodejs={{NODE_VERSION}}") {
+		t.Fatalf("expected node placeholder to remain, got: %s", updated)
+	}
+	if !strings.Contains(updated, "pre-commit=4.6.0") {
+		t.Fatalf("expected updated pre-commit version, got: %s", updated)
+	}
+}
+
 func TestUpdateMiseTextKeepsTemplatePlaceholders(t *testing.T) {
 	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
 	updated, err := UpdateMiseText(
 		source,
-		map[string]string{"shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.9.3"},
+		map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "go": "1.26.4", "shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
 		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
 		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
 		nil,
@@ -48,7 +65,7 @@ func TestUpdateMiseTextKeepsTemplatePlaceholders(t *testing.T) {
 		`shellcheck = "0.11.0"`,
 		`shfmt = "3.13.1"`,
 		`terraform = "1.15.6"`,
-		`taplo = "0.9.3"`,
+		`taplo = "0.10.0"`,
 		"pre-commit==4.6.0",
 		"editorconfig-checker==3.6.1",
 		"yamllint==1.38.0",
@@ -66,7 +83,7 @@ func TestUpdateMiseTextIgnoresMissingGoModulePatterns(t *testing.T) {
 	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
 	updated, err := UpdateMiseText(
 		source,
-		map[string]string{"shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.9.3"},
+		map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "go": "1.26.4", "shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
 		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
 		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
 		map[string]string{"github.com/daixiang0/gci": "v0.1.0", "github.com/golangci/golangci-lint/cmd/golangci-lint": "v1.2.3"},
@@ -76,6 +93,66 @@ func TestUpdateMiseTextIgnoresMissingGoModulePatterns(t *testing.T) {
 	}
 	if !strings.Contains(updated, "pre-commit==4.6.0") {
 		t.Fatalf("expected updated pre-commit version, got: %s", updated)
+	}
+}
+
+func TestUpdateMiseTextUpdatesJavaTemurinPrefix(t *testing.T) {
+	source := "[tools]\njava = \"temurin-21\"\npython = \"3.12\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "go": "1.26.4", "openjdk": "25.0.2", "shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	if !strings.Contains(updated, `java = "temurin-25.0.2"`) {
+		t.Fatalf("expected java temurin prefix update, got: %s", updated)
+	}
+	if !strings.Contains(updated, `python = "3.13.14"`) {
+		t.Fatalf("expected python update, got: %s", updated)
+	}
+}
+
+func TestUpdateMiseTextPreservesJavaTemplatePlaceholder(t *testing.T) {
+	source := "[tools]\njava = \"temurin-{{JAVA_VERSION}}\"\npython = \"{{PYTHON_VERSION}}\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "go": "1.26.4", "openjdk": "25.0.2", "shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	if !strings.Contains(updated, `java = "temurin-{{JAVA_VERSION}}"`) {
+		t.Fatalf("expected java placeholder to be preserved, got: %s", updated)
+	}
+	if !strings.Contains(updated, `python = "{{PYTHON_VERSION}}"`) {
+		t.Fatalf("expected python placeholder to be preserved, got: %s", updated)
+	}
+}
+
+func TestUpdateMiseTextUpdatesRuntimePinsWhenPresent(t *testing.T) {
+	source := "[tools]\npython = \"3.12\"\nnode = \"22\"\ngo = \"1.25\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		map[string]string{"python": "3.13.14", "nodejs": "24.10.0", "go": "1.26.4", "shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	expects := []string{`python = "3.13.14"`, `node = "24.10.0"`, `go = "1.26.4"`}
+	for _, expected := range expects {
+		if !strings.Contains(updated, expected) {
+			t.Fatalf("expected %q in output", expected)
+		}
 	}
 }
 

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -96,6 +96,27 @@ func TestUpdateMiseTextIgnoresMissingGoModulePatterns(t *testing.T) {
 	}
 }
 
+func TestUpdateMiseTextPlaceholderWithMissingCondaVersion(t *testing.T) {
+	// When a key has a {{...}} placeholder and the corresponding conda version
+	// is absent from envVersions, UpdateMiseText must succeed and leave the
+	// placeholder intact instead of erroring.
+	source := "[tools]\npython = \"{{PYTHON_VERSION}}\"\nshellcheck = \"0.10.0\"\nshfmt = \"3.0.0\"\nterraform = \"1.0.0\"\ntaplo = \"0.1.0\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
+	updated, err := UpdateMiseText(
+		source,
+		// python deliberately absent — key is placeholder-only in source
+		map[string]string{"shellcheck": "0.11.0", "go-shfmt": "3.13.1", "terraform": "1.15.6", "taplo": "0.10.0"},
+		map[string]string{"pre-commit": "4.6.0", "editorconfig-checker": "3.6.1", "yamllint": "1.38.0"},
+		map[string]string{"prettier": "3.9.3", "markdownlint-cli": "0.49.0"},
+		nil,
+	)
+	if err != nil {
+		t.Fatalf("UpdateMiseText returned error: %v", err)
+	}
+	if !strings.Contains(updated, `python = "{{PYTHON_VERSION}}"`) {
+		t.Fatalf("expected python placeholder to be preserved, got: %s", updated)
+	}
+}
+
 func TestUpdateMiseTextUpdatesJavaTemurinPrefix(t *testing.T) {
 	source := "[tools]\njava = \"temurin-21\"\npython = \"3.12\"\n\n[tasks.install-tools]\nrun = [\n  \"python -m pip install pre-commit==1.0.0 editorconfig-checker==1.0.0 yamllint==1.0.0\",\n  \"npm install -g prettier@1.0.0 markdownlint-cli@1.0.0\",\n]\n"
 	updated, err := UpdateMiseText(

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -20,7 +20,19 @@ const (
 	hashChunkSize      = 1024 * 1024
 )
 
-var condaPackages = []string{
+// condaRuntimePackages lists language runtime packages fetched from conda-forge.
+// Add new language runtimes here — UpdateEnvText and UpdateMiseText will
+// pick them up automatically for any env/toml file that contains a matching pin.
+var condaRuntimePackages = []string{
+	"python",
+	"go",
+	"nodejs",
+	"openjdk",
+	"rust",
+	"ruby",
+}
+
+var condaToolPackages = []string{
 	"pre-commit",
 	"prettier",
 	"markdownlint-cli",
@@ -32,6 +44,13 @@ var condaPackages = []string{
 	"terraform",
 	"jq",
 	"coreutils",
+}
+
+func allCondaPackages() []string {
+	packages := make([]string, 0, len(condaRuntimePackages)+len(condaToolPackages))
+	packages = append(packages, condaRuntimePackages...)
+	packages = append(packages, condaToolPackages...)
+	return packages
 }
 
 func retryBackoff(attempt int) {
@@ -249,7 +268,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 	}
 
 	conda := make(map[string]string)
-	for _, pkg := range condaPackages {
+	for _, pkg := range allCondaPackages() {
 		v, err := latestCondaVersion(pkg)
 		if err != nil {
 			return Versions{}, err

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -21,8 +21,9 @@ const (
 )
 
 // condaRuntimePackages lists language runtime packages fetched from conda-forge.
-// Add new language runtimes here — UpdateEnvText and UpdateMiseText will
-// pick them up automatically for any env/toml file that contains a matching pin.
+// Add new language runtimes here — UpdateEnvText will pick them up automatically
+// for any env file that contains a matching pin. For mise.toml keys, also add a
+// mapping in MiseToolSource / MisePrefixedToolSource.
 var condaRuntimePackages = []string{
 	"python",
 	"go",


### PR DESCRIPTION
## Summary
- decouple version collection into runtime + tool package sets in tooling updater
- extend runtime coverage to include Node.js along with Python/Go in updater source data
- make UpdateMiseText runtime/tool key updates optional by key presence, making new language templates easier to add
- preserve template placeholders during environment.yml updates (do not overwrite {{...}} runtime placeholders)
- add explicit Node.js runtime pins to repo and key language micromamba templates
- add/adjust tests for runtime updates and placeholder preservation

## Validation
- `cd tools && micromamba run -n github-bootstrap -- go test ./... -count=1`
- `ENV_MANAGER=micromamba make lint LINT_MODE=check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Node.js runtime support to multiple Micromamba environment templates, including language-specific setups.

* **Bug Fixes**
  * Improved environment updates so existing version pins are updated more reliably without breaking template placeholders.
  * Prevented failures when optional configuration entries are missing during version updates.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->