### PR TITLE
refactor(tooling): centralize provider asset pins

### DIFF
--- a/.github/actions/configure-provider-tooling-files/action.yml
+++ b/.github/actions/configure-provider-tooling-files/action.yml
@@ -84,6 +84,7 @@ runs:
         mkdir -p "$REPO_DIR/scripts"
         cp "$PROVIDER_SCRIPT_TEMPLATE" "$REPO_DIR/scripts/provider-run.sh"
         cp "$GITHUB_WORKSPACE/templates/scripts/bootstrap-provider-binary.sh" "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
+        cp "$GITHUB_WORKSPACE/templates/scripts/provider-assets.txt" "$REPO_DIR/scripts/provider-assets.txt"
         chmod +x "$REPO_DIR/scripts/provider-run.sh"
         chmod +x "$REPO_DIR/scripts/bootstrap-provider-binary.sh"
 

--- a/scripts/bootstrap-provider-binary.sh
+++ b/scripts/bootstrap-provider-binary.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 provider="${1:-}"
 target_path="${2:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest_path="${script_dir}/provider-assets.txt"
 
 if [[ -z "$provider" || -z "$target_path" ]]; then
     echo "Usage: scripts/bootstrap-provider-binary.sh <mise|micromamba> <target-path>" >&2
@@ -30,48 +32,31 @@ case "$arch_name" in
         ;;
 esac
 
-url=""
-sha256=""
+if [[ ! -f "$manifest_path" ]]; then
+    echo "Missing provider asset manifest: $manifest_path" >&2
+    exit 1
+fi
 
-case "$provider:$os:$arch" in
-    mise:linux:x64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-x64"
-        sha256="0744cb3c303baf0d308ff7b112ed41f22abb6029cb5644fd3a8ce74b29f16a68"
-        ;;
-    mise:linux:arm64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-arm64"
-        sha256="50d3752baf2d6542bf7b8cff1146e0fd9517531c74171b93a1e4b63dcd2d64e8"
-        ;;
-    mise:macos:x64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-x64"
-        sha256="c0debad068ea3e1e525d6580168e0be4759295cdd9049b6ab1aac37d90e952de"
-        ;;
-    mise:macos:arm64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-arm64"
-        sha256="cc5a708f75e9a84e007a650c23b127e79e54aacf0e41378d75bb15795e9ed54d"
-        ;;
+if ! command -v awk > /dev/null 2>&1; then
+    echo "Missing required tool: awk" >&2
+    exit 1
+fi
 
-    micromamba:linux:x64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-64"
-        sha256="9689782d863c05a1bf5d2d371ba527104e7a4eb4310c1637d8653b751aed9c82"
-        ;;
-    micromamba:linux:arm64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-aarch64"
-        sha256="e5ba23b5945aa49dfd11022e592a510d2686a8feee810e00140b73c9fdf0ba2a"
-        ;;
-    micromamba:macos:x64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-64"
-        sha256="b2bd613791c0a524883d7cb66505d630bf15badd1f492bc93ba78550a3a1a94b"
-        ;;
-    micromamba:macos:arm64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-arm64"
-        sha256="de71a646b73af92dd663e6ddc78993a6a4d47ea28b5d8908c3cc2b9c3077e528"
-        ;;
-    *)
-        echo "Unsupported provider/OS/arch combination: $provider:$os:$arch" >&2
-        exit 1
-        ;;
-esac
+if ! asset_line="$(awk -v provider="$provider" -v os="$os" -v arch="$arch" '
+    /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == provider && $2 == os && $3 == arch { print $4, $5; found = 1; exit }
+    END { if (!found) exit 1 }
+' "$manifest_path")"; then
+    echo "Unsupported provider/OS/arch combination: $provider:$os:$arch" >&2
+    exit 1
+fi
+
+read -r url sha256 <<< "$asset_line"
+
+if [[ -z "$url" || -z "$sha256" ]]; then
+    echo "Malformed provider asset entry for: $provider:$os:$arch" >&2
+    exit 1
+fi
 
 mkdir -p "$(dirname "$target_path")"
 

