### PR TITLE
feat(workflows): consume bootstrap input normalizer outputs

### DIFF
--- a/.github/scripts/configure-codeql.py
+++ b/.github/scripts/configure-codeql.py
@@ -14,10 +14,13 @@ from pathlib import Path
 LANGUAGE_MAP = {
     "javascript": "javascript-typescript",
     "typescript": "javascript-typescript",
+    "javascript-typescript": "javascript-typescript",
     "python": "python",
     "java": "java-kotlin",
     "kotlin": "java-kotlin",
+    "java-kotlin": "java-kotlin",
     "go": "go",
+    "golang": "go",
     "csharp": "csharp",
     "cpp": "cpp",
     "ruby": "ruby",

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -324,21 +324,33 @@ jobs:
             exit 1
           fi
 
+          ERR_FILE=$(mktemp)
           if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \
             --node-version "$NODE_VERSION" \
             --go-version "$GO_VERSION" \
-            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-validate.err.json); then
-            if [ -s /tmp/bootstrap-inputs-validate.err.json ]; then
-              ERROR_MESSAGE=$(jq -r '.message // "bootstrap input validation failed"' /tmp/bootstrap-inputs-validate.err.json 2>/dev/null || echo "bootstrap input validation failed")
-              echo "::error::$ERROR_MESSAGE"
+            --java-version "$JAVA_VERSION" 2>"$ERR_FILE"); then
+            if [ -s "$ERR_FILE" ]; then
+              LAST_LINE=$(tail -n 1 "$ERR_FILE")
+              ERROR_MESSAGE=$(printf '%s' "$LAST_LINE" | jq -r '.message // empty' 2>/dev/null || true)
+              if [ -n "$ERROR_MESSAGE" ]; then
+                echo "::error::$ERROR_MESSAGE"
+              else
+                echo "::error::bootstrap input validation failed"
+                echo "::error::Raw bootstrap-inputs output follows"
+                while IFS= read -r line; do
+                  echo "::error::$line"
+                done < "$ERR_FILE"
+              fi
             else
               echo "::error::bootstrap input validation failed"
             fi
+            rm -f "$ERR_FILE"
             exit 1
           fi
+          rm -f "$ERR_FILE"
 
           NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
           ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -343,7 +343,7 @@ jobs:
           NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
           ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
           RELEASE_TYPE=$(echo "$NORMALIZED_JSON" | jq -r '.release_type')
-          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.codeql_languages | join(",")')
+          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '(.codeql_languages // []) | join(",")')
 
           echo "languages=$LANGUAGES" >> "$GITHUB_OUTPUT"
           echo "normalized_languages=$NORMALIZED_LANGUAGES" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -325,7 +325,9 @@ jobs:
           fi
 
           ERR_FILE=$(mktemp)
