### PR TITLE
ci: refresh generated action pins

### DIFF
--- a/templates/.github/workflows/ai-code-review.yml
+++ b/templates/.github/workflows/ai-code-review.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Run Claude Code Review
         if: steps.check-key.outputs.has_key == 'true'
-        uses: anthropics/claude-code-action@0d1933529914177075d5bc3558ae3d047f188146 # v1.0.26
+        uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 

--- a/templates/.github/workflows/git-cliff-release.yml
+++ b/templates/.github/workflows/git-cliff-release.yml
@@ -74,7 +74,7 @@ jobs:
           fi
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631 # v2.2.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           name: ${{ github.ref_name }}
           body_path: RELEASE_NOTES.md

--- a/templates/.github/workflows/lint.yml
+++ b/templates/.github/workflows/lint.yml
@@ -64,7 +64,7 @@ jobs:
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/templates/.github/workflows/providers/lint-micromamba.yml
+++ b/templates/.github/workflows/providers/lint-micromamba.yml
@@ -37,7 +37,7 @@ jobs:
           cache-downloads: true
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/templates/.github/workflows/providers/lint-mise.yml
+++ b/templates/.github/workflows/providers/lint-mise.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/setup-lint-mise
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/templates/.github/workflows/providers/lint-system.yml
+++ b/templates/.github/workflows/providers/lint-system.yml
@@ -32,7 +32,7 @@ jobs:
         uses: ./.github/actions/setup-lint-system
 
       - name: Cache pre-commit hook environments
-        uses: actions/cache@a7833574556fa59680c1b7cb190c1735db73ebf0 # v5.0.0
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.cache/pre-commit
           key: pre-commit-${{ runner.os }}-${{ hashFiles('.pre-commit-config.yaml') }}

--- a/templates/.github/workflows/semantic-release.yml
+++ b/templates/.github/workflows/semantic-release.yml
@@ -35,7 +35,7 @@ jobs:
           token: ${{ github.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.0.0
+        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: lts/*
 


### PR DESCRIPTION
Refreshes stale third-party action pins in generated workflow templates using API-verified commit SHAs and release comments.

Depends on the bootstrap pin layer and #75.