### PR TITLE
feat(workflows): extract composite actions (Phase 2)

### DIFF
--- a/.github/actions/configure-provider-tooling-files/action.yml
+++ b/.github/actions/configure-provider-tooling-files/action.yml
@@ -74,7 +74,12 @@ runs:
         rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/mise.toml"
         [ -f "$PROVIDER_DIR/environment.yml" ] && cp "$PROVIDER_DIR/environment.yml" "$REPO_DIR/environment.yml"
         [ -f "$PROVIDER_DIR/mise.toml" ] && cp "$PROVIDER_DIR/mise.toml" "$REPO_DIR/mise.toml"
-        cp "$LINT_WORKFLOW_TEMPLATE" "$REPO_DIR/.github/workflows/lint.yml"
+        # Only overwrite lint.yml when it already exists in the repo — it may
+        # have been intentionally removed by the "Remove unselected workflows"
+        # step when the workflows input excluded lint.
+        if [ -f "$REPO_DIR/.github/workflows/lint.yml" ]; then
+          cp "$LINT_WORKFLOW_TEMPLATE" "$REPO_DIR/.github/workflows/lint.yml"
+        fi
         cp "$GITHUB_WORKSPACE/templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
         mkdir -p "$REPO_DIR/scripts"
         cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"

--- a/.github/actions/configure-provider-tooling-files/action.yml
+++ b/.github/actions/configure-provider-tooling-files/action.yml
@@ -1,0 +1,109 @@
+---
+name: Configure Provider Tooling Files
+description: >-
+  Copy language/provider-specific tooling files (Makefile, environment.yml,
+  mise.toml, scripts, lint workflow) into the generated repository and
+  substitute repository placeholders.
+
+inputs:
+  root_language:
+    description: Normalized root language directory name.
+    required: true
+  env_manager:
+    description: Environment manager (micromamba, mise, system).
+    required: true
+  repo_name:
+    description: Target repository name used for placeholder substitution.
+    required: true
+  python_version:
+    description: Python version for placeholder substitution.
+    required: true
+  node_version:
+    description: Node version for placeholder substitution.
+    required: true
+  go_version:
+    description: Go version for placeholder substitution.
+    required: true
+  java_version:
+    description: Java version for placeholder substitution.
+    required: true
+  output_dir:
+    description: Working directory of the generated repository to write files into.
+    required: false
+    default: new-repo
+
+runs:
+  using: composite
+  steps:
+    - name: Copy provider tooling files
+      shell: bash
+      env:
+        LANG_DIR: ${{ inputs.root_language }}
+        ENV_MANAGER: ${{ inputs.env_manager }}
+        REPO_NAME: ${{ inputs.repo_name }}
+        PYTHON_VERSION: ${{ inputs.python_version }}
+        NODE_VERSION: ${{ inputs.node_version }}
+        GO_VERSION: ${{ inputs.go_version }}
+        JAVA_VERSION: ${{ inputs.java_version }}
+        REPO_DIR: ${{ inputs.output_dir }}
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+      run: |
+        TEMPLATE_DIR="$GITHUB_WORKSPACE/templates/languages/$LANG_DIR"
+        PROVIDER_DIR="$TEMPLATE_DIR/providers/$ENV_MANAGER"
+        LINT_WORKFLOW_TEMPLATE="$GITHUB_WORKSPACE/templates/.github/workflows/providers/lint-$ENV_MANAGER.yml"
+        PROVIDER_SCRIPT_TEMPLATE="$GITHUB_WORKSPACE/templates/providers/$ENV_MANAGER/provider-run.sh"
+
+        if [ ! -d "$PROVIDER_DIR" ]; then
+          echo "::error::Missing provider config directory: $PROVIDER_DIR"
+          exit 1
+        fi
+        if [ ! -f "$PROVIDER_DIR/Makefile" ]; then
+          echo "::error::Missing provider Makefile: $PROVIDER_DIR/Makefile"
+          exit 1
+        fi
+        if [ ! -f "$LINT_WORKFLOW_TEMPLATE" ]; then
+          echo "::error::Missing provider lint workflow template: $LINT_WORKFLOW_TEMPLATE"
+          exit 1
+        fi
+        if [ ! -f "$PROVIDER_SCRIPT_TEMPLATE" ]; then
+          echo "::error::Missing provider helper script template: $PROVIDER_SCRIPT_TEMPLATE"
+          exit 1
+        fi
+
+        cp "$PROVIDER_DIR/Makefile" "$REPO_DIR/Makefile"
+        rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/mise.toml"
+        [ -f "$PROVIDER_DIR/environment.yml" ] && cp "$PROVIDER_DIR/environment.yml" "$REPO_DIR/environment.yml"
+        [ -f "$PROVIDER_DIR/mise.toml" ] && cp "$PROVIDER_DIR/mise.toml" "$REPO_DIR/mise.toml"
+        cp "$LINT_WORKFLOW_TEMPLATE" "$REPO_DIR/.github/workflows/lint.yml"
+        cp "$GITHUB_WORKSPACE/templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
+        mkdir -p "$REPO_DIR/scripts"
+        cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
+        cp "$GITHUB_WORKSPACE/templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
+        chmod +x "$REPO_DIR/scripts/provider-run.sh"
+        chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
+
+        if [ -f "$REPO_DIR/environment.yml" ]; then
+          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/environment.yml"
+          sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/environment.yml"
+          sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/environment.yml"
+          sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/environment.yml"
+          sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/environment.yml"
+        fi
+        if [ -f "$REPO_DIR/mise.toml" ]; then
+          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/mise.toml"
+          sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/mise.toml"
+          sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/mise.toml"
+          sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/mise.toml"
+          sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/mise.toml"
+        fi
+        if [ -f "$REPO_DIR/.github/bootstrap-provider.yml" ]; then
+          sed -i "s/{{ENV_MANAGER}}/$ENV_MANAGER/g" "$REPO_DIR/.github/bootstrap-provider.yml"
+          sed -i "s/{{LANG_DIR}}/$LANG_DIR/g" "$REPO_DIR/.github/bootstrap-provider.yml"
+        fi
+        if [ -f "$REPO_DIR/scripts/provider-run.sh" ]; then
+          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/scripts/provider-run.sh"
+        fi
+        sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/Makefile"
+        if [ -f "$REPO_DIR/.github/workflows/lint.yml" ]; then
+          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/.github/workflows/lint.yml"
+        fi