-          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+          REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+          BOOTSTRAP_INPUTS_PATH="$REPO_ROOT/tools/cmd/bootstrap-inputs"
+          if ! NORMALIZED_JSON=$(go run "$BOOTSTRAP_INPUTS_PATH" \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -323,54 +323,33 @@ jobs:
             echo "::error::Invalid languages input '$LANGUAGES'. Use comma-separated language identifiers."
             exit 1
           fi
-          IFS=',' read -ra LANG_PARTS <<< "$LANGUAGES"
-          has_agnostic=false
-          lang_count=0
-          for lang in "${LANG_PARTS[@]}"; do
-            normalized=$(echo "$lang" | xargs | tr '[:upper:]' '[:lower:]')
-            case "$normalized" in
-              language-agnostic-only|agnostic)
-                has_agnostic=true
-                lang_count=$((lang_count + 1))
-                ;;
-              all)
-                lang_count=$((lang_count + 1))
-                ;;
-              go|golang|python|typescript|javascript|node|nodejs|java|kotlin)
-                lang_count=$((lang_count + 1))
-                ;;
-              *)
-                echo "::error::Unknown language token '$normalized' in '$LANGUAGES'."
-                exit 1
-                ;;
-            esac
-          done
-          if [ "$lang_count" -eq 0 ]; then
-            echo "::error::No valid language tokens in '$LANGUAGES'."
-            exit 1
-          fi
-          if [ "$has_agnostic" = true ] && [ "$lang_count" -gt 1 ]; then
-            echo "::error::'language-agnostic-only' cannot be combined with other language tokens."
-            exit 1
-          fi
-          if ! [[ "$PYTHON_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
-            echo "::error::Invalid python_version '$PYTHON_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$NODE_VERSION" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid node_version '$NODE_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$GO_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
-            echo "::error::Invalid go_version '$GO_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid java_version '$JAVA_VERSION'"
+
+          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+            --mode validate \
+            --languages "$LANGUAGES" \
+            --python-version "$PYTHON_VERSION" \
+            --node-version "$NODE_VERSION" \
+            --go-version "$GO_VERSION" \
+            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-validate.err.json); then
+            if [ -s /tmp/bootstrap-inputs-validate.err.json ]; then
+              ERROR_MESSAGE=$(jq -r '.message // "bootstrap input validation failed"' /tmp/bootstrap-inputs-validate.err.json 2>/dev/null || echo "bootstrap input validation failed")
+              echo "::error::$ERROR_MESSAGE"
+            else
+              echo "::error::bootstrap input validation failed"
+            fi
             exit 1
           fi
 
+          NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
+          ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
+          RELEASE_TYPE=$(echo "$NORMALIZED_JSON" | jq -r '.release_type')
+          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.codeql_languages | join(",")')
+
           echo "languages=$LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "normalized_languages=$NORMALIZED_LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "root_language=$ROOT_LANGUAGE" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "codeql_languages=$CODEQL_LANGUAGES" >> "$GITHUB_OUTPUT"
           echo "env_manager=$ENV_MANAGER" >> "$GITHUB_OUTPUT"
           echo "python_version=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
           echo "node_version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
@@ -627,7 +606,9 @@ jobs:
 
       - name: Configure language tooling
         env:
-          LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
+          LANGUAGES: ${{ steps.validate-inputs.outputs.normalized_languages }}
+          RAW_LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
+          ROOT_LANGUAGE: ${{ steps.validate-inputs.outputs.root_language }}
           ENV_MANAGER: ${{ steps.validate-inputs.outputs.env_manager }}
           REPO_NAME: ${{ inputs.repo_name }}
           PYTHON_VERSION: ${{ steps.validate-inputs.outputs.python_version }}
@@ -635,21 +616,10 @@ jobs:
           GO_VERSION: ${{ steps.validate-inputs.outputs.go_version }}
           JAVA_VERSION: ${{ steps.validate-inputs.outputs.java_version }}
         run: |
-          # Map languages input to template directory.
-          # Use the first language when multiple are specified.
-          # Supported: language-agnostic-only, python, golang, typescript, java
-          FIRST_LANG=$(echo "$LANGUAGES" | cut -d',' -f1 | xargs)
-          if echo "$LANGUAGES" | grep -q ','; then
-            echo "⚠️ Multiple languages provided ($LANGUAGES). Tooling template uses first language: $FIRST_LANG" >> $GITHUB_STEP_SUMMARY
+          LANG_DIR="$ROOT_LANGUAGE"
+          if echo "$RAW_LANGUAGES" | grep -q ','; then
+            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
           fi
-          case "$FIRST_LANG" in
-            "all")                    LANG_DIR="agnostic" ;;
-            "python")                 LANG_DIR="python" ;;
-            "go"|"golang")            LANG_DIR="golang" ;;
-            "typescript"|"javascript"|"node"|"nodejs") LANG_DIR="typescript" ;;
-            "java"|"kotlin")          LANG_DIR="java" ;;
-            *)                        LANG_DIR="agnostic" ;;
-          esac
 
           TEMPLATE_DIR="templates/languages/$LANG_DIR"
           PROVIDER_DIR="$TEMPLATE_DIR/providers/$ENV_MANAGER"
@@ -741,6 +711,8 @@ jobs:
           fi
 
       - name: Configure Release Please for selected languages
+        env:
+          RELEASE_TYPE: ${{ steps.validate-inputs.outputs.release_type }}
         run: |
           cd new-repo
           RELEASE_TOOL="${{ inputs.release_tool }}"
@@ -749,40 +721,13 @@ jobs:
             *) exit 0 ;;
           esac
 
-          LANGUAGES="${{ inputs.languages }}"
-
-          # Map language to release-please release-type
-          # See: https://github.com/googleapis/release-please#supported-release-types
-          get_release_type() {
-            local lang=$1
-            case "$lang" in
-              "javascript"|"typescript") echo "node" ;;
-              "python")                  echo "python" ;;
-              "go")                      echo "go" ;;
-              "rust")                    echo "rust" ;;
-              "java"|"kotlin")           echo "java" ;;
-              "ruby")                    echo "ruby" ;;
-              "php")                     echo "php" ;;
-              "terraform")              echo "terraform-module" ;;
-              *)                         echo "simple" ;;
-            esac
-          }
-
-          RELEASE_TYPE="simple"
-
-          if [ "$LANGUAGES" != "all" ] && [ "$LANGUAGES" != "language-agnostic-only" ]; then
-            # Use the first language in the comma-separated list to determine release type
-            FIRST_LANG=$(echo "$LANGUAGES" | cut -d',' -f1 | xargs)
-            RELEASE_TYPE=$(get_release_type "$FIRST_LANG")
-          fi
-
           # Update release-please-config.json with the correct release type
           jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json && mv tmp.json release-please-config.json
           echo "Release Please configured with release-type: $RELEASE_TYPE" >> $GITHUB_STEP_SUMMARY
 
       - name: Configure CodeQL for selected languages
         env:
-          CODEQL_INPUT_LANGUAGES: ${{ inputs.languages }}
+          CODEQL_INPUT_LANGUAGES: ${{ steps.validate-inputs.outputs.codeql_languages }}
         run: |
           cd new-repo
           python3 "$GITHUB_WORKSPACE/.github/scripts/configure-codeql.py"

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -284,6 +284,11 @@ jobs:
           repository: ${{ steps.bootstrap-repo.outputs.repository }}
           ref: ${{ github.workflow_sha }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/go.mod
+
       - name: Set repository owner
         id: set-owner
         run: |

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -349,7 +349,7 @@ jobs:
           NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
           ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
           RELEASE_TYPE=$(echo "$NORMALIZED_JSON" | jq -r '.release_type')
-          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.codeql_languages | join(",")')
+          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '(.codeql_languages // []) | join(",")')
 
           echo "languages=$LANGUAGES" >> "$GITHUB_OUTPUT"
           echo "normalized_languages=$NORMALIZED_LANGUAGES" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -285,6 +285,11 @@ jobs:
           repository: ${{ steps.bootstrap-repo.outputs.repository }}
           ref: ${{ github.workflow_sha }}
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/go.mod
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v4
         with:

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -331,7 +331,9 @@ jobs:
           fi
 
           ERR_FILE=$(mktemp)
-          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+          REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+          BOOTSTRAP_INPUTS_PATH="$REPO_ROOT/tools/cmd/bootstrap-inputs"
+          if ! NORMALIZED_JSON=$(go run "$BOOTSTRAP_INPUTS_PATH" \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -329,54 +329,33 @@ jobs:
             echo "::error::Invalid languages input '$LANGUAGES'. Use comma-separated language identifiers."
             exit 1
           fi
-          IFS=',' read -ra LANG_PARTS <<< "$LANGUAGES"
-          has_agnostic=false
-          lang_count=0
-          for lang in "${LANG_PARTS[@]}"; do
-            normalized=$(echo "$lang" | xargs | tr '[:upper:]' '[:lower:]')
-            case "$normalized" in
-              language-agnostic-only|agnostic)
-                has_agnostic=true
-                lang_count=$((lang_count + 1))
-                ;;
-              all)
-                lang_count=$((lang_count + 1))
-                ;;
-              go|golang|python|typescript|javascript|node|nodejs|java|kotlin)
-                lang_count=$((lang_count + 1))
-                ;;
-              *)
-                echo "::error::Unknown language token '$normalized' in '$LANGUAGES'."
-                exit 1
-                ;;
-            esac
-          done
-          if [ "$lang_count" -eq 0 ]; then
-            echo "::error::No valid language tokens in '$LANGUAGES'."
-            exit 1
-          fi
-          if [ "$has_agnostic" = true ] && [ "$lang_count" -gt 1 ]; then
-            echo "::error::'language-agnostic-only' cannot be combined with other language tokens."
-            exit 1
-          fi
-          if ! [[ "$PYTHON_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
-            echo "::error::Invalid python_version '$PYTHON_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$NODE_VERSION" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid node_version '$NODE_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$GO_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
-            echo "::error::Invalid go_version '$GO_VERSION'"
-            exit 1
-          fi
-          if ! [[ "$JAVA_VERSION" =~ ^[0-9]+$ ]]; then
-            echo "::error::Invalid java_version '$JAVA_VERSION'"
+
+          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+            --mode validate \
+            --languages "$LANGUAGES" \
+            --python-version "$PYTHON_VERSION" \
+            --node-version "$NODE_VERSION" \
+            --go-version "$GO_VERSION" \
+            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-validate.err.json); then
+            if [ -s /tmp/bootstrap-inputs-validate.err.json ]; then
+              ERROR_MESSAGE=$(jq -r '.message // "bootstrap input validation failed"' /tmp/bootstrap-inputs-validate.err.json 2>/dev/null || echo "bootstrap input validation failed")
+              echo "::error::$ERROR_MESSAGE"
+            else
+              echo "::error::bootstrap input validation failed"
+            fi
             exit 1
           fi
 
+          NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
+          ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
+          RELEASE_TYPE=$(echo "$NORMALIZED_JSON" | jq -r '.release_type')
+          CODEQL_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.codeql_languages | join(",")')
+
           echo "languages=$LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "normalized_languages=$NORMALIZED_LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "root_language=$ROOT_LANGUAGE" >> "$GITHUB_OUTPUT"
+          echo "release_type=$RELEASE_TYPE" >> "$GITHUB_OUTPUT"
+          echo "codeql_languages=$CODEQL_LANGUAGES" >> "$GITHUB_OUTPUT"
           echo "env_manager=$ENV_MANAGER" >> "$GITHUB_OUTPUT"
           echo "python_version=$PYTHON_VERSION" >> "$GITHUB_OUTPUT"
           echo "node_version=$NODE_VERSION" >> "$GITHUB_OUTPUT"
@@ -554,7 +533,9 @@ jobs:
 
       - name: Configure language tooling
         env:
-          LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
+          LANGUAGES: ${{ steps.validate-inputs.outputs.normalized_languages }}
+          RAW_LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
+          ROOT_LANGUAGE: ${{ steps.validate-inputs.outputs.root_language }}
           ENV_MANAGER: ${{ steps.validate-inputs.outputs.env_manager }}
           REPO_NAME: ${{ inputs.repo_name }}
           PYTHON_VERSION: ${{ steps.validate-inputs.outputs.python_version }}
@@ -562,21 +543,10 @@ jobs:
           GO_VERSION: ${{ steps.validate-inputs.outputs.go_version }}
           JAVA_VERSION: ${{ steps.validate-inputs.outputs.java_version }}
         run: |
-          # Map languages input to template directory.
-          # Use the first language when multiple are specified.
-          # Supported: language-agnostic-only, python, golang, typescript, java
-          FIRST_LANG=$(echo "$LANGUAGES" | cut -d',' -f1 | xargs)
-          if echo "$LANGUAGES" | grep -q ','; then
-            echo "⚠️ Multiple languages provided ($LANGUAGES). Tooling template uses first language: $FIRST_LANG" >> $GITHUB_STEP_SUMMARY
+          LANG_DIR="$ROOT_LANGUAGE"
+          if echo "$RAW_LANGUAGES" | grep -q ','; then
+            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
           fi
-          case "$FIRST_LANG" in
-            "all")                    LANG_DIR="agnostic" ;;
-            "python")                 LANG_DIR="python" ;;
-            "go"|"golang")            LANG_DIR="golang" ;;
-            "typescript"|"javascript"|"node"|"nodejs") LANG_DIR="typescript" ;;
-            "java"|"kotlin")          LANG_DIR="java" ;;
-            *)                        LANG_DIR="agnostic" ;;
-          esac
 
           TEMPLATE_DIR="templates/languages/$LANG_DIR"
           PROVIDER_DIR="$TEMPLATE_DIR/providers/$ENV_MANAGER"