--- a/scripts/provider-assets.txt
+++ b/scripts/provider-assets.txt
@@ -1,0 +1,9 @@
+# provider os arch url sha256
+mise linux x64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-x64 0744cb3c303baf0d308ff7b112ed41f22abb6029cb5644fd3a8ce74b29f16a68
+mise linux arm64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-arm64 50d3752baf2d6542bf7b8cff1146e0fd9517531c74171b93a1e4b63dcd2d64e8
+mise macos x64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-x64 c0debad068ea3e1e525d6580168e0be4759295cdd9049b6ab1aac37d90e952de
+mise macos arm64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-arm64 cc5a708f75e9a84e007a650c23b127e79e54aacf0e41378d75bb15795e9ed54d
+micromamba linux x64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-64 9689782d863c05a1bf5d2d371ba527104e7a4eb4310c1637d8653b751aed9c82
+micromamba linux arm64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-aarch64 e5ba23b5945aa49dfd11022e592a510d2686a8feee810e00140b73c9fdf0ba2a
+micromamba macos x64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-64 b2bd613791c0a524883d7cb66505d630bf15badd1f492bc93ba78550a3a1a94b
+micromamba macos arm64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-arm64 de71a646b73af92dd663e6ddc78993a6a4d47ea28b5d8908c3cc2b9c3077e528

--- a/templates/scripts/bootstrap-provider-binary.sh
+++ b/templates/scripts/bootstrap-provider-binary.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 provider="${1:-}"
 target_path="${2:-}"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+manifest_path="${script_dir}/provider-assets.txt"
 
 if [[ -z "$provider" || -z "$target_path" ]]; then
     echo "Usage: scripts/bootstrap-provider-binary.sh <mise|micromamba> <target-path>" >&2
@@ -30,48 +32,31 @@ case "$arch_name" in
         ;;
 esac
 
-url=""
-sha256=""
+if [[ ! -f "$manifest_path" ]]; then
+    echo "Missing provider asset manifest: $manifest_path" >&2
+    exit 1
+fi
 
-case "$provider:$os:$arch" in
-    mise:linux:x64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-x64"
-        sha256="0744cb3c303baf0d308ff7b112ed41f22abb6029cb5644fd3a8ce74b29f16a68"
-        ;;
-    mise:linux:arm64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-arm64"
-        sha256="50d3752baf2d6542bf7b8cff1146e0fd9517531c74171b93a1e4b63dcd2d64e8"
-        ;;
-    mise:macos:x64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-x64"
-        sha256="c0debad068ea3e1e525d6580168e0be4759295cdd9049b6ab1aac37d90e952de"
-        ;;
-    mise:macos:arm64)
-        url="https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-arm64"
-        sha256="cc5a708f75e9a84e007a650c23b127e79e54aacf0e41378d75bb15795e9ed54d"
-        ;;
+if ! command -v awk > /dev/null 2>&1; then
+    echo "Missing required tool: awk" >&2
+    exit 1
+fi
 
-    micromamba:linux:x64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-64"
-        sha256="9689782d863c05a1bf5d2d371ba527104e7a4eb4310c1637d8653b751aed9c82"
-        ;;
-    micromamba:linux:arm64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-aarch64"
-        sha256="e5ba23b5945aa49dfd11022e592a510d2686a8feee810e00140b73c9fdf0ba2a"
-        ;;
-    micromamba:macos:x64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-64"
-        sha256="b2bd613791c0a524883d7cb66505d630bf15badd1f492bc93ba78550a3a1a94b"
-        ;;
-    micromamba:macos:arm64)
-        url="https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-arm64"
-        sha256="de71a646b73af92dd663e6ddc78993a6a4d47ea28b5d8908c3cc2b9c3077e528"
-        ;;
-    *)
-        echo "Unsupported provider/OS/arch combination: $provider:$os:$arch" >&2
-        exit 1
-        ;;
-esac
+if ! asset_line="$(awk -v provider="$provider" -v os="$os" -v arch="$arch" '
+    /^[[:space:]]*#/ || NF == 0 { next }
+    $1 == provider && $2 == os && $3 == arch { print $4, $5; found = 1; exit }
+    END { if (!found) exit 1 }
+' "$manifest_path")"; then
+    echo "Unsupported provider/OS/arch combination: $provider:$os:$arch" >&2
+    exit 1
+fi
+
+read -r url sha256 <<< "$asset_line"
+
+if [[ -z "$url" || -z "$sha256" ]]; then
+    echo "Malformed provider asset entry for: $provider:$os:$arch" >&2
+    exit 1
+fi
 
 mkdir -p "$(dirname "$target_path")"
 

