### PR TITLE
feat(tools): add bootstrap input normalizer package and CLI

### DIFF
--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -22,10 +22,10 @@ low-risk PR, then this refactor can proceed in phases.
 
 ## Progress tracking
 
-- Phase 0: In progress. Shared request validation and the behavior contract are
-  implemented; baseline renderer/workflow validation and generated-file snapshot
-  tests are implemented, and only CI confirmation remains.
-- Phase 1: Not started. Start after the Phase 0 changes land on `main`.
+- Phase 0: Completed. Validation extraction, behavior contract, baseline tests,
+  generated-file snapshots, and CI confirmation are all complete on `main`.
+- Phase 1: In progress. Shared normalization package and command wrapper are
+  implemented with tests; renderer and workflow migrations are next.
 - Phase 2: Not started. Depends on the normalization contract from Phase 1.
 - Phase 3: Not started. Can start after production workflow behavior is stable.
 - Phase 4: Not started. Final documentation pass after the implementation phases.
@@ -143,11 +143,11 @@ align with production behavior:
 ### Phase 0: Baseline and guardrails
 
 - [x] Extract exact duplicated request validation into small composite actions.
-- [ ] Freeze behavior with tests for current accepted inputs.
+- [x] Freeze behavior with tests for current accepted inputs.
   - [x] Add pre-commit renderer baseline tests for language aliases and current
         unknown-token drift.
   - [x] Add workflow-level input validation characterization tests.
-- [ ] Add snapshot tests for generated key files.
+- [x] Add snapshot tests for generated key files.
   - [x] Add snapshot-style assertions for pre-commit config generated from real
         language snippets.
   - [x] Add file snapshots for generated repository key files.
@@ -157,17 +157,17 @@ Exit criteria:
 
 - [x] duplicated allowlist/audit/App-vs-User shell is removed from both creation
       workflows
-- [ ] green CI
+- [x] green CI
 - [x] baseline snapshots committed
 - [x] current accepted and rejected language/runtime inputs are documented in
       `docs/repository-creation-behavior-contract.md`
 
 ### Phase 1: Canonical input normalization
 
-1. [ ] Implement `tools/pkg/bootstrapinputs` with tests covering aliases, `all`,
+1. [x] Implement `tools/pkg/bootstrapinputs` with tests covering aliases, `all`,
        `language-agnostic-only`, invalid tokens, runtime pins, root language policy,
        and release type mapping.
-2. [ ] Implement `tools/cmd/bootstrap-inputs` as a thin CLI over the package.
+2. [x] Implement `tools/cmd/bootstrap-inputs` as a thin CLI over the package.
 3. [ ] Migrate `tools/cmd/precommit-renderer` to use the shared package.
 4. [ ] Migrate `create-repository.yml` to consume normalized outputs.
 5. [ ] Migrate `terraform-create-repository.yml` to consume normalized outputs.