@@ -721,38 +691,14 @@ jobs:
           esac
 
       - name: Configure Release Please for selected languages
+        env:
+          RELEASE_TYPE: ${{ steps.validate-inputs.outputs.release_type }}
         run: |
           case "${{ inputs.release_tool }}" in
             "release-please") ;;
             *) echo "⏭️ Release Please configuration skipped (release_tool=${{ inputs.release_tool }})"; exit 0 ;;
           esac
           cd new-repo
-          LANGUAGES="${{ inputs.languages }}"
-
-          # Map language to release-please release-type
-          # See: https://github.com/googleapis/release-please#supported-release-types
-          get_release_type() {
-            local lang=$1
-            case "$lang" in
-              "javascript"|"typescript") echo "node" ;;
-              "python")                  echo "python" ;;
-              "go")                      echo "go" ;;
-              "rust")                    echo "rust" ;;
-              "java"|"kotlin")           echo "java" ;;
-              "ruby")                    echo "ruby" ;;
-              "php")                     echo "php" ;;
-              "terraform")              echo "terraform-module" ;;
-              *)                         echo "simple" ;;
-            esac
-          }
-
-          RELEASE_TYPE="simple"
-
-          if [ "$LANGUAGES" != "all" ] && [ "$LANGUAGES" != "language-agnostic-only" ]; then
-            # Use the first language in the comma-separated list to determine release type
-            FIRST_LANG=$(echo "$LANGUAGES" | cut -d',' -f1 | xargs)
-            RELEASE_TYPE=$(get_release_type "$FIRST_LANG")
-          fi
 
           # Update release-please-config.json with the correct release type
           jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json && mv tmp.json release-please-config.json
@@ -760,7 +706,7 @@ jobs:
 
       - name: Configure CodeQL for selected languages
         env:
-          CODEQL_INPUT_LANGUAGES: ${{ inputs.languages }}
+          CODEQL_INPUT_LANGUAGES: ${{ steps.validate-inputs.outputs.codeql_languages }}
         run: |
           cd new-repo
           python3 "$GITHUB_WORKSPACE/.github/scripts/configure-codeql.py"

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -330,21 +330,33 @@ jobs:
             exit 1
           fi
 
+          ERR_FILE=$(mktemp)
           if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \
             --node-version "$NODE_VERSION" \
             --go-version "$GO_VERSION" \
