### PR TITLE
feat(test): complete Phase 3 workflow parity and preset scenarios

### DIFF
--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -363,6 +363,10 @@ jobs:
             --field workflows="$WORKFLOWS" \
             --field cleanup_on_failure="true"
           DISPATCH_ACTOR=$(gh api /user --jq '.login')
+          if [ -z "$DISPATCH_ACTOR" ]; then
+            echo "::error::Failed to resolve dispatch actor from GH_TOKEN; cannot correlate workflow run"
+            exit 1
+          fi
           echo "workflow_triggered_at=$TRIGGERED_AT" >> "$GITHUB_OUTPUT"
           echo "dispatch_actor=$DISPATCH_ACTOR" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -354,7 +354,9 @@ jobs:
             --field enable_codeowners="$ENABLE_CODEOWNERS" \
             --field workflows="$WORKFLOWS" \
             --field cleanup_on_failure="true"
+          DISPATCH_ACTOR=$(gh api /user --jq '.login')
           echo "workflow_triggered_at=$TRIGGERED_AT" >> $GITHUB_OUTPUT
+          echo "dispatch_actor=$DISPATCH_ACTOR" >> $GITHUB_OUTPUT
 
       - name: Monitor workflow execution
         env:
@@ -363,10 +365,10 @@ jobs:
           TARGET_REF: ${{ steps.validate-inputs.outputs.target_ref }}
           REPOSITORY: ${{ github.repository }}
           TRIGGERED_AT: ${{ steps.trigger-workflow.outputs.workflow_triggered_at }}
-          ACTOR: ${{ github.actor }}
+          DISPATCH_ACTOR: ${{ steps.trigger-workflow.outputs.dispatch_actor }}
         timeout-minutes: 10
         run: |
-          echo "⏳ Monitoring ${WORKFLOW_FILE} on ref ${TARGET_REF}..."
+          echo "⏳ Monitoring ${WORKFLOW_FILE} on ref ${TARGET_REF} (dispatch actor: ${DISPATCH_ACTOR})..."
 
           # Wait a moment for the workflow to be registered
           sleep 5
