### PR TITLE
feat(tools): migrate precommit renderer to bootstrapinputs

### DIFF
--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -3,11 +3,9 @@
 ## Review status
 
 This plan remains the right long-term direction, but it is larger than one safe
-PR. The current repository already has a Go tooling module under `tools/` and a
-`precommit-renderer` command with its own language normalization. That existing
-normalization is not yet a safe source of truth for workflow inputs because it
-silently falls back to `agnostic` for unknown tokens, while the workflows fail
-early for unsupported language values.
+PR. The current repository already has a Go tooling module under `tools/`, and
+the shared `bootstrapinputs` package now provides the canonical normalization
+contract for the renderer and the future workflow migrations.
 
 Recommended rollout:
 

--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -24,8 +24,8 @@ low-risk PR, then this refactor can proceed in phases.
 
 - Phase 0: Completed. Validation extraction, behavior contract, baseline tests,
   generated-file snapshots, and CI confirmation are all complete on `main`.
-- Phase 1: In progress. Shared normalization package and command wrapper are
-  implemented with tests; renderer and workflow migrations are next.
+- Phase 1: In progress. Shared normalization package, command wrapper, and
+  renderer migration are implemented with tests; workflow migrations are next.
 - Phase 2: Not started. Depends on the normalization contract from Phase 1.
 - Phase 3: Not started. Can start after production workflow behavior is stable.
 - Phase 4: Not started. Final documentation pass after the implementation phases.
@@ -168,7 +168,7 @@ Exit criteria:
        `language-agnostic-only`, invalid tokens, runtime pins, root language policy,
        and release type mapping.
 2. [x] Implement `tools/cmd/bootstrap-inputs` as a thin CLI over the package.
-3. [ ] Migrate `tools/cmd/precommit-renderer` to use the shared package.
+3. [x] Migrate `tools/cmd/precommit-renderer` to use the shared package.
 4. [ ] Migrate `create-repository.yml` to consume normalized outputs.
 5. [ ] Migrate `terraform-create-repository.yml` to consume normalized outputs.
 6. [ ] Remove duplicated shell parsing blocks.

--- a/tools/cmd/precommit-renderer/main.go
+++ b/tools/cmd/precommit-renderer/main.go
@@ -52,6 +52,9 @@ func parseFlags() (config, error) {
 	if cfg.basePath == "" || cfg.snippetsRoot == "" || cfg.outputPath == "" {
 		return config{}, errors.New("--base, --snippets-root, and --output are required")
 	}
+	if strings.TrimSpace(cfg.languagesInput) == "" {
+		return config{}, errors.New("--languages is required")
+	}
 	return cfg, nil
 }
 