-            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-validate.err.json); then
-            if [ -s /tmp/bootstrap-inputs-validate.err.json ]; then
-              ERROR_MESSAGE=$(jq -r '.message // "bootstrap input validation failed"' /tmp/bootstrap-inputs-validate.err.json 2>/dev/null || echo "bootstrap input validation failed")
-              echo "::error::$ERROR_MESSAGE"
+            --java-version "$JAVA_VERSION" 2>"$ERR_FILE"); then
+            if [ -s "$ERR_FILE" ]; then
+              LAST_LINE=$(tail -n 1 "$ERR_FILE")
+              ERROR_MESSAGE=$(printf '%s' "$LAST_LINE" | jq -r '.message // empty' 2>/dev/null || true)
+              if [ -n "$ERROR_MESSAGE" ]; then
+                echo "::error::$ERROR_MESSAGE"
+              else
+                echo "::error::bootstrap input validation failed"
+                echo "::error::Raw bootstrap-inputs output follows"
+                while IFS= read -r line; do
+                  echo "::error::$line"
+                done < "$ERR_FILE"
+              fi
             else
               echo "::error::bootstrap input validation failed"
             fi
+            rm -f "$ERR_FILE"
             exit 1
           fi
+          rm -f "$ERR_FILE"
 
           NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
           ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
@@ -693,10 +705,11 @@ jobs:
       - name: Configure Release Please for selected languages
         env:
           RELEASE_TYPE: ${{ steps.validate-inputs.outputs.release_type }}
+          RELEASE_TOOL: ${{ inputs.release_tool }}
         run: |
-          case "${{ inputs.release_tool }}" in
+          case "$RELEASE_TOOL" in
             "release-please") ;;
-            *) echo "⏭️ Release Please configuration skipped (release_tool=${{ inputs.release_tool }})"; exit 0 ;;
+            *) echo "⏭️ Release Please configuration skipped (release_tool=$RELEASE_TOOL)"; exit 0 ;;
           esac
           cd new-repo
 

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -167,7 +167,9 @@ jobs:
           fi
 
           ERR_FILE=$(mktemp)
-          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+          REPO_ROOT="${GITHUB_WORKSPACE:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+          BOOTSTRAP_INPUTS_PATH="$REPO_ROOT/tools/cmd/bootstrap-inputs"
+          if ! NORMALIZED_JSON=$(go run "$BOOTSTRAP_INPUTS_PATH" \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: tools/go.mod
+
       - name: Generate unique test repository name
         id: generate-name
         run: |
@@ -161,21 +166,33 @@ jobs:
             exit 1
           fi
 
+          ERR_FILE=$(mktemp)
           if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
             --mode validate \
             --languages "$LANGUAGES" \
             --python-version "$PYTHON_VERSION" \
             --node-version "$NODE_VERSION" \
             --go-version "$GO_VERSION" \
-            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-test-validate.err.json); then
-            if [ -s /tmp/bootstrap-inputs-test-validate.err.json ]; then
-              ERROR_MESSAGE=$(jq -r '.message // "test input validation failed"' /tmp/bootstrap-inputs-test-validate.err.json 2>/dev/null || echo "test input validation failed")
-              echo "::error::$ERROR_MESSAGE"
+            --java-version "$JAVA_VERSION" 2>"$ERR_FILE"); then
+            if [ -s "$ERR_FILE" ]; then
+              LAST_LINE=$(tail -n 1 "$ERR_FILE")
+              ERROR_MESSAGE=$(printf '%s' "$LAST_LINE" | jq -r '.message // empty' 2>/dev/null || true)
+              if [ -n "$ERROR_MESSAGE" ]; then
+                echo "::error::$ERROR_MESSAGE"
+              else
+                echo "::error::test input validation failed"
+                echo "::error::Raw bootstrap-inputs output follows"
+                while IFS= read -r line; do
+                  echo "::error::$line"
+                done < "$ERR_FILE"
+              fi
             else
               echo "::error::test input validation failed"
             fi
+            rm -f "$ERR_FILE"
             exit 1
           fi
+          rm -f "$ERR_FILE"
 
           NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
           ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -131,11 +131,19 @@ jobs:
           LANGUAGES_INPUT: ${{ github.event.inputs.languages }}
           TARGET_WORKFLOW_INPUT: ${{ github.event.inputs.target_workflow }}
           TARGET_REF_INPUT: ${{ github.event.inputs.target_ref }}
+          PYTHON_VERSION_INPUT: ${{ github.event.inputs.python_version }}
+          NODE_VERSION_INPUT: ${{ github.event.inputs.node_version }}
+          GO_VERSION_INPUT: ${{ github.event.inputs.go_version }}
+          JAVA_VERSION_INPUT: ${{ github.event.inputs.java_version }}
         run: |
           ENV_MANAGER="$ENV_MANAGER_INPUT"
           LANGUAGES="$LANGUAGES_INPUT"
           TARGET_WORKFLOW="$TARGET_WORKFLOW_INPUT"
           TARGET_REF="$TARGET_REF_INPUT"