--- a/tools/cmd/bootstrap-inputs/main.go
+++ b/tools/cmd/bootstrap-inputs/main.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+
+	"github-bootstrap/tools/pkg/bootstrapinputs"
+)
+
+type config struct {
+	mode          string
+	languages     string
+	pythonVersion string
+	nodeVersion   string
+	goVersion     string
+	javaVersion   string
+}
+
+type output struct {
+	Mode         string   `json:"mode"`
+	LanguagesRaw string   `json:"languages_raw,omitempty"`
+	Languages    []string `json:"languages,omitempty"`
+	RootLanguage string   `json:"root_language,omitempty"`
+	ReleaseType  string   `json:"release_type,omitempty"`
+	CodeQL       []string `json:"codeql_languages,omitempty"`
+	Valid        bool     `json:"valid"`
+	Message      string   `json:"message,omitempty"`
+}
+
+func main() {
+	cfg, err := parseFlags(os.Args[1:])
+	if err != nil {
+		writeError(err)
+		os.Exit(2)
+	}
+	result, err := run(cfg)
+	if err != nil {
+		writeError(err)
+		os.Exit(1)
+	}
+	if err := json.NewEncoder(os.Stdout).Encode(result); err != nil {
+		writeError(err)
+		os.Exit(1)
+	}
+}
+
+func parseFlags(args []string) (config, error) {
+	fs := flag.NewFlagSet("bootstrap-inputs", flag.ContinueOnError)
+	fs.SetOutput(os.Stderr)
+
+	cfg := config{}
+	fs.StringVar(&cfg.mode, "mode", "normalize", "mode: normalize or validate")
+	fs.StringVar(&cfg.languages, "languages", "", "comma-separated languages")
+	fs.StringVar(&cfg.pythonVersion, "python-version", "", "python runtime version")
+	fs.StringVar(&cfg.nodeVersion, "node-version", "", "node runtime version")
+	fs.StringVar(&cfg.goVersion, "go-version", "", "go runtime version")
+	fs.StringVar(&cfg.javaVersion, "java-version", "", "java runtime version")
+
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	if cfg.mode != "normalize" && cfg.mode != "validate" {
+		return config{}, fmt.Errorf("unsupported mode %q", cfg.mode)
+	}
+	if cfg.languages == "" {
+		return config{}, errors.New("--languages is required")
+	}
+	return cfg, nil
+}
+
+func run(cfg config) (output, error) {
+	langs, err := bootstrapinputs.NormalizeLanguagesStrict(cfg.languages)
+	if err != nil {
+		return output{}, err
+	}
+
+	result := output{
+		Mode:         cfg.mode,
+		LanguagesRaw: cfg.languages,
+		Languages:    langs,
+		RootLanguage: bootstrapinputs.RootLanguageDir(cfg.languages),
+		ReleaseType:  bootstrapinputs.ReleaseTypeForFirstToken(cfg.languages),
+		CodeQL:       bootstrapinputs.CodeQLLanguages(cfg.languages),
+		Valid:        true,
+		Message:      "ok",
+	}
+
+	if cfg.mode == "validate" {
+		if err := bootstrapinputs.ValidateRuntimePins(
+			cfg.pythonVersion,
+			cfg.nodeVersion,
+			cfg.goVersion,
+			cfg.javaVersion,
+		); err != nil {
+			return output{}, err
+		}
+	}
+
+	return result, nil
+}
+
+func writeError(err error) {
+	_ = json.NewEncoder(os.Stderr).Encode(output{
+		Mode:    "error",
+		Valid:   false,
+		Message: err.Error(),
+	})
+}

--- a/tools/cmd/bootstrap-inputs/main.go
+++ b/tools/cmd/bootstrap-inputs/main.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 
 	"github-bootstrap/tools/pkg/bootstrapinputs"