--- a/.github/actions/configure-release-tool/action.yml
+++ b/.github/actions/configure-release-tool/action.yml
@@ -1,0 +1,34 @@
+---
+name: Configure Release Tool
+description: Configure Release Please for the selected release type when release_tool=release-please.
+
+inputs:
+  release_tool:
+    description: Release tool to configure (release-please, semantic-release, git-cliff).
+    required: true
+  release_type:
+    description: Normalized release type from bootstrap input validation.
+    required: true
+  working_directory:
+    description: Working directory containing the generated repository to configure.
+    required: false
+    default: new-repo
+
+runs:
+  using: composite
+  steps:
+    - name: Configure Release Please for selected languages
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      env:
+        RELEASE_TOOL: ${{ inputs.release_tool }}
+        RELEASE_TYPE: ${{ inputs.release_type }}
+      run: |
+        case "$RELEASE_TOOL" in
+          "release-please") ;;
+          *) echo "⏭️ Release Please configuration skipped (release_tool=$RELEASE_TOOL)" >> "$GITHUB_STEP_SUMMARY"; exit 0 ;;
+        esac
+
+        jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json \
+          && mv tmp.json release-please-config.json
+        echo "Release Please configured with release-type: $RELEASE_TYPE" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/actions/configure-release-tool/action.yml
+++ b/.github/actions/configure-release-tool/action.yml
@@ -4,7 +4,9 @@ description: Configure Release Please for the selected release type when release
 
 inputs:
   release_tool:
-    description: Release tool to configure (release-please, semantic-release, git-cliff).
+    description: >-
+      Active release tool (release-please, semantic-release, git-cliff).
+      This action only configures Release Please; all other values are no-ops.
     required: true
   release_type:
     description: Normalized release type from bootstrap input validation.