+          PYTHON_VERSION="$PYTHON_VERSION_INPUT"
+          NODE_VERSION="$NODE_VERSION_INPUT"
+          GO_VERSION="$GO_VERSION_INPUT"
+          JAVA_VERSION="$JAVA_VERSION_INPUT"
           if ! [[ "$ENV_MANAGER" =~ ^(micromamba|mise|system)$ ]]; then
             echo "::error::Invalid env_manager '$ENV_MANAGER'. Allowed: micromamba, mise, system"
             exit 1
@@ -152,8 +160,29 @@ jobs:
             echo "::error::Invalid target_ref '$TARGET_REF'."
             exit 1
           fi
+
+          if ! NORMALIZED_JSON=$(go run ./tools/cmd/bootstrap-inputs \
+            --mode validate \
+            --languages "$LANGUAGES" \
+            --python-version "$PYTHON_VERSION" \
+            --node-version "$NODE_VERSION" \
+            --go-version "$GO_VERSION" \
+            --java-version "$JAVA_VERSION" 2>/tmp/bootstrap-inputs-test-validate.err.json); then
+            if [ -s /tmp/bootstrap-inputs-test-validate.err.json ]; then
+              ERROR_MESSAGE=$(jq -r '.message // "test input validation failed"' /tmp/bootstrap-inputs-test-validate.err.json 2>/dev/null || echo "test input validation failed")
+              echo "::error::$ERROR_MESSAGE"
+            else
+              echo "::error::test input validation failed"
+            fi
+            exit 1
+          fi
+
+          NORMALIZED_LANGUAGES=$(echo "$NORMALIZED_JSON" | jq -r '.languages | join(",")')
+          ROOT_LANGUAGE=$(echo "$NORMALIZED_JSON" | jq -r '.root_language')
           echo "env_manager=$ENV_MANAGER" >> "$GITHUB_OUTPUT"
           echo "languages=$LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "normalized_languages=$NORMALIZED_LANGUAGES" >> "$GITHUB_OUTPUT"
+          echo "root_language=$ROOT_LANGUAGE" >> "$GITHUB_OUTPUT"
           echo "target_workflow=$TARGET_WORKFLOW" >> "$GITHUB_OUTPUT"
           echo "target_ref=$TARGET_REF" >> "$GITHUB_OUTPUT"
 
@@ -276,7 +305,9 @@ jobs:
         run: |
           REPO_NAME="${{ steps.generate-name.outputs.repo_name }}"
           ENV_MANAGER="${{ steps.validate-inputs.outputs.env_manager }}"
-          LANGUAGES="${{ steps.validate-inputs.outputs.languages }}"
+          RAW_LANGUAGES="${{ steps.validate-inputs.outputs.languages }}"
+          LANGUAGES="${{ steps.validate-inputs.outputs.normalized_languages }}"
+          LANG_DIR="${{ steps.validate-inputs.outputs.root_language }}"
 
           echo "🔍 Validating repository structure..."
 
@@ -310,14 +341,9 @@ jobs:
             fi
           done
 
-          FIRST_LANG=$(echo "$LANGUAGES" | cut -d',' -f1 | xargs)
-          case "$FIRST_LANG" in
-            "python")                 LANG_DIR="python" ;;
-            "go"|"golang")            LANG_DIR="golang" ;;
-            "typescript"|"javascript") LANG_DIR="typescript" ;;
-            "java"|"kotlin")          LANG_DIR="java" ;;
-            *)                         LANG_DIR="agnostic" ;;
-          esac
+          if echo "$RAW_LANGUAGES" | grep -q ','; then
+            echo "ℹ️ Multiple languages requested ($RAW_LANGUAGES). Root template uses first-language policy: $LANG_DIR"
+          fi
 
           PROVIDER_DIR="templates/languages/$LANG_DIR/providers/$ENV_MANAGER"
           if [ ! -d "$PROVIDER_DIR" ]; then
@@ -343,28 +369,14 @@ jobs:
             fi
           done
 
-          normalize_lang() {
-            case "$(echo "$1" | xargs | tr '[:upper:]' '[:lower:]')" in
-              go|golang) echo "golang" ;;
-              python) echo "python" ;;
-              typescript|javascript|node|nodejs) echo "typescript" ;;
-              java|kotlin) echo "java" ;;
-              all) echo "all" ;;
-              *) echo "agnostic" ;;
-            esac
-          }
-
           SELECTED_LANGS=()
           IFS=',' read -ra LANG_INPUTS <<< "$LANGUAGES"
-          for raw_lang in "${LANG_INPUTS[@]}"; do
-            normalized=$(normalize_lang "$raw_lang")
-            if [ "$normalized" = "all" ]; then
-              for every in golang python typescript java; do
-                SELECTED_LANGS+=("$every")
-              done
-            elif [ "$normalized" != "agnostic" ]; then
-              SELECTED_LANGS+=("$normalized")
+          for normalized in "${LANG_INPUTS[@]}"; do
+            normalized=$(echo "$normalized" | xargs | tr '[:upper:]' '[:lower:]')
+            if [ "$normalized" = "" ] || [ "$normalized" = "agnostic" ]; then
+              continue
             fi