@@ -49,7 +50,8 @@ func main() {
 
 func parseFlags(args []string) (config, error) {
 	fs := flag.NewFlagSet("bootstrap-inputs", flag.ContinueOnError)
-	fs.SetOutput(os.Stderr)
+	fs.SetOutput(io.Discard)
+	fs.Usage = func() {}
 
 	cfg := config{}
 	fs.StringVar(&cfg.mode, "mode", "normalize", "mode: normalize or validate")
@@ -67,6 +69,9 @@ func parseFlags(args []string) (config, error) {
 	}
 	if cfg.languages == "" {
 		return config{}, errors.New("--languages is required")
+	}
+	if cfg.mode == "validate" && (cfg.pythonVersion == "" || cfg.nodeVersion == "" || cfg.goVersion == "" || cfg.javaVersion == "") {
+		return config{}, errors.New("--python-version, --node-version, --go-version, and --java-version are required in validate mode")
 	}
 	return cfg, nil
 }

--- a/tools/cmd/bootstrap-inputs/main_test.go
+++ b/tools/cmd/bootstrap-inputs/main_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestParseFlags(t *testing.T) {
+	cfg, err := parseFlags([]string{"--mode", "normalize", "--languages", "python,go"})
+	if err != nil {
+		t.Fatalf("parseFlags failed: %v", err)
+	}
+	if cfg.mode != "normalize" || cfg.languages != "python,go" {
+		t.Fatalf("unexpected parse result: %+v", cfg)
+	}
+}
+
+func TestParseFlagsInvalidMode(t *testing.T) {
+	_, err := parseFlags([]string{"--mode", "other", "--languages", "python"})
+	if err == nil {
+		t.Fatal("expected mode error, got nil")
+	}
+}
+
+func TestRunNormalize(t *testing.T) {
+	result, err := run(config{mode: "normalize", languages: "go,node,kotlin"})
+	if err != nil {
+		t.Fatalf("run failed: %v", err)
+	}
+	if !result.Valid {
+		t.Fatal("expected valid result")
+	}
+	wantLanguages := []string{"golang", "typescript", "java"}
+	if !reflect.DeepEqual(result.Languages, wantLanguages) {
+		t.Fatalf("languages mismatch: got %v want %v", result.Languages, wantLanguages)
+	}
+	if result.RootLanguage != "golang" {
+		t.Fatalf("unexpected root language: %s", result.RootLanguage)
+	}
+	if result.ReleaseType != "go" {
+		t.Fatalf("unexpected release type: %s", result.ReleaseType)
+	}
+}
+
+func TestRunValidateRuntimePins(t *testing.T) {
+	_, err := run(config{
+		mode:          "validate",
+		languages:     "python",
+		pythonVersion: "3",
+		nodeVersion:   "24",
+		goVersion:     "1.26",
+		javaVersion:   "25",
+	})
+	if err == nil {
+		t.Fatal("expected runtime pin error, got nil")
+	}
+	if !strings.Contains(err.Error(), "python_version") {
+		t.Fatalf("unexpected runtime validation error: %v", err)
+	}
+}

--- a/tools/cmd/bootstrap-inputs/main_test.go
+++ b/tools/cmd/bootstrap-inputs/main_test.go
@@ -23,6 +23,13 @@ func TestParseFlagsInvalidMode(t *testing.T) {
 	}
 }
 
