### PR TITLE
fix(workflows): remove template-only dirs from generated repositories

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -469,6 +469,9 @@ jobs:
           cp -r templates/.cursor new-repo/
           cp -r templates/.claude new-repo/
 
+          # Remove template-only helper trees that should not ship in generated repositories.
+          rm -rf new-repo/languages new-repo/providers new-repo/.github/workflows/providers
+
           # Copy root-level dotfiles
           cp templates/.gitignore new-repo/
           cp templates/.gitattributes new-repo/

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -469,6 +469,10 @@ jobs:
           cp -r templates/.github new-repo/
           cp -r templates/.cursor new-repo/
           cp -r templates/.claude new-repo/
+
+          # Remove template-only helper trees that should not ship in generated repositories.
+          rm -rf new-repo/languages new-repo/providers new-repo/.github/workflows/providers
+
           cp templates/.gitignore new-repo/
           cp templates/.gitattributes new-repo/
           cp templates/.commitlintrc.yml new-repo/

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -234,6 +234,21 @@ jobs:
             fi
           done
 
+          FORBIDDEN_TEMPLATE_PATHS=(
+            "languages"
+            "providers"
+            ".github/workflows/providers"
+          )
+
+          for path in "${FORBIDDEN_TEMPLATE_PATHS[@]}"; do
+            if gh api "/repos/${{ github.repository_owner }}/${REPO_NAME}/contents/${path}" >/dev/null 2>&1; then
+              echo "❌ Unexpected template-only path found: ${path}"
+              exit 1
+            else
+              echo "✅ Absent template-only path: ${path}"
+            fi
+          done
+
           echo "🎉 All required files are present!"
 
       - name: Validate agent kit structure


### PR DESCRIPTION
## Summary

Generated repositories were receiving `languages/`, `providers/`, and `.github/workflows/providers/` from the broad `cp -r templates/*` copy at the start of repository creation. Every new repo ended up with tooling files for all languages instead of only the selected one.

Identified via [aydabd/testing-repo-creation#1](https://github.com/aydabd/testing-repo-creation/pull/1), which was a downstream workaround applied to the generated repo — the root cause belongs here.

## Root Cause

Both creation workflows copy the entire `templates/` tree before the language-tooling selection step runs. The three directories below are bootstrap-internal helpers used only during generation and were never intended to ship in generated repositories:

| Path | Purpose |
|------|---------|
| `languages/` | Per-language tooling templates (source for generation, not output) |
| `providers/` | Provider-specific runtime scripts (source for generation, not output) |
| `.github/workflows/providers/` | Provider-specific lint workflow variants (source for generation, not output) |

## What Changed

- **`create-repository.yml`** — add `rm -rf` of the three template-only trees immediately after the broad copy, before any language-tooling selection.
- **`terraform-create-repository.yml`** — same fix applied to the Terraform-backed creation path.
- **`test-repository-creation.yml`** — add absence assertions for all three paths in the repository structure validation step so this regression is caught automatically on future test runs.

## How to Test

Trigger the [Test Repository Creation](../../actions/workflows/test-repository-creation.yml) workflow with any single language (e.g. `python`) and confirm:

1. `languages/` is absent from the generated repo.
2. `providers/` is absent from the generated repo.
3. `.github/workflows/providers/` is absent from the generated repo.
4. Selected tooling files (`.pre-commit-config.yaml`, `Makefile`, `environment.yml` / `mise.toml`) are still present and correct.

The new validation step in `test-repository-creation.yml` will emit ✅ / ❌ lines for each forbidden path and fail the job if any are found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository creation so template-only helper directories are removed from newly generated projects.
  * Added validation to ensure those template-only paths are not present in test-created repositories, helping catch unwanted files before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->