+            SELECTED_LANGS+=("$normalized")
           done
 
           # De-duplicate while preserving order.

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -588,7 +588,6 @@ jobs:
     runs-on: ubuntu-latest
     if: >-
       ${{ always() &&
-      needs.create-test-repo.outputs.repo_created == 'true' &&
       (github.event.inputs.cleanup_after_test == 'true' ||
       needs.create-test-repo.result == 'failure') }}
     permissions:

--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -22,8 +22,8 @@ low-risk PR, then this refactor can proceed in phases.
 
 - Phase 0: Completed. Validation extraction, behavior contract, baseline tests,
   generated-file snapshots, and CI confirmation are all complete on `main`.
-- Phase 1: In progress. Shared normalization package, command wrapper, and
-  renderer migration are implemented with tests; workflow migrations are next.
+- Phase 1: Completed. Shared normalization package, command wrapper, renderer,
+  and both workflow migrations now consume the same normalization contract.
 - Phase 2: Not started. Depends on the normalization contract from Phase 1.
 - Phase 3: Not started. Can start after production workflow behavior is stable.
 - Phase 4: Not started. Final documentation pass after the implementation phases.
@@ -167,15 +167,15 @@ Exit criteria:
        and release type mapping.
 2. [x] Implement `tools/cmd/bootstrap-inputs` as a thin CLI over the package.
 3. [x] Migrate `tools/cmd/precommit-renderer` to use the shared package.
-4. [ ] Migrate `create-repository.yml` to consume normalized outputs.
-5. [ ] Migrate `terraform-create-repository.yml` to consume normalized outputs.
-6. [ ] Remove duplicated shell parsing blocks.
+4. [x] Migrate `create-repository.yml` to consume normalized outputs.
+5. [x] Migrate `terraform-create-repository.yml` to consume normalized outputs.
+6. [x] Remove duplicated shell parsing blocks.
 
 Exit criteria:
 
-- [ ] no language parsing logic duplicated in workflow shell blocks
-- [ ] all input validation sourced from one shared Go package
-- [ ] unsupported language tokens fail consistently across workflows and tools
+- [x] no language parsing logic duplicated in workflow shell blocks
+- [x] all input validation sourced from one shared Go package
+- [x] unsupported language tokens fail consistently across workflows and tools
 
 ### Phase 2: Extract composite actions
 

--- a/tools/cmd/bootstrap-inputs/main_test.go
+++ b/tools/cmd/bootstrap-inputs/main_test.go
@@ -82,7 +82,7 @@ func TestRunValidateSuccess(t *testing.T) {
 	if !result.Valid {
 		t.Fatal("expected valid result")
 	}
-	if result.ReleaseType != "simple" {
+	if result.ReleaseType != "go" {
 		t.Fatalf("unexpected release type in validate mode: %s", result.ReleaseType)
 	}
 }

--- a/tools/internal/workflowcontract/input_validation_test.go
+++ b/tools/internal/workflowcontract/input_validation_test.go
@@ -52,7 +52,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"LANGUAGES": "python,rust",
 			}),
 			wantErr:    true,
-			wantStderr: "unknown language token \"rust\"",
+			wantStderr: "\"message\":\"unknown language token",
 		},
 		{
 			name: "language agnostic cannot combine",
@@ -76,7 +76,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"PYTHON_VERSION": "3",
 			}),
 			wantErr:    true,
-			wantStderr: "invalid python_version \"3\"",
+			wantStderr: "\"message\":\"invalid python_version",
 		},
 		{
 			name: "invalid node version",
@@ -84,7 +84,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"NODE_VERSION": "24.1",
 			}),
 			wantErr:    true,
-			wantStderr: "invalid node_version \"24.1\"",
+			wantStderr: "\"message\":\"invalid node_version",
 		},
 		{
 			name: "invalid go version",
@@ -92,7 +92,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"GO_VERSION": "1",
 			}),
 			wantErr:    true,
-			wantStderr: "invalid go_version \"1\"",
+			wantStderr: "\"message\":\"invalid go_version",
 		},
 		{
 			name: "invalid java version",
@@ -100,7 +100,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"JAVA_VERSION": "25.0",
 			}),
 			wantErr:    true,
-			wantStderr: "invalid java_version \"25.0\"",
+			wantStderr: "\"message\":\"invalid java_version",
 		},
 	}
 

--- a/tools/internal/workflowcontract/input_validation_test.go
+++ b/tools/internal/workflowcontract/input_validation_test.go
@@ -52,7 +52,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"LANGUAGES": "python,rust",
 			}),
 			wantErr:    true,