@@ -377,7 +379,7 @@ jobs:
             # This avoids relying on branch-only filtering so tag refs are supported.
             RUN_STATUS=$(gh api \
               "/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=20&event=workflow_dispatch" \
-              | jq -c --arg ref "$TARGET_REF" --arg since "$TRIGGERED_AT" --arg actor "$ACTOR" '
+              | jq -c --arg ref "$TARGET_REF" --arg since "$TRIGGERED_AT" --arg actor "$DISPATCH_ACTOR" '
                   [.workflow_runs[]
                   | select(.head_branch == $ref)
                   | select(.created_at >= $since)

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -363,8 +363,8 @@ jobs:
             --field workflows="$WORKFLOWS" \
             --field cleanup_on_failure="true"
           DISPATCH_ACTOR=$(gh api /user --jq '.login')
-          echo "workflow_triggered_at=$TRIGGERED_AT" >> $GITHUB_OUTPUT
-          echo "dispatch_actor=$DISPATCH_ACTOR" >> $GITHUB_OUTPUT
+          echo "workflow_triggered_at=$TRIGGERED_AT" >> "$GITHUB_OUTPUT"
+          echo "dispatch_actor=$DISPATCH_ACTOR" >> "$GITHUB_OUTPUT"
 
       - name: Monitor workflow execution
         env:

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -264,6 +264,14 @@ jobs:
             echo "::error::Invalid enable_codeowners '$ENABLE_CODEOWNERS'. Allowed: true, false"
             exit 1
           fi
+          if ! [[ "$RELEASE_TOOL" =~ ^(git-cliff|release-please|semantic-release)$ ]]; then
+            echo "::error::Invalid release_tool '$RELEASE_TOOL'."
+            exit 1
+          fi
+          if ! [[ "$WORKFLOWS" =~ ^(all|none)$ ]] && ! [[ "$WORKFLOWS" =~ ^(lint|codeql|ai-code-review|release)(,(lint|codeql|ai-code-review|release))*$ ]]; then
+            echo "::error::Invalid workflows '$WORKFLOWS'. Allowed: all, none, or comma-separated of lint,codeql,ai-code-review,release"
+            exit 1
+          fi
           if ! [[ "$TARGET_REF" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$TARGET_REF" == *".."* ]] || [[ "$TARGET_REF" == /* ]] || [[ "$TARGET_REF" == */ ]]; then
             echo "::error::Invalid target_ref '$TARGET_REF'."
             exit 1
@@ -784,6 +792,8 @@ jobs:
       - name: Write job summary
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          PRESET: ${{ steps.validate-inputs.outputs.preset }}
+          TARGET_WORKFLOW: ${{ steps.validate-inputs.outputs.target_workflow }}
         run: |
           REPO_NAME="${{ steps.generate-name.outputs.repo_name }}"
           OWNER="${{ github.repository_owner }}"
@@ -795,8 +805,8 @@ jobs:
           | Item | Status |
           |------|--------|
           | Repository | [${OWNER}/${REPO_NAME}](${REPO_URL}) |
-          | Preset | `${{ steps.validate-inputs.outputs.preset }}` |
-          | Target workflow | `${{ steps.validate-inputs.outputs.target_workflow }}` |
+          | Preset | \`${PRESET}\` |
+          | Target workflow | \`${TARGET_WORKFLOW}\` |
           | Structure validation | ✅ Passed |
           | Agent kit (agents + skills) | ✅ Passed |
           | API parity (settings + rulesets) | ✅ Passed |

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -265,7 +265,7 @@ jobs:
             exit 1
           fi
           if ! [[ "$RELEASE_TOOL" =~ ^(git-cliff|release-please|semantic-release)$ ]]; then
-            echo "::error::Invalid release_tool '$RELEASE_TOOL'."
+            echo "::error::Invalid release_tool '$RELEASE_TOOL'. Allowed: git-cliff, release-please, semantic-release"
             exit 1
           fi
           WORKFLOWS="${WORKFLOWS//[[:space:]]/}"

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -8,11 +8,33 @@ on:
         required: false
         default: "bootstrap-test"
         type: string
+      preset:
+        description: "One-click test scenario preset"
+        required: false
+        default: "none"
+        type: choice
+        options:
+          - none
+          - api-default
+          - terraform-default
+          - api-no-repo-settings
+          - terraform-no-repo-settings
+          - api-all-languages
+          - terraform-all-languages
       languages:
         description: "Languages to test (comma-separated or 'all' or 'language-agnostic-only')"
         required: false
         default: "language-agnostic-only"
         type: string
+      visibility:
+        description: "Repository visibility to pass to target workflow"
+        required: false
+        default: "public"
+        type: choice
+        options:
+          - public
+          - private
+          - internal
       target_workflow:
         description: "Creation workflow to test"
         required: false
@@ -86,6 +108,16 @@ on:
         required: false
         default: true
         type: boolean
+      enable_codeowners:
+        description: "Enable CODEOWNERS generation in target workflow"
+        required: false
+        default: true
+        type: boolean
+      workflows:
+        description: "Workflows to include: all, none, or comma-separated names"
+        required: false
+        default: "all"
+        type: string
       gh_token:
         description: >-
           Personal Access Token with repo and admin:org scopes.
@@ -141,21 +173,73 @@ jobs:
           LANGUAGES_INPUT: ${{ github.event.inputs.languages }}
           TARGET_WORKFLOW_INPUT: ${{ github.event.inputs.target_workflow }}
           TARGET_REF_INPUT: ${{ github.event.inputs.target_ref }}
+          PRESET_INPUT: ${{ github.event.inputs.preset }}
+          VISIBILITY_INPUT: ${{ github.event.inputs.visibility }}
           PYTHON_VERSION_INPUT: ${{ github.event.inputs.python_version }}
           NODE_VERSION_INPUT: ${{ github.event.inputs.node_version }}
           GO_VERSION_INPUT: ${{ github.event.inputs.go_version }}
           JAVA_VERSION_INPUT: ${{ github.event.inputs.java_version }}
+          RELEASE_TOOL_INPUT: ${{ github.event.inputs.release_tool }}
           ENABLE_REPO_SETTINGS_INPUT: ${{ github.event.inputs.enable_repo_settings }}
+          ENABLE_CODEOWNERS_INPUT: ${{ github.event.inputs.enable_codeowners }}
+          WORKFLOWS_INPUT: ${{ github.event.inputs.workflows }}
         run: |
           ENV_MANAGER="$ENV_MANAGER_INPUT"
           LANGUAGES="$LANGUAGES_INPUT"
           TARGET_WORKFLOW="$TARGET_WORKFLOW_INPUT"
           TARGET_REF="$TARGET_REF_INPUT"
+          PRESET="$PRESET_INPUT"
+          VISIBILITY="$VISIBILITY_INPUT"
           PYTHON_VERSION="$PYTHON_VERSION_INPUT"
           NODE_VERSION="$NODE_VERSION_INPUT"
           GO_VERSION="$GO_VERSION_INPUT"
           JAVA_VERSION="$JAVA_VERSION_INPUT"
+          RELEASE_TOOL="$RELEASE_TOOL_INPUT"
           ENABLE_REPO_SETTINGS="$ENABLE_REPO_SETTINGS_INPUT"
+          ENABLE_CODEOWNERS="$ENABLE_CODEOWNERS_INPUT"
+          WORKFLOWS="$WORKFLOWS_INPUT"
+
+          case "$PRESET" in
+            "none") ;;
+            "api-default")
+              TARGET_WORKFLOW="create-repository.yml"
+              LANGUAGES="language-agnostic-only"
+              ENV_MANAGER="micromamba"
+              VISIBILITY="public"
+              ENABLE_REPO_SETTINGS="true"
+              ENABLE_CODEOWNERS="true"
+              WORKFLOWS="all"
+              ;;
+            "terraform-default")
+              TARGET_WORKFLOW="terraform-create-repository.yml"
+              LANGUAGES="language-agnostic-only"
+              ENV_MANAGER="micromamba"
+              VISIBILITY="public"
+              ENABLE_REPO_SETTINGS="true"
+              ENABLE_CODEOWNERS="true"
+              WORKFLOWS="all"
+              ;;
+            "api-no-repo-settings")
+              TARGET_WORKFLOW="create-repository.yml"
+              ENABLE_REPO_SETTINGS="false"
+              ;;
+            "terraform-no-repo-settings")
+              TARGET_WORKFLOW="terraform-create-repository.yml"
+              ENABLE_REPO_SETTINGS="false"
+              ;;
+            "api-all-languages")
+              TARGET_WORKFLOW="create-repository.yml"
+              LANGUAGES="all"
+              ;;
+            "terraform-all-languages")
+              TARGET_WORKFLOW="terraform-create-repository.yml"
+              LANGUAGES="all"
+              ;;
+            *)
+              echo "::error::Invalid preset '$PRESET'"
+              exit 1
+              ;;
+          esac
           if ! [[ "$ENV_MANAGER" =~ ^(micromamba|mise|system)$ ]]; then
             echo "::error::Invalid env_manager '$ENV_MANAGER'. Allowed: micromamba, mise, system"
             exit 1
@@ -166,6 +250,18 @@ jobs:
           fi
           if [ -z "$TARGET_REF" ]; then
             echo "::error::target_ref must not be empty"
+            exit 1
+          fi
+          if ! [[ "$VISIBILITY" =~ ^(public|private|internal)$ ]]; then
+            echo "::error::Invalid visibility '$VISIBILITY'. Allowed: public, private, internal"
+            exit 1
+          fi
+          if ! [[ "$ENABLE_REPO_SETTINGS" =~ ^(true|false)$ ]]; then
+            echo "::error::Invalid enable_repo_settings '$ENABLE_REPO_SETTINGS'. Allowed: true, false"
+            exit 1
+          fi
+          if ! [[ "$ENABLE_CODEOWNERS" =~ ^(true|false)$ ]]; then
+            echo "::error::Invalid enable_codeowners '$ENABLE_CODEOWNERS'. Allowed: true, false"
             exit 1
           fi
           if ! [[ "$TARGET_REF" =~ ^[A-Za-z0-9._/-]+$ ]] || [[ "$TARGET_REF" == *".."* ]] || [[ "$TARGET_REF" == /* ]] || [[ "$TARGET_REF" == */ ]]; then
@@ -211,7 +307,12 @@ jobs:
           echo "root_language=$ROOT_LANGUAGE" >> "$GITHUB_OUTPUT"
           echo "target_workflow=$TARGET_WORKFLOW" >> "$GITHUB_OUTPUT"
           echo "target_ref=$TARGET_REF" >> "$GITHUB_OUTPUT"
+          echo "preset=$PRESET" >> "$GITHUB_OUTPUT"
+          echo "visibility=$VISIBILITY" >> "$GITHUB_OUTPUT"
+          echo "release_tool=$RELEASE_TOOL" >> "$GITHUB_OUTPUT"
           echo "enable_repo_settings=$ENABLE_REPO_SETTINGS" >> "$GITHUB_OUTPUT"
+          echo "enable_codeowners=$ENABLE_CODEOWNERS" >> "$GITHUB_OUTPUT"
+          echo "workflows=$WORKFLOWS" >> "$GITHUB_OUTPUT"
 
       - name: Trigger repository creation workflow
         id: trigger-workflow
@@ -223,12 +324,15 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           LANGUAGES: ${{ steps.validate-inputs.outputs.languages }}
           ENV_MANAGER: ${{ steps.validate-inputs.outputs.env_manager }}
+          VISIBILITY: ${{ steps.validate-inputs.outputs.visibility }}
           PYTHON_VERSION: ${{ github.event.inputs.python_version }}
           NODE_VERSION: ${{ github.event.inputs.node_version }}
           GO_VERSION: ${{ github.event.inputs.go_version }}
           JAVA_VERSION: ${{ github.event.inputs.java_version }}
-          RELEASE_TOOL: ${{ github.event.inputs.release_tool }}
+          RELEASE_TOOL: ${{ steps.validate-inputs.outputs.release_tool }}
           ENABLE_REPO_SETTINGS: ${{ steps.validate-inputs.outputs.enable_repo_settings }}
+          ENABLE_CODEOWNERS: ${{ steps.validate-inputs.outputs.enable_codeowners }}
+          WORKFLOWS: ${{ steps.validate-inputs.outputs.workflows }}
         run: |
           TRIGGERED_AT=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
@@ -236,7 +340,7 @@ jobs:
             --ref "$TARGET_REF" \
             --field repo_name="$REPO_NAME" \
             --field repo_description="Test repository for bootstrap validation - created $(date)" \
-            --field visibility="public" \
+            --field visibility="$VISIBILITY" \
             --field team_name="* @$REPO_OWNER" \
             --field license_holder="$REPO_OWNER" \
             --field languages="$LANGUAGES" \
@@ -247,6 +351,8 @@ jobs:
             --field java_version="$JAVA_VERSION" \
             --field release_tool="$RELEASE_TOOL" \
             --field enable_repo_settings="$ENABLE_REPO_SETTINGS" \
+            --field enable_codeowners="$ENABLE_CODEOWNERS" \
+            --field workflows="$WORKFLOWS" \
             --field cleanup_on_failure="true"
           echo "workflow_triggered_at=$TRIGGERED_AT" >> $GITHUB_OUTPUT
 
@@ -257,6 +363,7 @@ jobs:
           TARGET_REF: ${{ steps.validate-inputs.outputs.target_ref }}
           REPOSITORY: ${{ github.repository }}
           TRIGGERED_AT: ${{ steps.trigger-workflow.outputs.workflow_triggered_at }}
+          ACTOR: ${{ github.actor }}
         timeout-minutes: 10
         run: |
           echo "⏳ Monitoring ${WORKFLOW_FILE} on ref ${TARGET_REF}..."
@@ -270,10 +377,11 @@ jobs:
             # This avoids relying on branch-only filtering so tag refs are supported.
             RUN_STATUS=$(gh api \
               "/repos/${REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/runs?per_page=20&event=workflow_dispatch" \
-              | jq -c --arg ref "$TARGET_REF" --arg since "$TRIGGERED_AT" '
+              | jq -c --arg ref "$TARGET_REF" --arg since "$TRIGGERED_AT" --arg actor "$ACTOR" '
                   [.workflow_runs[]
                   | select(.head_branch == $ref)
                   | select(.created_at >= $since)
+                  | select(.actor.login == $actor)
                   | {status: .status, conclusion: .conclusion, html_url: .html_url}]
                   | first // {}')
 
@@ -685,6 +793,8 @@ jobs:
           | Item | Status |
           |------|--------|
           | Repository | [${OWNER}/${REPO_NAME}](${REPO_URL}) |
+          | Preset | `${{ steps.validate-inputs.outputs.preset }}` |
+          | Target workflow | `${{ steps.validate-inputs.outputs.target_workflow }}` |
           | Structure validation | ✅ Passed |
           | Agent kit (agents + skills) | ✅ Passed |
           | API parity (settings + rulesets) | ✅ Passed |

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -268,6 +268,10 @@ jobs:
             echo "::error::Invalid release_tool '$RELEASE_TOOL'."
             exit 1
           fi
+          WORKFLOWS="${WORKFLOWS//[[:space:]]/}"
+          if [ -z "$WORKFLOWS" ]; then
+            WORKFLOWS="all"
+          fi
           if ! [[ "$WORKFLOWS" =~ ^(all|none)$ ]] && ! [[ "$WORKFLOWS" =~ ^(lint|codeql|ai-code-review|release)(,(lint|codeql|ai-code-review|release))*$ ]]; then
             echo "::error::Invalid workflows '$WORKFLOWS'. Allowed: all, none, or comma-separated of lint,codeql,ai-code-review,release"
             exit 1

--- a/docs/workflow-refactor-plan-repo-creation.md
+++ b/docs/workflow-refactor-plan-repo-creation.md
@@ -28,7 +28,8 @@ low-risk PR, then this refactor can proceed in phases.
   provider tooling files, release-tool configuration, CodeQL configuration,
   and repository settings. Branch protection automation removed from workflows.
   Both creation workflows updated.
-- Phase 3: Not started. Can start after production workflow behavior is stable.
+- Phase 3: Completed. Test workflow input parity, deterministic run correlation,
+  and preset-driven manual scenarios are in place.
 - Phase 4: Not started. Final documentation pass after the implementation phases.
 
 Use the exit criteria under each phase as the source of truth for deciding when a
@@ -202,14 +203,23 @@ Exit criteria:
 
 ### Phase 3: Test workflow parity and reliability
 
-1. [ ] Align test workflow inputs with create workflow schema.
-2. [ ] Add deterministic dispatch-run correlation metadata.
-3. [ ] Add matrix-style manual test presets (docs + dispatch examples).
+1. [x] Align test workflow inputs with create workflow schema.
+2. [x] Add deterministic dispatch-run correlation metadata.
+3. [x] Add matrix-style manual test presets (docs + dispatch examples).
+
+Preset examples now supported in `test-repository-creation.yml`:
+
+- `api-default`
+- `terraform-default`
+- `api-no-repo-settings`
+- `terraform-no-repo-settings`
+- `api-all-languages`
+- `terraform-all-languages`
 
 Exit criteria:
 
-- [ ] repeatable manual validation against branch/tag refs
-- [ ] no ambiguous run polling behavior
+- [x] repeatable manual validation against branch/tag refs
+- [x] no ambiguous run polling behavior
 
 ### Phase 4: Documentation consolidation
 


### PR DESCRIPTION
## Summary

Implements Phase 3 from docs/workflow-refactor-plan-repo-creation.md for test workflow parity and reliability.

## Changes

- test-repository-creation.yml
  - Added test input parity fields:
    - preset
    - visibility
    - enable_codeowners
    - workflows
  - Extended validation and output propagation for new fields
  - Added preset-based scenario overrides:
    - api-default
    - terraform-default
    - api-no-repo-settings
    - terraform-no-repo-settings
    - api-all-languages
    - terraform-all-languages
  - Dispatch now forwards the expanded input set to target workflows
  - Monitoring now includes actor-based filtering for more deterministic run correlation
  - Job summary now records selected preset and target workflow

- docs/workflow-refactor-plan-repo-creation.md
  - Marked Phase 3 as completed
  - Marked all Phase 3 checklist items and exit criteria as complete
  - Added explicit preset examples section

## Validation

- Ran LINT_MODE=check make lint successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the repository creation test workflow with more setup options, including preset selection, visibility choices, CODEOWNERS generation, and workflow selection.
  * Improved run tracking so dispatched workflows are matched more reliably.

* **Documentation**
  * Updated the workflow refactor plan to mark Phase 3 as complete and reflect the newly supported preset options and validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->