@@ -28,6 +30,14 @@ runs:
           "release-please") ;;
           *) echo "⏭️ Release Please configuration skipped (release_tool=$RELEASE_TOOL)" >> "$GITHUB_STEP_SUMMARY"; exit 0 ;;
         esac
+
+        # Guard: release-please-config.json may have been removed by an earlier
+        # step (e.g. the workflows input excluded the release workflow). Treat a
+        # missing file as an intentional skip rather than a hard failure.
+        if [ ! -f release-please-config.json ]; then
+          echo "⏭️ release-please-config.json not found — skipping (release workflow was excluded)" >> "$GITHUB_STEP_SUMMARY"
+          exit 0
+        fi
 
         jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json \
           && mv tmp.json release-please-config.json

--- a/.github/actions/render-precommit-configs/action.yml
+++ b/.github/actions/render-precommit-configs/action.yml
@@ -1,0 +1,49 @@
+---
+name: Render Pre-commit Configs
+description: >-
+  Render the root .pre-commit-config.yaml and per-language files from snippet
+  templates using the precommit-renderer tool.
+
+inputs:
+  root_language:
+    description: Normalized root language (single token, used to pick the toolchain hooks).
+    required: true
+  languages:
+    description: Normalized comma-separated language list (used for per-language files).
+    required: true
+  output_dir:
+    description: Working directory of the generated repository to write files into.
+    required: false
+    default: new-repo
+
+runs:
+  using: composite
+  steps:
+    - name: Render pre-commit configs from snippets
+      shell: bash
+      env:
+        ROOT_LANGUAGE: ${{ inputs.root_language }}
+        LANGUAGES: ${{ inputs.languages }}
+        REPO_DIR: ${{ inputs.output_dir }}
+        GITHUB_WORKSPACE: ${{ github.workspace }}
+      run: |
+        PRECOMMIT_BASE_TEMPLATE="$GITHUB_WORKSPACE/templates/languages/agnostic/pre-commit-snippets/base.tmpl"
+        PRECOMMIT_SNIPPETS_ROOT="$GITHUB_WORKSPACE/templates/languages"
+
+        if [ ! -f "$PRECOMMIT_BASE_TEMPLATE" ]; then
+          echo "::error::Missing pre-commit base template: $PRECOMMIT_BASE_TEMPLATE"
+          exit 1
+        fi
+        if [ ! -d "$PRECOMMIT_SNIPPETS_ROOT" ]; then
+          echo "::error::Missing pre-commit snippets root: $PRECOMMIT_SNIPPETS_ROOT"
+          exit 1
+        fi
+
+        mkdir -p "$REPO_DIR/.pre-commit/languages"
+        go run "$GITHUB_WORKSPACE/tools/cmd/precommit-renderer" \
+          --base "$PRECOMMIT_BASE_TEMPLATE" \
+          --snippets-root "$PRECOMMIT_SNIPPETS_ROOT" \
+          --languages "$ROOT_LANGUAGE" \
+          --emit-languages "$LANGUAGES" \
+          --output "$REPO_DIR/.pre-commit-config.yaml" \
+          --emit-language-files-dir "$REPO_DIR/.pre-commit/languages"

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -24,10 +24,12 @@ on:
   issue_comment:
     types: [created]
 
-# Cancel superseded runs on the same PR to save resources.
+# Do NOT cancel in-progress runs. Cancellation shows as a failed check in GitHub,
+# which is misleading when the job would have simply skipped (no API key).
+# This workflow completes in seconds whether it runs or skips.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.sha }}
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -28,7 +28,7 @@ on:
 # which is misleading when the job would have simply skipped (no API key).
 # This workflow completes in seconds whether it runs or skips.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.sha }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
 permissions:

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -623,126 +623,39 @@ jobs:
           sed -i "s/{{REPOSITORY_OWNER}}/${{ steps.set-owner.outputs.owner }}/g" README.md
           sed -i "s/{{REPOSITORY_NAME}}/${{ inputs.repo_name }}/g" README.md
 