+func TestParseFlagsMissingLanguages(t *testing.T) {
+	_, err := parseFlags([]string{"--mode", "normalize"})
+	if err == nil {
+		t.Fatal("expected missing languages error, got nil")
+	}
+}
+
 func TestRunNormalize(t *testing.T) {
 	result, err := run(config{mode: "normalize", languages: "go,node,kotlin"})
 	if err != nil {
@@ -57,5 +64,25 @@ func TestRunValidateRuntimePins(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "python_version") {
 		t.Fatalf("unexpected runtime validation error: %v", err)
+	}
+}
+
+func TestRunValidateSuccess(t *testing.T) {
+	result, err := run(config{
+		mode:          "validate",
+		languages:     "golang,typescript",
+		pythonVersion: "3.13",
+		nodeVersion:   "24",
+		goVersion:     "1.26",
+		javaVersion:   "25",
+	})
+	if err != nil {
+		t.Fatalf("validate run failed: %v", err)
+	}
+	if !result.Valid {
+		t.Fatal("expected valid result")
+	}
+	if result.ReleaseType != "simple" {
+		t.Fatalf("unexpected release type in validate mode: %s", result.ReleaseType)
 	}
 }

--- a/tools/pkg/bootstrapinputs/bootstrapinputs.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs.go
@@ -34,6 +34,7 @@ var codeQLLanguageMap = map[string]string{
 	"java":       "java-kotlin",
 	"kotlin":     "java-kotlin",
 	"go":         "go",
+	"golang":     "go",
 	"csharp":     "csharp",
 	"cpp":        "cpp",
 	"ruby":       "ruby",
@@ -49,7 +50,13 @@ func NormalizeLanguagesPermissive(input string) ([]string, error) {
 
 func normalizeLanguages(input string, strictUnknown bool) ([]string, error) {
 	trimmed := strings.TrimSpace(input)
-	if trimmed == "" || strings.EqualFold(trimmed, "language-agnostic-only") || strings.EqualFold(trimmed, "agnostic") {
+	if strings.EqualFold(trimmed, "language-agnostic-only") || strings.EqualFold(trimmed, "agnostic") {
+		return []string{"agnostic"}, nil
+	}
+	if trimmed == "" {
+		if strictUnknown {
+			return nil, fmt.Errorf("no valid language tokens in %q", input)
+		}
 		return []string{"agnostic"}, nil
 	}
 

--- a/tools/pkg/bootstrapinputs/bootstrapinputs.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs.go
@@ -1,0 +1,210 @@
+package bootstrapinputs
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	pythonVersionPattern = regexp.MustCompile(`^[0-9]+(\.[0-9]+){1,2}$`)
+	nodeVersionPattern   = regexp.MustCompile(`^[0-9]+$`)
+	goVersionPattern     = regexp.MustCompile(`^[0-9]+(\.[0-9]+){1,2}$`)
+	javaVersionPattern   = regexp.MustCompile(`^[0-9]+$`)
+)
+
+var canonicalLanguages = []string{"golang", "python", "typescript", "java"}
+
+var codeQLAllLanguages = []string{
+	"javascript-typescript",
+	"python",
+	"java-kotlin",
+	"csharp",
+	"go",
+	"ruby",
+	"cpp",
+}
+
+var codeQLLanguageMap = map[string]string{
+	"javascript": "javascript-typescript",
+	"typescript": "javascript-typescript",
+	"python":     "python",
+	"java":       "java-kotlin",
+	"kotlin":     "java-kotlin",
+	"go":         "go",
+	"csharp":     "csharp",
+	"cpp":        "cpp",
+	"ruby":       "ruby",
+}
+
+func NormalizeLanguagesStrict(input string) ([]string, error) {
+	return normalizeLanguages(input, true)
+}
+
+func NormalizeLanguagesPermissive(input string) ([]string, error) {
+	return normalizeLanguages(input, false)
+}
+
+func normalizeLanguages(input string, strictUnknown bool) ([]string, error) {
+	trimmed := strings.TrimSpace(input)
+	if trimmed == "" || strings.EqualFold(trimmed, "language-agnostic-only") || strings.EqualFold(trimmed, "agnostic") {
+		return []string{"agnostic"}, nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	seen := map[string]bool{}
+	result := make([]string, 0, len(parts))
+	hasAgnostic := false
+	hasAll := false
+
+	for _, part := range parts {
+		canonical, err := canonicalToken(part)
+		if err != nil {
+			if strictUnknown {
+				return nil, err
+			}
+			continue
+		}
+		if canonical == "all" {
+			hasAll = true
+			continue
+		}
+		if canonical == "agnostic" {
+			hasAgnostic = true
+		}
+		if !seen[canonical] {
+			seen[canonical] = true
+			result = append(result, canonical)
+		}
+	}
+
+	if hasAll {
+		if hasAgnostic {
+			return nil, fmt.Errorf("language-agnostic-only cannot be combined with other languages")
+		}
+		return append([]string{}, canonicalLanguages...), nil
+	}
+
+	if len(result) == 0 {
+		if strictUnknown {
+			return nil, fmt.Errorf("no valid language tokens in %q", input)
+		}
+		return []string{"agnostic"}, nil
+	}
+
+	if hasAgnostic && len(result) > 1 {
+		return nil, fmt.Errorf("language-agnostic-only cannot be combined with other languages")
+	}
+
+	return result, nil
+}
+
+func canonicalToken(raw string) (string, error) {
+	token := strings.ToLower(strings.TrimSpace(raw))
+	switch token {
+	case "":
+		return "", fmt.Errorf("unknown language token %q", raw)
+	case "language-agnostic-only", "agnostic":
+		return "agnostic", nil
+	case "all":
+		return "all", nil
+	case "go", "golang":
+		return "golang", nil
+	case "python":
+		return "python", nil
+	case "typescript", "javascript", "node", "nodejs":
+		return "typescript", nil
+	case "java", "kotlin":
+		return "java", nil
+	default:
+		return "", fmt.Errorf("unknown language token %q", token)
+	}
+}
+
+func RootLanguageDir(languagesInput string) string {
+	first := strings.ToLower(strings.TrimSpace(strings.Split(languagesInput, ",")[0]))
+	switch first {
+	case "all", "language-agnostic-only", "agnostic":
+		return "agnostic"
+	case "python":
+		return "python"
+	case "go", "golang":
+		return "golang"
+	case "typescript", "javascript", "node", "nodejs":
+		return "typescript"
+	case "java", "kotlin":
+		return "java"
+	default:
+		return "agnostic"
+	}
+}
+
+func ReleaseTypeForFirstToken(languagesInput string) string {
+	first := strings.ToLower(strings.TrimSpace(strings.Split(languagesInput, ",")[0]))
+	switch first {
+	case "javascript", "typescript":
+		return "node"
+	case "python":
+		return "python"
+	case "go":
+		return "go"
+	case "rust":
+		return "rust"
+	case "java", "kotlin":
+		return "java"
+	case "ruby":
+		return "ruby"
+	case "php":
+		return "php"
+	case "terraform":
+		return "terraform-module"
+	default:
+		return "simple"
+	}
+}
+
+func CodeQLLanguages(languagesInput string) []string {
+	trimmed := strings.ToLower(strings.TrimSpace(languagesInput))
+	if trimmed == "all" {
+		return append([]string{}, codeQLAllLanguages...)
+	}
+	if trimmed == "language-agnostic-only" || trimmed == "agnostic" || trimmed == "" {
+		return nil
+	}
+
+	parts := strings.Split(trimmed, ",")
+	seen := map[string]bool{}
+	result := make([]string, 0, len(parts))
+	for _, part := range parts {
+		mapped, ok := codeQLLanguageMap[strings.TrimSpace(part)]
+		if !ok || seen[mapped] {
+			continue
+		}
+		seen[mapped] = true
+		result = append(result, mapped)
+	}
+	return result
+}
+
+func ValidateRuntimePins(pythonVersion, nodeVersion, goVersion, javaVersion string) error {
+	problems := make([]string, 0, 4)
+	if !pythonVersionPattern.MatchString(strings.TrimSpace(pythonVersion)) {
+		problems = append(problems, fmt.Sprintf("invalid python_version %q", pythonVersion))
+	}
+	if !nodeVersionPattern.MatchString(strings.TrimSpace(nodeVersion)) {
+		problems = append(problems, fmt.Sprintf("invalid node_version %q", nodeVersion))
+	}
+	if !goVersionPattern.MatchString(strings.TrimSpace(goVersion)) {
+		problems = append(problems, fmt.Sprintf("invalid go_version %q", goVersion))
+	}
+	if !javaVersionPattern.MatchString(strings.TrimSpace(javaVersion)) {
+		problems = append(problems, fmt.Sprintf("invalid java_version %q", javaVersion))
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+	sort.Strings(problems)
+	return errors.New(strings.Join(problems, "; "))
+}

--- a/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
@@ -1,0 +1,130 @@
+package bootstrapinputs
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestNormalizeLanguagesStrict(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    []string
+		wantErr bool
+	}{
+		{name: "agnostic default", input: "", want: []string{"agnostic"}},
+		{name: "agnostic explicit", input: "language-agnostic-only", want: []string{"agnostic"}},
+		{name: "alias mapping", input: "go,node,nodejs,kotlin", want: []string{"golang", "typescript", "java"}},
+		{name: "all", input: "all", want: []string{"golang", "python", "typescript", "java"}},
+		{name: "all mixed", input: "python,all", want: []string{"golang", "python", "typescript", "java"}},
+		{name: "unknown token fails", input: "python,rust", wantErr: true},
+		{name: "agnostic with others fails", input: "agnostic,go", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := NormalizeLanguagesStrict(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NormalizeLanguagesStrict failed: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("NormalizeLanguagesStrict mismatch: got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeLanguagesPermissive(t *testing.T) {
+	got, err := NormalizeLanguagesPermissive("unknown")
+	if err != nil {
+		t.Fatalf("NormalizeLanguagesPermissive failed: %v", err)
+	}
+	want := []string{"agnostic"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("NormalizeLanguagesPermissive mismatch: got %v want %v", got, want)
+	}
+}
+
+func TestRootLanguageDir(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "all", want: "agnostic"},
+		{input: "language-agnostic-only", want: "agnostic"},
+		{input: "python,go", want: "python"},
+		{input: "go,python", want: "golang"},
+		{input: "node", want: "typescript"},
+		{input: "kotlin", want: "java"},
+		{input: "unknown", want: "agnostic"},
+	}
+	for _, tt := range tests {
+		if got := RootLanguageDir(tt.input); got != tt.want {
+			t.Fatalf("RootLanguageDir(%q) mismatch: got %q want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestReleaseTypeForFirstToken(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{input: "typescript", want: "node"},
+		{input: "python", want: "python"},
+		{input: "go", want: "go"},
+		{input: "kotlin", want: "java"},
+		{input: "terraform", want: "terraform-module"},
+		{input: "all", want: "simple"},
+		{input: "language-agnostic-only", want: "simple"},
+	}
+	for _, tt := range tests {
+		if got := ReleaseTypeForFirstToken(tt.input); got != tt.want {
+			t.Fatalf("ReleaseTypeForFirstToken(%q) mismatch: got %q want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestCodeQLLanguages(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{name: "agnostic none", input: "language-agnostic-only", want: nil},
+		{name: "all", input: "all", want: []string{"javascript-typescript", "python", "java-kotlin", "csharp", "go", "ruby", "cpp"}},
+		{name: "dedupe alias", input: "javascript,typescript,go", want: []string{"javascript-typescript", "go"}},
+		{name: "unsupported removed", input: "python,rust", want: []string{"python"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := CodeQLLanguages(tt.input)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("CodeQLLanguages mismatch: got %v want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateRuntimePins(t *testing.T) {
+	if err := ValidateRuntimePins("3.13", "24", "1.26", "25"); err != nil {
+		t.Fatalf("expected valid runtime pins, got %v", err)
+	}
+
+	err := ValidateRuntimePins("3", "24.1", "1", "25.0")
+	if err == nil {
+		t.Fatal("expected runtime validation error, got nil")
+	}
+	for _, want := range []string{"python_version", "node_version", "go_version", "java_version"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("missing expected key %q in error: %v", want, err)
+		}
+	}
+}

--- a/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
@@ -13,7 +13,8 @@ func TestNormalizeLanguagesStrict(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{name: "agnostic default", input: "", want: []string{"agnostic"}},
+		{name: "empty strict fails", input: "", wantErr: true},
+		{name: "blank strict fails", input: "   ", wantErr: true},
 		{name: "agnostic explicit", input: "language-agnostic-only", want: []string{"agnostic"}},
 		{name: "alias mapping", input: "go,node,nodejs,kotlin", want: []string{"golang", "typescript", "java"}},
 		{name: "all", input: "all", want: []string{"golang", "python", "typescript", "java"}},
@@ -100,6 +101,7 @@ func TestCodeQLLanguages(t *testing.T) {
 	}{
 		{name: "agnostic none", input: "language-agnostic-only", want: nil},
 		{name: "all", input: "all", want: []string{"javascript-typescript", "python", "java-kotlin", "csharp", "go", "ruby", "cpp"}},
+		{name: "golang alias", input: "golang", want: []string{"go"}},
 		{name: "dedupe alias", input: "javascript,typescript,go", want: []string{"javascript-typescript", "go"}},
 		{name: "unsupported removed", input: "python,rust", want: []string{"python"}},
 	}


### PR DESCRIPTION
## Summary

- Add shared normalization package at tools/pkg/bootstrapinputs with strict and permissive language normalization
- Include runtime pin validation, root-language policy, release-type mapping, and CodeQL language mapping helpers
- Add thin command wrapper at tools/cmd/bootstrap-inputs supporting normalize and validate modes with JSON output
- Update the workflow refactor plan to mark Phase 1 items 1 and 2 complete

## Verification

- .provider/bin/micromamba run -n github-bootstrap go test ./tools/pkg/bootstrapinputs ./tools/cmd/bootstrap-inputs
- LINT_MODE=check make lint

## Notes

This is the core Phase 1 foundation. Next slices will migrate precommit-renderer and both creation workflows to consume this package/CLI.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line tool for preparing and checking runtime input settings.
  * Language input values are now normalized more consistently, including common aliases and combined selections.
  * Runtime version settings can now be validated with clearer error reporting.

* **Documentation**
  * Updated the workflow plan to reflect completed and in-progress milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->