### PR TITLE
fix: restore lint and address security review findings

### DIFF
--- a/.github/actions/apply-repo-settings/action.yml
+++ b/.github/actions/apply-repo-settings/action.yml
@@ -63,6 +63,8 @@ runs:
         MANAGE_ENVIRONMENTS: ${{ inputs.manage_environments }}
         ENABLE_DEPENDABOT: ${{ inputs.enable_dependabot }}
       run: |
+        set -euo pipefail
+
         case "$ENABLE" in
           "true") ;;
           *)
@@ -80,7 +82,15 @@ runs:
               echo "::error::Missing repository settings payload: $REPO_SETTINGS_FILE"
           exit 1
         fi
-        jq -e 'type == "object" and .default_branch == "main" and .has_wiki == false and .has_issues == true and .has_projects == true and .allow_auto_merge == false' "$REPO_SETTINGS_FILE" >/dev/null
+        jq -e '
+          type == "object" and .default_branch == "main" and
+          .has_wiki == false and .has_issues == true and .has_projects == true and
+          .allow_auto_merge == false and .allow_squash_merge == true and
+          .allow_merge_commit == false and .allow_rebase_merge == false and
+          .allow_update_branch == true and .delete_branch_on_merge == true and
+          .squash_merge_commit_title == "PR_TITLE" and
+          .squash_merge_commit_message == "COMMIT_MESSAGES"
+        ' "$REPO_SETTINGS_FILE" >/dev/null
             gh api \
               --method PATCH \
               -H "Accept: application/vnd.github+json" \

--- a/.github/actions/apply-security-settings/action.yml
+++ b/.github/actions/apply-security-settings/action.yml
@@ -46,7 +46,15 @@ runs:
           echo "::error::Security settings file not found: $SECURITY_FILE"
           exit 1
         fi
-        jq -e 'type == "object" and all(to_entries[]; .value == "enabled" or .value == "disabled" or (.key == "private_vulnerability_reporting" and .value == "best-effort"))' "$SECURITY_FILE" >/dev/null
+        jq -e '
+          type == "object" and
+          ((keys_unsorted | sort) == [
+            "automated_security_fixes", "dependency_graph", "private_vulnerability_reporting",
+            "secret_scanning", "secret_scanning_push_protection", "vulnerability_alerts"
+          ]) and
+          all(to_entries[]; .value == "enabled" or .value == "disabled" or
+            (.key == "private_vulnerability_reporting" and .value == "best-effort"))
+        ' "$SECURITY_FILE" >/dev/null
 
         enabled_count=0
         skipped_count=0

--- a/.github/actions/resolve-gh-token/action.yml
+++ b/.github/actions/resolve-gh-token/action.yml
@@ -107,7 +107,7 @@ runs:
     - name: Create GitHub App installation token
       id: app-token
       if: steps.validate-auth-mode.outputs.mode == 'app'
-      uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+      uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
         client-id: ${{ inputs.app_id }}
         private-key: ${{ inputs.app_private_key }}

--- a/.github/workflows/ai-code-review.yml
+++ b/.github/workflows/ai-code-review.yml
@@ -39,7 +39,8 @@ permissions:
 jobs:
   claude-review:
     name: Claude AI Review
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
 
     # Run when:
     #   1. A PR is opened/updated (non-draft, no skip-ai-review label)
@@ -80,9 +81,11 @@ jobs:
         uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-
-          # Direct Claude to focus on high-impact issues only
           prompt: |
+            REPOSITORY: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            # Direct Claude to focus on high-impact issues only
             Review this pull request focusing ONLY on high-impact issues:
 
             1. **Security vulnerabilities** — injection, auth bypass, secrets exposure, unsafe deserialization, path traversal, XSS, CSRF

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,12 +16,16 @@ permissions: {}
 
 jobs:
   analyze:
-    name: Analyze (actions)
+    name: Analyze (${{ matrix.language }})
     runs-on: ubuntu-24.04
     permissions:
       actions: read
       contents: read
       security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
     steps:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -30,9 +34,12 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
-          languages: actions, python
+          languages: ${{ matrix.language }}
           queries: security-extended
+      - name: Autobuild
+        if: matrix.language != 'actions'
+        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         with:
-          category: "/language:actions-python"
+          category: "/language:${{ matrix.language }}"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,8 +8,10 @@
 
 ## Reporting a Vulnerability
 
-The main-branch policy requires cryptographically signed commits and
-`Signed-off-by` trailers. GitHub may be unable to create a verified squash
+The main-branch policy requires cryptographically signed commits. The generated
+`Signed-off-by trailers` workflow validates every pull request; it becomes a
+merge requirement when its exact check name is supplied to the ruleset setup.
+GitHub may be unable to create a verified squash
 commit when a contributor other than the pull-request author performs the
 merge; in that case, the contributor may need to create a locally signed
 squash commit.