-			wantStderr: "Unknown language token 'rust'",
+			wantStderr: "unknown language token \"rust\"",
 		},
 		{
 			name: "language agnostic cannot combine",
@@ -60,7 +60,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"LANGUAGES": "language-agnostic-only,go",
 			}),
 			wantErr:    true,
-			wantStderr: "language-agnostic-only' cannot be combined",
+			wantStderr: "language-agnostic-only cannot be combined",
 		},
 		{
 			name: "languages cannot contain spaces",
@@ -76,7 +76,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"PYTHON_VERSION": "3",
 			}),
 			wantErr:    true,
-			wantStderr: "Invalid python_version '3'",
+			wantStderr: "invalid python_version \"3\"",
 		},
 		{
 			name: "invalid node version",
@@ -84,7 +84,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"NODE_VERSION": "24.1",
 			}),
 			wantErr:    true,
-			wantStderr: "Invalid node_version '24.1'",
+			wantStderr: "invalid node_version \"24.1\"",
 		},
 		{
 			name: "invalid go version",
@@ -92,7 +92,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"GO_VERSION": "1",
 			}),
 			wantErr:    true,
-			wantStderr: "Invalid go_version '1'",
+			wantStderr: "invalid go_version \"1\"",
 		},
 		{
 			name: "invalid java version",
@@ -100,7 +100,7 @@ func TestValidateBootstrapInputsContract(t *testing.T) {
 				"JAVA_VERSION": "25.0",
 			}),
 			wantErr:    true,
-			wantStderr: "Invalid java_version '25.0'",
+			wantStderr: "invalid java_version \"25.0\"",
 		},
 	}
 

--- a/tools/pkg/bootstrapinputs/bootstrapinputs.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs.go
@@ -30,6 +30,8 @@ var codeQLAllLanguages = []string{
 var codeQLLanguageMap = map[string]string{
 	"javascript": "javascript-typescript",
 	"typescript": "javascript-typescript",
+	"node":       "javascript-typescript",
+	"nodejs":     "javascript-typescript",
 	"python":     "python",
 	"java":       "java-kotlin",
 	"kotlin":     "java-kotlin",
@@ -151,11 +153,11 @@ func RootLanguageDir(languagesInput string) string {
 func ReleaseTypeForFirstToken(languagesInput string) string {
 	first := strings.ToLower(strings.TrimSpace(strings.Split(languagesInput, ",")[0]))
 	switch first {
-	case "javascript", "typescript":
+	case "javascript", "typescript", "node", "nodejs":
 		return "node"
 	case "python":
 		return "python"
-	case "go":
+	case "go", "golang":
 		return "go"
 	case "rust":
 		return "rust"

--- a/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
+++ b/tools/pkg/bootstrapinputs/bootstrapinputs_test.go
@@ -79,8 +79,11 @@ func TestReleaseTypeForFirstToken(t *testing.T) {
 		want  string
 	}{
 		{input: "typescript", want: "node"},
+		{input: "node", want: "node"},
+		{input: "nodejs", want: "node"},
 		{input: "python", want: "python"},
 		{input: "go", want: "go"},
+		{input: "golang", want: "go"},
 		{input: "kotlin", want: "java"},
 		{input: "terraform", want: "terraform-module"},
 		{input: "all", want: "simple"},
@@ -102,6 +105,7 @@ func TestCodeQLLanguages(t *testing.T) {
 		{name: "agnostic none", input: "language-agnostic-only", want: nil},
 		{name: "all", input: "all", want: []string{"javascript-typescript", "python", "java-kotlin", "csharp", "go", "ruby", "cpp"}},
 		{name: "golang alias", input: "golang", want: []string{"go"}},
+		{name: "node alias", input: "node,nodejs,typescript", want: []string{"javascript-typescript"}},
 		{name: "dedupe alias", input: "javascript,typescript,go", want: []string{"javascript-typescript", "go"}},
 		{name: "unsupported removed", input: "python,rust", want: []string{"python"}},
 	}


### PR DESCRIPTION
## Summary

- Migrate both repository creation workflows to consume outputs from `tools/cmd/bootstrap-inputs --mode validate`
- Remove duplicated shell parsing/mapping for language normalization, runtime pin validation, and release-type mapping
- Wire normalized outputs into language tooling, release-please config, and CodeQL config steps
- Update CodeQL helper mapping to accept normalized CodeQL identifiers directly
- Mark Phase 1 workflow migration and exit criteria complete in the refactor plan

## Verification

- LINT_MODE=check make lint

## Notes

This closes the remaining Phase 1 migration items by making workflow orchestration use the shared normalization contract.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository setup checks so language and version inputs are handled more consistently across workflows.
  * Made language detection and template selection more reliable for multi-language projects.
  * Updated release and CodeQL setup to use validated language values, reducing configuration mismatches.

* **Documentation**
  * Marked the first phase of the workflow refactor plan as complete and refreshed its progress notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->