--- a/tools/cmd/precommit-renderer/main.go
+++ b/tools/cmd/precommit-renderer/main.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github-bootstrap/tools/pkg/bootstrapinputs"
 )
 
 const (
@@ -101,79 +103,7 @@ func run(cfg config) error {
 }
 
 func normalizeLanguages(input string) ([]string, error) {
-	trimmed := strings.TrimSpace(input)
-	if trimmed == "" || trimmed == "language-agnostic-only" {
-		return []string{"agnostic"}, nil
-	}
-
-	if trimmed == "all" {
-		return append([]string{}, supportedLanguages...), nil
-	}
-
-	raw := strings.Split(trimmed, ",")
-	seen := map[string]bool{}
-	langs := make([]string, 0, len(raw))
-	hasAll := false
-	hasAgnostic := false
-
-	for _, item := range raw {
-		normalized := normalizeAlias(item)
-		if normalized == "" {
-			continue
-		}
-		if normalized == "all" {
-			hasAll = true
-			continue
-		}
-		if normalized == "agnostic" {
-			hasAgnostic = true
-		}
-		if !seen[normalized] {
-			langs = append(langs, normalized)
-			seen[normalized] = true
-		}
-	}
-
-	if hasAll {
-		if hasAgnostic {
-			return nil, errors.New("language-agnostic-only cannot be combined with other languages")
-		}
-		return append([]string{}, supportedLanguages...), nil
-	}
-
-	if len(langs) == 0 {
-		return []string{"agnostic"}, nil
-	}
-
-	for _, lang := range langs {
-		if lang == "agnostic" {
-			if len(langs) == 1 {
-				return langs, nil
-			}
-			return nil, errors.New("language-agnostic-only cannot be combined with other languages")
-		}
-	}
-
-	return langs, nil
-}
-
-func normalizeAlias(value string) string {
-	switch strings.TrimSpace(strings.ToLower(value)) {
-	case "language-agnostic-only", "agnostic":
-		return "agnostic"
-	case "go", "golang":
-		return "golang"
-	case "python":
-		return "python"
-	case "typescript", "javascript", "node", "nodejs":
-		return "typescript"
-	case "java", "kotlin":
-		return "java"
-	case "all":
-		return "all"
-	default:
-		return ""
-	}
+	return bootstrapinputs.NormalizeLanguagesStrict(input)
 }
 
 func renderConfig(basePath, snippetsRoot string, languages []string) (string, error) {

--- a/tools/cmd/precommit-renderer/main_test.go
+++ b/tools/cmd/precommit-renderer/main_test.go
@@ -50,6 +50,16 @@ func TestNormalizeLanguages(t *testing.T) {
 	}
 }
 
+func TestParseFlagsMissingLanguages(t *testing.T) {
+	oldArgs := os.Args
+	t.Cleanup(func() { os.Args = oldArgs })
+	os.Args = []string{"precommit-renderer", "--base", "base.tmpl", "--snippets-root", "templates", "--output", "out.yaml"}
+	_, err := parseFlags()
+	if err == nil {
+		t.Fatal("expected missing languages error, got nil")
+	}
+}
+
 func TestRepositoryTemplateSnapshots(t *testing.T) {
 	repoRoot := findRepoRoot(t)
 	basePath := filepath.Join(repoRoot, "templates", "languages", "agnostic", "pre-commit-snippets", "base.tmpl")

--- a/tools/cmd/precommit-renderer/main_test.go
+++ b/tools/cmd/precommit-renderer/main_test.go
@@ -16,7 +16,7 @@ func TestNormalizeLanguages(t *testing.T) {
 		want    []string
 		wantErr bool
 	}{
-		{name: "default agnostic", input: "", want: []string{"agnostic"}},
+		{name: "default agnostic fails", input: "", wantErr: true},
 		{name: "explicit agnostic", input: "agnostic", want: []string{"agnostic"}},
 		{name: "language agnostic only", input: "language-agnostic-only", want: []string{"agnostic"}},
 		{name: "single alias", input: "go", want: []string{"golang"}},
@@ -27,8 +27,7 @@ func TestNormalizeLanguages(t *testing.T) {
 		{name: "all", input: "all", want: expectedAllLanguages},
 		{name: "mixed all token", input: "python,all", want: expectedAllLanguages},
 		{name: "invalid agnostic with all", input: "agnostic,all", wantErr: true},
-		// Current drift: workflows reject unknown tokens, but the renderer falls back to agnostic.
-		{name: "current unknown token drift", input: "unknown", want: []string{"agnostic"}},
+		{name: "unknown token fails", input: "unknown", wantErr: true},
 		{name: "invalid mixed agnostic", input: "language-agnostic-only,go", wantErr: true},
 	}
 


### PR DESCRIPTION
## Summary

- Replace the local language normalization logic in `tools/cmd/precommit-renderer` with the shared `bootstrapinputs` package
- Keep the renderer tests aligned with the stricter shared normalization contract
- Update the Phase 1 plan to mark renderer migration complete

## Verification

- .provider/bin/micromamba run -n github-bootstrap go test ./tools/cmd/precommit-renderer ./tools/pkg/bootstrapinputs
- LINT_MODE=check make lint

## Notes

This is the next Phase 1 slice after the shared normalization package and CLI wrapper landed in PR #51.