-      - name: Configure language tooling
-        env:
-          LANGUAGES: ${{ steps.validate-inputs.outputs.normalized_languages }}
-          RAW_LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
-          ROOT_LANGUAGE: ${{ steps.validate-inputs.outputs.root_language }}
-          ENV_MANAGER: ${{ steps.validate-inputs.outputs.env_manager }}
-          REPO_NAME: ${{ inputs.repo_name }}
-          PYTHON_VERSION: ${{ steps.validate-inputs.outputs.python_version }}
-          NODE_VERSION: ${{ steps.validate-inputs.outputs.node_version }}
-          GO_VERSION: ${{ steps.validate-inputs.outputs.go_version }}
-          JAVA_VERSION: ${{ steps.validate-inputs.outputs.java_version }}
+      - name: Log language tooling selection
         run: |
-          LANG_DIR="$ROOT_LANGUAGE"
+          ROOT_LANGUAGE="${{ steps.validate-inputs.outputs.root_language }}"
+          RAW_LANGUAGES="${{ steps.validate-inputs.outputs.languages }}"
+          ENV_MANAGER="${{ steps.validate-inputs.outputs.env_manager }}"
           if echo "$RAW_LANGUAGES" | grep -q ','; then
-            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $ROOT_LANGUAGE" >> "$GITHUB_STEP_SUMMARY"
           fi
+          echo "Using language template: $ROOT_LANGUAGE" >> "$GITHUB_STEP_SUMMARY"
+          echo "Using environment manager: $ENV_MANAGER" >> "$GITHUB_STEP_SUMMARY"
 
-          TEMPLATE_DIR="templates/languages/$LANG_DIR"
-          PROVIDER_DIR="$TEMPLATE_DIR/providers/$ENV_MANAGER"
-          LINT_WORKFLOW_TEMPLATE="templates/.github/workflows/providers/lint-$ENV_MANAGER.yml"
-          PROVIDER_SCRIPT_TEMPLATE="templates/providers/$ENV_MANAGER/provider-run.sh"
-          PRECOMMIT_BASE_TEMPLATE="templates/languages/agnostic/pre-commit-snippets/base.tmpl"
-          PRECOMMIT_SNIPPETS_ROOT="templates/languages"
-          REPO_DIR="new-repo"
+      - name: Render pre-commit configs
+        uses: ./.github/actions/render-precommit-configs
+        with:
+          root_language: ${{ steps.validate-inputs.outputs.root_language }}
+          languages: ${{ steps.validate-inputs.outputs.normalized_languages }}
 