--- a/templates/scripts/provider-assets.txt
+++ b/templates/scripts/provider-assets.txt
@@ -1,0 +1,9 @@
+# provider os arch url sha256
+mise linux x64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-x64 0744cb3c303baf0d308ff7b112ed41f22abb6029cb5644fd3a8ce74b29f16a68
+mise linux arm64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-linux-arm64 50d3752baf2d6542bf7b8cff1146e0fd9517531c74171b93a1e4b63dcd2d64e8
+mise macos x64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-x64 c0debad068ea3e1e525d6580168e0be4759295cdd9049b6ab1aac37d90e952de
+mise macos arm64 https://github.com/jdx/mise/releases/download/v2026.7.0/mise-v2026.7.0-macos-arm64 cc5a708f75e9a84e007a650c23b127e79e54aacf0e41378d75bb15795e9ed54d
+micromamba linux x64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-64 9689782d863c05a1bf5d2d371ba527104e7a4eb4310c1637d8653b751aed9c82
+micromamba linux arm64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-linux-aarch64 e5ba23b5945aa49dfd11022e592a510d2686a8feee810e00140b73c9fdf0ba2a
+micromamba macos x64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-64 b2bd613791c0a524883d7cb66505d630bf15badd1f492bc93ba78550a3a1a94b
+micromamba macos arm64 https://github.com/mamba-org/micromamba-releases/releases/download/2.8.1-0/micromamba-osx-arm64 de71a646b73af92dd663e6ddc78993a6a4d47ea28b5d8908c3cc2b9c3077e528

--- a/tools/internal/toolingupdater/updaters/scoped_provider.go
+++ b/tools/internal/toolingupdater/updaters/scoped_provider.go
@@ -27,15 +27,15 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 			changed = append(changed, repoPath)
 		}
 
-		repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
-		ok, err = toolinglib.UpdateFile(repoBootstrap, func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
+		repoProviderAssets := filepath.Join(root, "scripts", "provider-assets.txt")
+		ok, err = toolinglib.UpdateFile(repoProviderAssets, func(content string) (string, error) {
+			return toolinglib.UpdateProviderAssetManifestText(content, cfg.providerAssets)
 		}, write)
 		if err != nil {
 			return changed, err
 		}
 		if ok {
-			changed = append(changed, repoBootstrap)
+			changed = append(changed, repoProviderAssets)
 		}
 	}
 
@@ -50,15 +50,15 @@ func runScopedProviderUpdater(root string, scope string, write bool, cfg scopedP
 			}
 		}
 