--- a/scripts/github-setup/setup-security-settings.sh
+++ b/scripts/github-setup/setup-security-settings.sh
@@ -64,8 +64,16 @@ validate_inputs() {
     require_owner_repo
     require_github_owner_repo_names
     require_file "$security_file" "security file"
-    if ! jq -e 'all(to_entries[]; .value == "enabled" or .value == "disabled" or (.key == "private_vulnerability_reporting" and .value == "best-effort"))' "$security_file" > /dev/null; then
-        echo "security controls must be enabled or disabled; only private_vulnerability_reporting may be best-effort" >&2
+    if ! jq -e '
+        type == "object" and
+        ((keys_unsorted | sort) == [
+            "automated_security_fixes", "dependency_graph", "private_vulnerability_reporting",
+            "secret_scanning", "secret_scanning_push_protection", "vulnerability_alerts"
+        ]) and
+        all(to_entries[]; .value == "enabled" or .value == "disabled" or
+            (.key == "private_vulnerability_reporting" and .value == "best-effort"))
+    ' "$security_file" > /dev/null; then
+        echo "security payload must contain exactly the supported controls with valid values" >&2
         exit 1
     fi
 }
@@ -122,6 +130,9 @@ apply_security_and_analysis() {
     rm -f "$payload"
     if [ "$value" = "best-effort" ]; then
         echo "warning: $key unsupported or unavailable for this repository" >&2
+        if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+            echo "⚠️ $key unavailable; skipped because the repository plan may not support private vulnerability reporting." >> "$GITHUB_STEP_SUMMARY"
+        fi
         return 0
     fi
     echo "failed to enable $key" >&2

--- a/templates/.github/workflows/codeql.yml
+++ b/templates/.github/workflows/codeql.yml
@@ -55,7 +55,7 @@ jobs:
         run: |
           case "${{ matrix.language }}" in
             "actions")
-              PATTERN='\.github/workflows/.*\.ya?ml$'
+              PATTERN='\.github/(workflows/.*\.ya?ml|actions/.*/action\.ya?ml)$'
               ;;
             "python")
               PATTERN='\.py$'

--- a/templates/.github/workflows/git-cliff-release.yml
+++ b/templates/.github/workflows/git-cliff-release.yml
@@ -69,7 +69,8 @@ jobs:
             echo "CHANGELOG.md unchanged, nothing to commit"
           else
             git commit -m "chore(release): update CHANGELOG.md for ${{ github.ref_name }} [skip ci]"
-            git push origin HEAD:${{ github.event.repository.default_branch }}
+            git -c http.extraheader="AUTHORIZATION: bearer ${{ secrets.GITHUB_TOKEN }}" \
+              push origin HEAD:${{ github.event.repository.default_branch }}
           fi
 
       - name: Create GitHub Release

--- a/templates/.github/workflows/lint.yml
+++ b/templates/.github/workflows/lint.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Set up micromamba environment
         if: env.ENV_MANAGER == 'micromamba'
-        uses: mamba-org/setup-micromamba@5d5dbebd87f7b9358c403c7a66651fa92b310105 # v1.4.1
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
         with:
           environment-file: environment.yml
           environment-name: "{{REPOSITORY_NAME}}"

--- a/templates/.github/workflows/providers/lint-micromamba.yml
+++ b/templates/.github/workflows/providers/lint-micromamba.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 0
 
       - name: Setup provider (micromamba)
-        uses: mamba-org/setup-micromamba@5d5dbebd87f7b9358c403c7a66651fa92b310105 # v1.4.1
+        uses: mamba-org/setup-micromamba@ce51e99f4bb8a82ab7158c4dc59ef4634c59c4f9 # v3.1.0
         with:
           environment-file: environment.yml
           environment-name: "{{REPOSITORY_NAME}}"

--- a/templates/SECURITY.md
+++ b/templates/SECURITY.md
@@ -8,8 +8,10 @@
 
 ## Reporting a Vulnerability
 
-The main-branch policy requires cryptographically signed commits and
-`Signed-off-by` trailers. GitHub may be unable to create a verified squash
+The main-branch policy requires cryptographically signed commits. The generated
+`Signed-off-by trailers` workflow validates every pull request; it becomes a
+merge requirement when its exact check name is supplied to the ruleset setup.
+GitHub may be unable to create a verified squash
 commit when a contributor other than the pull-request author performs the
 merge; in that case, the contributor may need to create a locally signed
 squash commit.


### PR DESCRIPTION
Adds the focused follow-up fixes after the bootstrap tests layer: restores registered lint jobs, updates micromamba, hardens validation, fixes CodeQL categories, and addresses review findings.

Depends on #71, #72, #73, and #74.