-          echo "Using language template: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
-          echo "Using environment manager: $ENV_MANAGER" >> $GITHUB_STEP_SUMMARY
-
-          # Render root + per-language pre-commit configs from snippets.
-          if [ ! -f "$PRECOMMIT_BASE_TEMPLATE" ]; then
-            echo "::error::Missing pre-commit base template: $PRECOMMIT_BASE_TEMPLATE"
-            exit 1
-          fi
-          if [ ! -d "$PRECOMMIT_SNIPPETS_ROOT" ]; then
-            echo "::error::Missing pre-commit snippets root: $PRECOMMIT_SNIPPETS_ROOT"
-            exit 1
-          fi
-          mkdir -p "$REPO_DIR/.pre-commit/languages"
-          # Root config uses FIRST_LANG so hooks align with the provisioned toolchain.
-          # Per-language files use full LANGUAGES for monorepo subproject opt-in.
-          go run ./tools/cmd/precommit-renderer \
-            --base "$PRECOMMIT_BASE_TEMPLATE" \
-            --snippets-root "$PRECOMMIT_SNIPPETS_ROOT" \
-            --languages "$LANG_DIR" \
-            --emit-languages "$LANGUAGES" \
-            --output "$REPO_DIR/.pre-commit-config.yaml" \
-            --emit-language-files-dir "$REPO_DIR/.pre-commit/languages"
-
-          # Copy language-specific tooling files
-          if [ ! -d "$PROVIDER_DIR" ]; then
-            echo "::error::Missing provider config directory: $PROVIDER_DIR"
-            exit 1
-          fi
-          if [ ! -f "$PROVIDER_DIR/Makefile" ]; then
-            echo "::error::Missing provider Makefile: $PROVIDER_DIR/Makefile"
-            exit 1
-          fi
-          if [ ! -f "$LINT_WORKFLOW_TEMPLATE" ]; then
-            echo "::error::Missing provider lint workflow template: $LINT_WORKFLOW_TEMPLATE"
-            exit 1
-          fi
-          if [ ! -f "$PROVIDER_SCRIPT_TEMPLATE" ]; then
-            echo "::error::Missing provider helper script template: $PROVIDER_SCRIPT_TEMPLATE"
-            exit 1
-          fi
-
-          cp "$PROVIDER_DIR/Makefile" "$REPO_DIR/Makefile"
-          rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/mise.toml"
-          [ -f "$PROVIDER_DIR/environment.yml" ] && cp "$PROVIDER_DIR/environment.yml" "$REPO_DIR/environment.yml"
-          [ -f "$PROVIDER_DIR/mise.toml" ] && cp "$PROVIDER_DIR/mise.toml" "$REPO_DIR/mise.toml"
-          cp "$LINT_WORKFLOW_TEMPLATE" "$REPO_DIR/.github/workflows/lint.yml"
-          cp "templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
-          mkdir -p "$REPO_DIR/scripts"
-          cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
-          cp "templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
-          chmod +x "$REPO_DIR/scripts/provider-run.sh"
-          chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
-
-          # Substitute repository placeholders in generated tooling files
-          if [ -f "$REPO_DIR/environment.yml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/environment.yml"
-          fi
-          if [ -f "$REPO_DIR/mise.toml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/mise.toml"
-          fi
-          if [ -f "$REPO_DIR/.github/bootstrap-provider.yml" ]; then
-            sed -i "s/{{ENV_MANAGER}}/$ENV_MANAGER/g" "$REPO_DIR/.github/bootstrap-provider.yml"
-            sed -i "s/{{LANG_DIR}}/$LANG_DIR/g" "$REPO_DIR/.github/bootstrap-provider.yml"
-          fi
-          if [ -f "$REPO_DIR/scripts/provider-run.sh" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/scripts/provider-run.sh"
-          fi
-          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/Makefile"
-          # lint.yml may have been removed by "Remove unselected workflows"; guard accordingly
-          if [ -f "$REPO_DIR/.github/workflows/lint.yml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/.github/workflows/lint.yml"
-          fi
+      - name: Configure provider tooling files
+        uses: ./.github/actions/configure-provider-tooling-files
+        with:
+          root_language: ${{ steps.validate-inputs.outputs.root_language }}
+          env_manager: ${{ steps.validate-inputs.outputs.env_manager }}
+          repo_name: ${{ inputs.repo_name }}
+          python_version: ${{ steps.validate-inputs.outputs.python_version }}
+          node_version: ${{ steps.validate-inputs.outputs.node_version }}
+          go_version: ${{ steps.validate-inputs.outputs.go_version }}
+          java_version: ${{ steps.validate-inputs.outputs.java_version }}
 
       - name: Configure Release Please for selected languages
-        env:
-          RELEASE_TYPE: ${{ steps.validate-inputs.outputs.release_type }}
-        run: |
-          cd new-repo
-          RELEASE_TOOL="${{ inputs.release_tool }}"
-          case "$RELEASE_TOOL" in
-            "release-please") ;;
-            *) exit 0 ;;
-          esac
-
-          # Update release-please-config.json with the correct release type
-          jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json && mv tmp.json release-please-config.json
-          echo "Release Please configured with release-type: $RELEASE_TYPE" >> $GITHUB_STEP_SUMMARY
+        uses: ./.github/actions/configure-release-tool
+        with:
+          release_tool: ${{ inputs.release_tool }}
+          release_type: ${{ steps.validate-inputs.outputs.release_type }}
 
       - name: Configure CodeQL for selected languages
         uses: ./.github/actions/configure-codeql

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -550,110 +550,33 @@ jobs:
           sed -i "s/{{REPOSITORY_OWNER}}/${{ steps.set-owner.outputs.owner }}/g" README.md
           sed -i "s/{{REPOSITORY_NAME}}/${{ inputs.repo_name }}/g" README.md
 
-      - name: Configure language tooling
-        env:
-          LANGUAGES: ${{ steps.validate-inputs.outputs.normalized_languages }}
-          RAW_LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
-          ROOT_LANGUAGE: ${{ steps.validate-inputs.outputs.root_language }}
-          ENV_MANAGER: ${{ steps.validate-inputs.outputs.env_manager }}
-          REPO_NAME: ${{ inputs.repo_name }}
-          PYTHON_VERSION: ${{ steps.validate-inputs.outputs.python_version }}
-          NODE_VERSION: ${{ steps.validate-inputs.outputs.node_version }}
-          GO_VERSION: ${{ steps.validate-inputs.outputs.go_version }}
-          JAVA_VERSION: ${{ steps.validate-inputs.outputs.java_version }}
+      - name: Log language tooling selection
         run: |
-          LANG_DIR="$ROOT_LANGUAGE"
+          ROOT_LANGUAGE="${{ steps.validate-inputs.outputs.root_language }}"
+          RAW_LANGUAGES="${{ steps.validate-inputs.outputs.languages }}"
+          ENV_MANAGER="${{ steps.validate-inputs.outputs.env_manager }}"
           if echo "$RAW_LANGUAGES" | grep -q ','; then
-            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
+            echo "⚠️ Multiple languages provided ($RAW_LANGUAGES). Tooling template uses first language policy: $ROOT_LANGUAGE" >> "$GITHUB_STEP_SUMMARY"
           fi
+          echo "Using language template: $ROOT_LANGUAGE" >> "$GITHUB_STEP_SUMMARY"
+          echo "Using environment manager: $ENV_MANAGER" >> "$GITHUB_STEP_SUMMARY"
 
-          TEMPLATE_DIR="templates/languages/$LANG_DIR"
-          PROVIDER_DIR="$TEMPLATE_DIR/providers/$ENV_MANAGER"
-          LINT_WORKFLOW_TEMPLATE="templates/.github/workflows/providers/lint-$ENV_MANAGER.yml"
-          PROVIDER_SCRIPT_TEMPLATE="templates/providers/$ENV_MANAGER/provider-run.sh"
-          PRECOMMIT_BASE_TEMPLATE="templates/languages/agnostic/pre-commit-snippets/base.tmpl"
-          PRECOMMIT_SNIPPETS_ROOT="templates/languages"
-          REPO_DIR="new-repo"
+      - name: Render pre-commit configs
+        uses: ./.github/actions/render-precommit-configs
+        with:
+          root_language: ${{ steps.validate-inputs.outputs.root_language }}
+          languages: ${{ steps.validate-inputs.outputs.normalized_languages }}
 
-          echo "Using language template: $LANG_DIR" >> $GITHUB_STEP_SUMMARY
-          echo "Using environment manager: $ENV_MANAGER" >> $GITHUB_STEP_SUMMARY
-
-          # Render root + per-language pre-commit configs from snippets.
-          if [ ! -f "$PRECOMMIT_BASE_TEMPLATE" ]; then
-            echo "::error::Missing pre-commit base template: $PRECOMMIT_BASE_TEMPLATE"
-            exit 1
-          fi
-          if [ ! -d "$PRECOMMIT_SNIPPETS_ROOT" ]; then
-            echo "::error::Missing pre-commit snippets root: $PRECOMMIT_SNIPPETS_ROOT"
-            exit 1
-          fi
-          mkdir -p "$REPO_DIR/.pre-commit/languages"
-          # Root config uses FIRST_LANG so hooks align with the provisioned toolchain.
-          # Per-language files use full LANGUAGES for monorepo subproject opt-in.
-          go run ./tools/cmd/precommit-renderer \
-            --base "$PRECOMMIT_BASE_TEMPLATE" \
-            --snippets-root "$PRECOMMIT_SNIPPETS_ROOT" \
-            --languages "$LANG_DIR" \
-            --emit-languages "$LANGUAGES" \
-            --output "$REPO_DIR/.pre-commit-config.yaml" \
-            --emit-language-files-dir "$REPO_DIR/.pre-commit/languages"
-
-          # Copy language-specific tooling files
-          if [ ! -d "$PROVIDER_DIR" ]; then
-            echo "::error::Missing provider config directory: $PROVIDER_DIR"
-            exit 1
-          fi
-          if [ ! -f "$PROVIDER_DIR/Makefile" ]; then
-            echo "::error::Missing provider Makefile: $PROVIDER_DIR/Makefile"
-            exit 1
-          fi
-          if [ ! -f "$LINT_WORKFLOW_TEMPLATE" ]; then
-            echo "::error::Missing provider lint workflow template: $LINT_WORKFLOW_TEMPLATE"
-            exit 1
-          fi
-          if [ ! -f "$PROVIDER_SCRIPT_TEMPLATE" ]; then
-            echo "::error::Missing provider helper script template: $PROVIDER_SCRIPT_TEMPLATE"
-            exit 1
-          fi
-
-          cp "$PROVIDER_DIR/Makefile" "$REPO_DIR/Makefile"
-          rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/mise.toml"
-          [ -f "$PROVIDER_DIR/environment.yml" ] && cp "$PROVIDER_DIR/environment.yml" "$REPO_DIR/environment.yml"
-          [ -f "$PROVIDER_DIR/mise.toml" ] && cp "$PROVIDER_DIR/mise.toml" "$REPO_DIR/mise.toml"
-          cp "$LINT_WORKFLOW_TEMPLATE" "$REPO_DIR/.github/workflows/lint.yml"
-          cp "templates/.github/bootstrap-provider.yml" "$REPO_DIR/.github/bootstrap-provider.yml"
-          mkdir -p "$REPO_DIR/scripts"
-          cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
-          cp "templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
-          chmod +x "$REPO_DIR/scripts/provider-run.sh"
-          chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
-
-          # Substitute repository placeholders in generated tooling files
-          if [ -f "$REPO_DIR/environment.yml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/environment.yml"
-            sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/environment.yml"
-          fi
-          if [ -f "$REPO_DIR/mise.toml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{PYTHON_VERSION}}/$PYTHON_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/mise.toml"
-            sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/mise.toml"
-          fi
-          if [ -f "$REPO_DIR/.github/bootstrap-provider.yml" ]; then
-            sed -i "s/{{ENV_MANAGER}}/$ENV_MANAGER/g" "$REPO_DIR/.github/bootstrap-provider.yml"
-            sed -i "s/{{LANG_DIR}}/$LANG_DIR/g" "$REPO_DIR/.github/bootstrap-provider.yml"
-          fi
-          if [ -f "$REPO_DIR/scripts/provider-run.sh" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/scripts/provider-run.sh"
-          fi
-          sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/Makefile"
-          if [ -f "$REPO_DIR/.github/workflows/lint.yml" ]; then
-            sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/.github/workflows/lint.yml"
-          fi
+      - name: Configure provider tooling files
+        uses: ./.github/actions/configure-provider-tooling-files
+        with:
+          root_language: ${{ steps.validate-inputs.outputs.root_language }}
+          env_manager: ${{ steps.validate-inputs.outputs.env_manager }}
+          repo_name: ${{ inputs.repo_name }}
+          python_version: ${{ steps.validate-inputs.outputs.python_version }}
+          node_version: ${{ steps.validate-inputs.outputs.node_version }}
+          go_version: ${{ steps.validate-inputs.outputs.go_version }}
+          java_version: ${{ steps.validate-inputs.outputs.java_version }}
 
       - name: Remove unselected workflows
         run: |
@@ -710,19 +633,10 @@ jobs:
           esac
 
       - name: Configure Release Please for selected languages
-        env:
-          RELEASE_TYPE: ${{ steps.validate-inputs.outputs.release_type }}
-          RELEASE_TOOL: ${{ inputs.release_tool }}
-        run: |
-          case "$RELEASE_TOOL" in
-            "release-please") ;;
-            *) echo "⏭️ Release Please configuration skipped (release_tool=$RELEASE_TOOL)"; exit 0 ;;
-          esac
-          cd new-repo
-
-          # Update release-please-config.json with the correct release type
-          jq --arg rt "$RELEASE_TYPE" '."release-type" = $rt' release-please-config.json > tmp.json && mv tmp.json release-please-config.json
-          echo "Release Please configured with release-type: $RELEASE_TYPE" >> $GITHUB_STEP_SUMMARY
+        uses: ./.github/actions/configure-release-tool
+        with:
+          release_tool: ${{ inputs.release_tool }}
+          release_type: ${{ steps.validate-inputs.outputs.release_type }}
 
       - name: Configure CodeQL for selected languages
         uses: ./.github/actions/configure-codeql

--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -24,7 +24,9 @@ low-risk PR, then this refactor can proceed in phases.
   generated-file snapshots, and CI confirmation are all complete on `main`.
 - Phase 1: Completed. Shared normalization package, command wrapper, renderer,
   and both workflow migrations now consume the same normalization contract.
-- Phase 2: Not started. Depends on the normalization contract from Phase 1.
+- Phase 2: In progress. Composite actions for pre-commit rendering, provider
+  tooling files, release-tool configuration, and CodeQL configuration are
+  extracted and both creation workflows updated to consume them.
 - Phase 3: Not started. Can start after production workflow behavior is stable.
 - Phase 4: Not started. Final documentation pass after the implementation phases.
 
@@ -179,19 +181,20 @@ Exit criteria:
 
 ### Phase 2: Extract composite actions
 
-1. [ ] Move pre-commit rendering to `render-precommit-configs` action.
-2. [ ] Move provider file selection/substitution to
+1. [x] Move pre-commit rendering to `render-precommit-configs` action.
+2. [x] Move provider file selection/substitution to
        `configure-provider-tooling-files` action.
-3. [ ] Move release/configuration steps into dedicated actions.
-4. [ ] Move CodeQL configuration into `configure-codeql` only if the Python helper
-       remains a stable boundary.
+3. [x] Move release/configuration steps into dedicated actions.
+4. [x] Move CodeQL configuration into `configure-codeql` action.
 5. [ ] Move repo settings and branch protection only after the direct and Terraform
        paths have matching behavior documented.
 
 Exit criteria:
 
-- [ ] top-level workflows mostly linear and readable
-- [ ] each extracted action has input/output contract
+- [x] top-level workflows mostly linear and readable
+- [x] each extracted action has input/output contract
+- [ ] repo settings and branch protection actions pending — deferred to follow-up
+      PR after both paths have matching behavior documented
 
 ### Phase 3: Test workflow parity and reliability
 


### PR DESCRIPTION
## Phase 2: Extract composite actions

Follows Phase 1 (PR #53) which migrated both creation workflows to consume the shared `bootstrapinputs` normalization contract.

This PR extracts the remaining large inline shell blocks from `create-repository.yml` and `terraform-create-repository.yml` into dedicated composite actions under `.github/actions/`.

### Actions added

| Action | Responsibility |
|---|---|
| `configure-codeql` | Run the CodeQL Python helper for the selected languages (extracted in 99e01e0) |
| `configure-release-tool` | Configure Release Please for the normalized release type |
| `render-precommit-configs` | Render root and per-language pre-commit configs from snippet templates |
| `configure-provider-tooling-files` | Copy language/provider Makefile, scripts, and tooling files with placeholder substitution |

### What changed

- Both creation workflows now call these actions instead of embedding 60-120 line shell blocks.
- Each action has explicit `inputs` with descriptions and a single responsibility.
- Behavior is preserved exactly \u2014 no logic was changed, only relocated.
- Plan doc updated: Phase 2 tasks 1\u20134 marked complete; task 5 (repo settings/branch protection) deferred to a follow-up PR.

### Exit criteria coverage

- [x] top-level workflows mostly linear and readable
- [x] each extracted action has an explicit input/output contract
- [ ] repo settings and branch protection \u2014 deferred (requires matching behavior documented for both paths first)