-		templateBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
-		ok, err := toolinglib.UpdateFile(templateBootstrap, func(content string) (string, error) {
-			return toolinglib.UpdateBootstrapScriptText(content, cfg.providerAssets)
+		templateProviderAssets := filepath.Join(root, "templates", "scripts", "provider-assets.txt")
+		ok, err := toolinglib.UpdateFile(templateProviderAssets, func(content string) (string, error) {
+			return toolinglib.UpdateProviderAssetManifestText(content, cfg.providerAssets)
 		}, write)
 		if err != nil {
 			return changed, err
 		}
 		if ok {
-			changed = append(changed, templateBootstrap)
+			changed = append(changed, templateProviderAssets)
 		}
 	}
 

--- a/tools/internal/toolingupdater/updaters/updaters_integration_test.go
+++ b/tools/internal/toolingupdater/updaters/updaters_integration_test.go
@@ -50,6 +50,8 @@ func buildTestWorkspace(t *testing.T) (root string, versions toolinglib.Versions
 	tplMise := filepath.Join(root, "templates", "languages", "go", "providers", "mise", "mise.toml")
 	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
 	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	repoProviderAssets := filepath.Join(root, "scripts", "provider-assets.txt")
+	tplProviderAssets := filepath.Join(root, "templates", "scripts", "provider-assets.txt")
 	repoPre := filepath.Join(root, ".pre-commit-config.yaml")
 	tplPre := filepath.Join(root, "templates", "languages", "go", ".pre-commit-config.yaml")
 
@@ -60,9 +62,12 @@ func buildTestWorkspace(t *testing.T) (root string, versions toolinglib.Versions
 	mustWriteFile(t, repoMise, miseSource)
 	mustWriteFile(t, tplMise, miseSource)
 
-	bootstrap := "case \"$provider:$os:$arch\" in\n  mise:linux:x64)\n    url=\"https://old.example/mise\"\n    sha256=\"old\"\n    ;;\n  micromamba:linux:x64)\n    url=\"https://old.example/mamba\"\n    sha256=\"old\"\n    ;;\nesac\n"
+	bootstrap := "#!/usr/bin/env bash\nset -euo pipefail\n"
+	providerAssets := "# provider os arch url sha256\nmise linux x64 https://old.example/mise old\nmicromamba linux x64 https://old.example/mamba old\n"
 	mustWriteFile(t, repoBootstrap, bootstrap)
 	mustWriteFile(t, tplBootstrap, bootstrap)
+	mustWriteFile(t, repoProviderAssets, providerAssets)
+	mustWriteFile(t, tplProviderAssets, providerAssets)
 
 	mustWriteFile(t, repoPre, "repos:\n  - repo: https://example.invalid\n")
 	mustWriteFile(t, tplPre, "repos:\n  - repo: https://example.invalid\n")
@@ -113,8 +118,8 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
 	repoMise := filepath.Join(root, "mise.toml")
 	tplMise := filepath.Join(root, "templates", "languages", "go", "providers", "mise", "mise.toml")
-	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
-	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	repoProviderAssets := filepath.Join(root, "scripts", "provider-assets.txt")
+	tplProviderAssets := filepath.Join(root, "templates", "scripts", "provider-assets.txt")
 	repoPre := filepath.Join(root, ".pre-commit-config.yaml")
 	tplPre := filepath.Join(root, "templates", "languages", "go", ".pre-commit-config.yaml")
 
@@ -122,7 +127,7 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunMicromamba failed: %v", err)
 	}
-	if !containsAll(mambaChanged, repoEnv, tplEnv, repoBootstrap, tplBootstrap) {
+	if !containsAll(mambaChanged, repoEnv, tplEnv, repoProviderAssets, tplProviderAssets) {
 		t.Fatalf("RunMicromamba changed mismatch: %v", mambaChanged)
 	}
 
@@ -130,7 +135,7 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	if err != nil {
 		t.Fatalf("RunMise failed: %v", err)
 	}
-	if !containsAll(miseChanged, repoMise, tplMise, repoBootstrap, tplBootstrap) {
+	if !containsAll(miseChanged, repoMise, tplMise, repoProviderAssets, tplProviderAssets) {
 		t.Fatalf("RunMise changed mismatch: %v", miseChanged)
 	}
 
@@ -162,11 +167,11 @@ func TestRunUpdatersEndToEndWithTempWorkspace(t *testing.T) {
 	if !strings.Contains(mustReadFile(t, tplMise), "github.com/daixiang0/gci@v0.13.7") {
 		t.Fatalf("template mise.toml go module pins were not updated")
 	}
-	if !strings.Contains(mustReadFile(t, repoBootstrap), "url=\"https://new.example/mamba\"") {
-		t.Fatalf("repo bootstrap script was not updated")
+	if !strings.Contains(mustReadFile(t, repoProviderAssets), "micromamba linux x64 https://new.example/mamba mamba-sha") {
+		t.Fatalf("repo provider assets were not updated")
 	}
-	if !strings.Contains(mustReadFile(t, tplBootstrap), "sha256=\"mise-sha\"") {
-		t.Fatalf("template bootstrap script was not updated")
+	if !strings.Contains(mustReadFile(t, tplProviderAssets), "mise linux x64 https://new.example/mise mise-sha") {
+		t.Fatalf("template provider assets were not updated")
 	}
 	if !strings.Contains(mustReadFile(t, repoPre), "# updated-by-fake-pre-commit") {
 		t.Fatalf("repo pre-commit config was not updated by fake pre-commit")
@@ -183,10 +188,10 @@ func TestRunMicromamba_ScopeRepo(t *testing.T) {
 
 	repoEnv := filepath.Join(root, "environment.yml")
 	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
-	tplBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
+	tplProviderAssets := filepath.Join(root, "templates", "scripts", "provider-assets.txt")
 
 	originalTplEnv := mustReadFile(t, tplEnv)
-	originalTplBootstrap := mustReadFile(t, tplBootstrap)
+	originalTplProviderAssets := mustReadFile(t, tplProviderAssets)
 
 	changed, err := RunMicromamba(root, "repo", versions, true)
 	if err != nil {
@@ -201,8 +206,8 @@ func TestRunMicromamba_ScopeRepo(t *testing.T) {
 	if mustReadFile(t, tplEnv) != originalTplEnv {
 		t.Fatalf("template environment.yml was modified but should not have been")
 	}
-	if mustReadFile(t, tplBootstrap) != originalTplBootstrap {
-		t.Fatalf("template bootstrap was modified but should not have been")
+	if mustReadFile(t, tplProviderAssets) != originalTplProviderAssets {
+		t.Fatalf("template provider assets were modified but should not have been")
 	}
 }
 
@@ -213,10 +218,10 @@ func TestRunMicromamba_ScopeTemplates(t *testing.T) {
 
 	repoEnv := filepath.Join(root, "environment.yml")
 	tplEnv := filepath.Join(root, "templates", "languages", "go", "providers", "micromamba", "environment.yml")
-	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
+	repoProviderAssets := filepath.Join(root, "scripts", "provider-assets.txt")
 
 	originalRepoEnv := mustReadFile(t, repoEnv)
-	originalRepoBootstrap := mustReadFile(t, repoBootstrap)
+	originalRepoProviderAssets := mustReadFile(t, repoProviderAssets)
 
 	changed, err := RunMicromamba(root, "templates", versions, true)
 	if err != nil {
@@ -231,8 +236,8 @@ func TestRunMicromamba_ScopeTemplates(t *testing.T) {
 	if mustReadFile(t, repoEnv) != originalRepoEnv {
 		t.Fatalf("repo environment.yml was modified but should not have been")
 	}
-	if mustReadFile(t, repoBootstrap) != originalRepoBootstrap {
-		t.Fatalf("repo bootstrap was modified but should not have been")
+	if mustReadFile(t, repoProviderAssets) != originalRepoProviderAssets {
+		t.Fatalf("repo provider assets were modified but should not have been")
 	}
 }
 
@@ -294,9 +299,9 @@ func TestRunPreCommitAutoupdate_ReturnsPartialChangesOnLaterError(t *testing.T) 
 func TestRunMicromamba_ReturnsPartialChangesOnLaterError(t *testing.T) {
 	root, versions := buildTestWorkspace(t)
 
-	templateBootstrap := filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh")
-	if err := os.Chmod(templateBootstrap, 0o444); err != nil {
-		t.Fatalf("failed to chmod template bootstrap: %v", err)
+	templateProviderAssets := filepath.Join(root, "templates", "scripts", "provider-assets.txt")
+	if err := os.Chmod(templateProviderAssets, 0o444); err != nil {
+		t.Fatalf("failed to chmod template provider assets: %v", err)
 	}
 
 	changed, err := RunMicromamba(root, "all", versions, true)
@@ -305,8 +310,8 @@ func TestRunMicromamba_ReturnsPartialChangesOnLaterError(t *testing.T) {
 	}
 
 	repoEnv := filepath.Join(root, "environment.yml")
-	repoBootstrap := filepath.Join(root, "scripts", "bootstrap-provider-binary.sh")
-	if !containsAll(changed, repoEnv, repoBootstrap) {
+	repoProviderAssets := filepath.Join(root, "scripts", "provider-assets.txt")
+	if !containsAll(changed, repoEnv, repoProviderAssets) {
 		t.Fatalf("expected partial changed set to keep earlier repo updates, got %v", changed)
 	}
 }

--- a/tools/pkg/toolinglib/layout.go
+++ b/tools/pkg/toolinglib/layout.go
@@ -33,8 +33,10 @@ func VerifyWorkspaceLayout(root string) error {
 		filepath.Join(root, "environment.yml"),
 		filepath.Join(root, "mise.toml"),
 		filepath.Join(root, "scripts", "bootstrap-provider-binary.sh"),
+		filepath.Join(root, "scripts", "provider-assets.txt"),
 		filepath.Join(root, ".pre-commit-config.yaml"),
 		filepath.Join(root, "templates", "scripts", "bootstrap-provider-binary.sh"),
+		filepath.Join(root, "templates", "scripts", "provider-assets.txt"),
 	}
 	missing := make([]string, 0)
 	for _, p := range requiredFiles {

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -193,12 +193,23 @@ func HasTOMLAssignment(text string, key string) (bool, error) {
 	return re.MatchString(text), nil
 }
 
-func UpdateBootstrapScriptText(text string, providerData map[string]ProviderAsset) (string, error) {
+func parseProviderKey(key string) (string, string, string, error) {
+	parts := strings.Split(key, ":")
+	if len(parts) != 3 {
+		return "", "", "", fmt.Errorf("invalid provider asset key: %s", key)
+	}
+	return parts[0], parts[1], parts[2], nil
+}
+
+func UpdateProviderAssetManifestText(text string, providerData map[string]ProviderAsset) (string, error) {
 	updated := text
 	for key, values := range providerData {
-		caseLabel := regexp.QuoteMeta(key)
-		pattern := fmt.Sprintf(`(%s\)\n\s*url=")[^"]+("\n\s*sha256=")[^"]+(")`, caseLabel)
-		replacement := fmt.Sprintf(`${1}%s${2}%s${3}`, values.URL, values.SHA256)
+		provider, osName, arch, err := parseProviderKey(key)
+		if err != nil {
+			return "", err
+		}
+		pattern := fmt.Sprintf(`(?m)^%s\s+%s\s+%s\s+\S+\s+\S+\s*$`, regexp.QuoteMeta(provider), regexp.QuoteMeta(osName), regexp.QuoteMeta(arch))
+		replacement := fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256)
 		next, err := ReplaceOrFail(pattern, replacement, updated)
 		if err != nil {
 			return "", err

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -209,7 +209,7 @@ func UpdateProviderAssetManifestText(text string, providerData map[string]Provid
 			return "", err
 		}
 		pattern := fmt.Sprintf(`(?m)^%s\s+%s\s+%s\s+\S+\s+\S+\s*$`, regexp.QuoteMeta(provider), regexp.QuoteMeta(osName), regexp.QuoteMeta(arch))
-		replacement := fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256)
+		replacement := regexp.QuoteReplacement(fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256))
 		next, err := ReplaceOrFail(pattern, replacement, updated)
 		if err != nil {
 			return "", err

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -209,12 +209,17 @@ func UpdateProviderAssetManifestText(text string, providerData map[string]Provid
 			return "", err
 		}
 		pattern := fmt.Sprintf(`(?m)^%s\s+%s\s+%s\s+\S+\s+\S+\s*$`, regexp.QuoteMeta(provider), regexp.QuoteMeta(osName), regexp.QuoteMeta(arch))
-		replacement := fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256)
-		next, err := ReplaceOrFail(pattern, replacement, updated)
+		re, err := regexp.Compile(pattern)
 		if err != nil {
 			return "", err
 		}
-		updated = next
+		if !re.MatchString(updated) {
+			return "", fmt.Errorf("expected pattern not found: %s", pattern)
+		}
+		replacement := fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256)
+		updated = re.ReplaceAllStringFunc(updated, func(_ string) string {
+			return replacement
+		})
 	}
 	return updated, nil
 }

--- a/tools/pkg/toolinglib/transform.go
+++ b/tools/pkg/toolinglib/transform.go
@@ -209,7 +209,7 @@ func UpdateProviderAssetManifestText(text string, providerData map[string]Provid
 			return "", err
 		}
 		pattern := fmt.Sprintf(`(?m)^%s\s+%s\s+%s\s+\S+\s+\S+\s*$`, regexp.QuoteMeta(provider), regexp.QuoteMeta(osName), regexp.QuoteMeta(arch))
-		replacement := regexp.QuoteReplacement(fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256))
+		replacement := fmt.Sprintf("%s %s %s %s %s", provider, osName, arch, values.URL, values.SHA256)
 		next, err := ReplaceOrFail(pattern, replacement, updated)
 		if err != nil {
 			return "", err

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -177,19 +177,16 @@ func TestUpdateMiseTextUpdatesRuntimePinsWhenPresent(t *testing.T) {
 	}
 }
 
-func TestUpdateBootstrapScriptText(t *testing.T) {
-	source := "case \"$provider:$os:$arch\" in\n    mise:linux:x64)\n        url=\"https://example.invalid/old\"\n        sha256=\"old\"\n        ;;\nesac\n"
-	updated, err := UpdateBootstrapScriptText(source, map[string]ProviderAsset{
+func TestUpdateProviderAssetManifestText(t *testing.T) {
+	source := "# provider os arch url sha256\nmise linux x64 https://example.invalid/old old\n"
+	updated, err := UpdateProviderAssetManifestText(source, map[string]ProviderAsset{
 		"mise:linux:x64": {URL: "https://example.invalid/new", SHA256: "abc123"},
 	})
 	if err != nil {
-		t.Fatalf("UpdateBootstrapScriptText returned error: %v", err)
+		t.Fatalf("UpdateProviderAssetManifestText returned error: %v", err)
 	}
-	if !strings.Contains(updated, `url="https://example.invalid/new"`) {
-		t.Fatalf("expected updated url, got: %s", updated)
-	}
-	if !strings.Contains(updated, `sha256="abc123"`) {
-		t.Fatalf("expected updated sha256, got: %s", updated)
+	if !strings.Contains(updated, "mise linux x64 https://example.invalid/new abc123") {
+		t.Fatalf("expected updated provider asset row, got: %s", updated)
 	}
 }
 

--- a/tools/pkg/toolinglib/transform_test.go
+++ b/tools/pkg/toolinglib/transform_test.go
@@ -190,6 +190,26 @@ func TestUpdateProviderAssetManifestText(t *testing.T) {
 	}
 }
 
+func TestUpdateProviderAssetManifestTextInvalidKey(t *testing.T) {
+	source := "# provider os arch url sha256\nmise linux x64 https://example.invalid/old old\n"
+	_, err := UpdateProviderAssetManifestText(source, map[string]ProviderAsset{
+		"mise:linux": {URL: "https://example.invalid/new", SHA256: "abc123"},
+	})
+	if err == nil {
+		t.Fatal("expected error for invalid provider key")
+	}
+}
+
+func TestUpdateProviderAssetManifestTextMissingRow(t *testing.T) {
+	source := "# provider os arch url sha256\nmise linux x64 https://example.invalid/old old\n"
+	_, err := UpdateProviderAssetManifestText(source, map[string]ProviderAsset{
+		"mise:linux:arm64": {URL: "https://example.invalid/new", SHA256: "abc123"},
+	})
+	if err == nil {
+		t.Fatal("expected error when provider row is missing")
+	}
+}
+
 func TestUpdateFilePreservesPermissions(t *testing.T) {
 	tmp, err := os.CreateTemp(t.TempDir(), "bootstrap-*.sh")
 	if err != nil {


### PR DESCRIPTION
## Summary
- move provider binary URL/SHA pins into shared manifest files under scripts and templates
- update runtime bootstrap scripts to resolve provider assets from the manifest instead of hardcoded case blocks
- update tooling updater logic to patch manifest entries directly and keep workspace layout verification aligned
- ensure generated repositories include the provider-assets manifest
- update tooling tests to validate manifest update behavior

## Validation
- make lint
- ENV_MANAGER=micromamba make tooling-verify


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added manifest-based provider asset updates for supported downloads on Linux and macOS, covering both x64 and arm64 builds.
  * Included new provider asset files in generated repositories and templates.

* **Bug Fixes**
  * Improved provider binary bootstrap reliability by validating asset metadata before download.
  * Added clearer failures when a requested provider, OS, or architecture isn’t supported.
  * Workspace checks now ensure required provider asset files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->