### PR TITLE
feat(auth): require scoped GitHub App tokens

### DIFF
--- a/.github/actions/audit-bootstrap-request/action.yml
+++ b/.github/actions/audit-bootstrap-request/action.yml
@@ -44,11 +44,18 @@ runs:
         OWNER: ${{ inputs.owner }}
         AUTH_MODE: ${{ inputs.auth_mode }}
       run: |
+        set -euo pipefail
         OWNER_TYPE=$(gh api "/users/$OWNER" --jq '.type')
         echo "Owner type: $OWNER_TYPE, Auth mode: $AUTH_MODE"
         if [ "$AUTH_MODE" = "app" ] && [ "$OWNER_TYPE" = "User" ]; then
-          ERROR_MESSAGE="GitHub App installation tokens cannot create repositories under a personal user account ('$OWNER' is a User, not an Organization)."
-          ERROR_MESSAGE+=" Use a PAT (GH_PAT secret or gh_token input) for personal account targets, or use an organization as the target repo_owner."
+          ERROR_MESSAGE="GitHub App installation tokens cannot create repositories under a personal user account ('$OWNER' is a User)."
+          ERROR_MESSAGE+=" Use an App user access token for personal-account creation."
+          echo "::error::$ERROR_MESSAGE"
+          exit 1
+        fi
+        if [ "$AUTH_MODE" = "app-user" ] && [ "$OWNER_TYPE" != "User" ]; then
+          ERROR_MESSAGE="GitHub App user access tokens are reserved for personal-account creation ('$OWNER' is $OWNER_TYPE)."
+          ERROR_MESSAGE+=" Use the installation-token mode for organization creation."
           echo "::error::$ERROR_MESSAGE"
           exit 1
         fi

--- a/.github/actions/resolve-gh-token/action.yml
+++ b/.github/actions/resolve-gh-token/action.yml
@@ -1,108 +1,109 @@
 ---
 name: Resolve GitHub Token
 description: >-
-  Resolves a GitHub token for bootstrap workflows.
-  Supports GitHub App installation tokens (recommended) with PAT fallback.
+  Resolves an isolated GitHub App installation token or user access token.
 
 inputs:
-  gh_token:
-    description: Optional user-supplied PAT from workflow_dispatch input.
-    required: false
-    default: ""
-  gh_pat_secret:
-    description: >-
-      Repository secret GH_PAT. Pass as
-      secrets.GH_PAT from the calling workflow.
-    required: false
-    default: ""
   client_id:
     description: GitHub App client ID for App-based auth.
-    required: false
-    default: ""
+    required: true
   app_private_key:
-    description: Optional GitHub App private key (PEM) for App-based auth.
+    description: GitHub App private key (PEM) for App-based auth.
     required: false
-    default: ""
+  app_user_token:
+    description: GitHub App user access token for the target personal account.
+    required: false
   app_owner:
-    description: Optional owner (user/org) to resolve the App installation token for.
+    description: Owner bound to the App installation or user access token.
+    required: true
+  target_owner:
+    description: Target repository owner; must match app_owner.
+    required: true
+  permission_profile:
+    description: Permission set required by the calling workflow phase.
+    required: true
+  repositories:
+    description: Comma- or newline-separated repository names; required except for repository-creation.
     required: false
     default: ""
 
 outputs:
   token:
-    description: Resolved and masked GitHub token (App installation token or PAT).
+    description: Resolved and masked GitHub App token.
     value: ${{ steps.finalize.outputs.token }}
   auth_mode:
-    description: Authentication mode used (app or pat).
+    description: Authentication mode used (app or app-user).
     value: ${{ steps.validate-auth-mode.outputs.mode }}
 
 runs:
   using: composite
   steps:
-    - name: Resolve PAT fallback
-      id: resolve-pat
-      shell: bash
-      env:
-        INPUT_TOKEN: ${{ inputs.gh_token }}
-        SECRET_TOKEN: ${{ inputs.gh_pat_secret }}
-      run: |
-        TOKEN="${INPUT_TOKEN:-$SECRET_TOKEN}"
-        if [ -n "$TOKEN" ]; then
-          echo "::add-mask::$TOKEN"
-        fi
-        echo "token=$TOKEN" >> $GITHUB_OUTPUT
-
-    - name: Validate authentication configuration
+    - name: Validate GitHub App configuration
       id: validate-auth-mode
       shell: bash
       env:
-        CLIENT_ID: ${{ inputs.client_id }}
+        APP_CLIENT_ID: ${{ inputs.client_id }}
         APP_PRIVATE_KEY: ${{ inputs.app_private_key }}
+        APP_USER_TOKEN: ${{ inputs.app_user_token }}
         APP_OWNER: ${{ inputs.app_owner }}
-        PAT_TOKEN: ${{ steps.resolve-pat.outputs.token }}
+        TARGET_OWNER: ${{ inputs.target_owner }}
+        PERMISSION_PROFILE: ${{ inputs.permission_profile }}
+        REPOSITORIES: ${{ inputs.repositories }}
       run: |
-        HAS_CLIENT_ID=false
-        HAS_APP_KEY=false
-        HAS_PAT=false
-
-        if [ -n "$CLIENT_ID" ]; then
-          HAS_CLIENT_ID=true
-        fi
-        if [ -n "$APP_PRIVATE_KEY" ]; then
-          HAS_APP_KEY=true
-        fi
-        if [ -n "$PAT_TOKEN" ]; then
-          HAS_PAT=true
-        fi
-
-        if [ "$HAS_CLIENT_ID" = true ] && [ "$HAS_APP_KEY" = true ]; then
-          if [ -z "$APP_OWNER" ]; then
-            echo "::error::GitHub App authentication requires the 'app_owner' input to scope the installation token to a specific tenant owner. Please provide this value."
-            exit 1
-          fi
-          echo "mode=app" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        # Only fail on partial App config when client_id was explicitly provided.
-        # If only the private key is present (e.g. a repo-level secret always injected
-        # by the caller workflow) but no client_id, fall through to PAT gracefully.
-        if [ "$HAS_CLIENT_ID" = true ] && [ "$HAS_APP_KEY" = false ]; then
-          echo "::error::Incomplete GitHub App auth config: client_id is set but app_private_key is missing. Provide both or neither."
+        set -euo pipefail
+        case "$PERMISSION_PROFILE" in
+          repository-creation|repository-setup|repository-cleanup|weekly-tooling) ;;
+          *) echo "::error::Unsupported GitHub App permission profile '$PERMISSION_PROFILE'." >&2; exit 1 ;;
+        esac
+        if [ "$PERMISSION_PROFILE" != "repository-creation" ] && [ -z "$REPOSITORIES" ]; then
+          echo "::error::Repository scoping is required for the '$PERMISSION_PROFILE' permission profile." >&2
           exit 1
         fi
-
-        if [ "$HAS_PAT" = true ]; then
-          echo "mode=pat" >> $GITHUB_OUTPUT
-          exit 0
+        if [ -n "$APP_USER_TOKEN" ]; then
+          echo "::add-mask::$APP_USER_TOKEN"
         fi
+        AUTH_MODE=owner-only bash ./scripts/github-setup/validate-app-auth.sh
+        target_owner_type="$(env -u GH_TOKEN -u GITHUB_TOKEN gh api "/users/$TARGET_OWNER" --jq '.type')"
 
-        if [ "$HAS_APP_KEY" = true ]; then
-          echo "::error::No GitHub credentials available. app_private_key is set but client_id is missing (incomplete App config). Provide client_id to use App auth, or set GH_PAT/pass gh_token for PAT auth."
-        else
-          echo "::error::No GitHub credentials available. Provide GitHub App credentials (recommended) or set GH_PAT/pass gh_token."
-        fi
-        exit 1
+        case "$target_owner_type" in
+          User)
+            if [ -z "$APP_USER_TOKEN" ]; then
+              echo "::error::Personal-account creation requires BOOTSTRAP_APP_USER_TOKEN; installation credentials cannot create a personal repository." >&2
+              exit 1
+            fi
+            case "$PERMISSION_PROFILE" in
+              repository-creation|repository-cleanup) ;;
+              *)
+                echo "::error::GitHub App user access tokens are supported only for repository creation and its explicitly scoped cleanup." >&2
+                exit 1
+                ;;
+            esac
+            case "$APP_USER_TOKEN" in
+              ghu_*) ;;
+              *)
+                echo "::error::Personal-account creation requires a GitHub App user access token (ghu_ prefix); PATs and other token types are rejected." >&2
+                exit 1
+                ;;
+            esac
+            authenticated_user="$(GH_TOKEN="$APP_USER_TOKEN" gh api /user --jq '.login')"
+            normalized_user="$(printf '%s' "$authenticated_user" | tr '[:upper:]' '[:lower:]')"
+            normalized_target="$(printf '%s' "$TARGET_OWNER" | tr '[:upper:]' '[:lower:]')"
+            if [ "$normalized_user" != "$normalized_target" ]; then
+              echo "::error::GitHub App user token belongs to '$authenticated_user', not target owner '$TARGET_OWNER'." >&2
+              exit 1
+            fi
+            AUTH_MODE=app-user bash ./scripts/github-setup/validate-app-auth.sh
+            echo "mode=app-user" >> "$GITHUB_OUTPUT"
+            ;;
+          Organization)
+            AUTH_MODE=app bash ./scripts/github-setup/validate-app-auth.sh
+            echo "mode=app" >> "$GITHUB_OUTPUT"
+            ;;
+          *)
+            echo "::error::Unable to classify target owner '$TARGET_OWNER' as a GitHub User or Organization." >&2
+            exit 1
+            ;;
+        esac
 
     - name: Create GitHub App installation token
       id: app-token
@@ -112,23 +113,30 @@ runs:
         client-id: ${{ inputs.client_id }}
         private-key: ${{ inputs.app_private_key }}
         owner: ${{ inputs.app_owner }}
+        repositories: ${{ inputs.repositories }}
+        permission-administration: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'repository-cleanup') && 'write' || '' }}
+        permission-contents: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'weekly-tooling') && 'write' || '' }}
+        permission-issues: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup') && 'write' || '' }}
+        permission-organization-administration: ${{ inputs.permission_profile == 'repository-creation' && 'write' || '' }}
+        permission-pull-requests: ${{ inputs.permission_profile == 'weekly-tooling' && 'write' || '' }}
 
     - name: Finalize token output
       id: finalize
       shell: bash
       env:
         AUTH_MODE: ${{ steps.validate-auth-mode.outputs.mode }}
-        PAT_TOKEN: ${{ steps.resolve-pat.outputs.token }}
         APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        APP_USER_TOKEN: ${{ inputs.app_user_token }}
       run: |
-        case "$AUTH_MODE" in
-          "app") TOKEN="$APP_TOKEN" ;;
-          "pat") TOKEN="$PAT_TOKEN" ;;
-          *)
-            echo "::error::Unknown auth mode '$AUTH_MODE'."
-            exit 1
-            ;;
-        esac
+        set -euo pipefail
+        if [ "$AUTH_MODE" = "app-user" ]; then
+          TOKEN="$APP_USER_TOKEN"
+        elif [ "$AUTH_MODE" = "app" ]; then
+          TOKEN="$APP_TOKEN"
+        else
+          echo "::error::Unexpected authentication mode '$AUTH_MODE'." >&2
+          exit 1
+        fi
 
         if [ -z "$TOKEN" ]; then
           echo "::error::Resolved auth mode '$AUTH_MODE' but no token was produced."
@@ -136,4 +144,4 @@ runs:
         fi
 
         echo "::add-mask::$TOKEN"
-        echo "token=$TOKEN" >> $GITHUB_OUTPUT
+        echo "token=$TOKEN" >> "$GITHUB_OUTPUT"

--- a/.github/actions/validate-bootstrap-owner/action.yml
+++ b/.github/actions/validate-bootstrap-owner/action.yml
@@ -1,15 +1,14 @@
 ---
 name: Validate Bootstrap Owner
-description: Validate the target repository owner against the optional allowlist.
+description: Validate the target repository owner against a required allowlist.
 
 inputs:
   owner:
     description: Target repository owner.
     required: true
   allowed_repo_owners:
-    description: Optional comma-separated allowlist of permitted target owners.
-    required: false
-    default: ""
+    description: Comma-separated allowlist of permitted target owners.
+    required: true
 
 runs:
   using: composite
@@ -23,8 +22,8 @@ runs:
         CLEAN_ALLOWLIST=$(printf '%s' "$ALLOWLIST" | tr '[:upper:]' '[:lower:]' | tr -d '[:space:]')
 
         if [ -z "$CLEAN_ALLOWLIST" ]; then
-          echo "No owner allowlist configured; all owners allowed."
-          exit 0
+          echo "::error::Owner allowlist is required; refusing an unrestricted target owner." >&2
+          exit 1
         fi
         OWNER_LC=$(printf '%s' "$OWNER" | tr '[:upper:]' '[:lower:]')
 

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -128,16 +128,16 @@ on:
         default: "github.com"
         type: string
       client_id:
-        description: "GitHub App client ID for App-based auth (recommended)"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner (user/org) whose GitHub App installation token should be used"
-        required: false
+        description: "Owner whose GitHub App installation or user token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of permitted target owners"
-        required: false
+        description: "Comma-separated allowlist of permitted target owners"
+        required: true
         type: string
       require_cleanup_approval:
         description: "Require environment approval before deleting a failed repo"
@@ -236,28 +236,23 @@ on:
         required: false
         default: "github.com"
         type: string
-      gh_token:
-        required: false
-        type: string
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
       require_cleanup_approval:
         required: false
         default: true
         type: boolean
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
+        required: false
+      BOOTSTRAP_APP_USER_TOKEN:
         required: false
 
 jobs:
@@ -298,21 +293,26 @@ jobs:
 
       - name: Set repository owner
         id: set-owner
+        env:
+          INPUT_REPO_OWNER: ${{ inputs.repo_owner }}
+          DEFAULT_REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ inputs.repo_owner }}" ]; then
-            echo "owner=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+          if [ -z "$INPUT_REPO_OWNER" ]; then
+            echo "owner=$DEFAULT_REPO_OWNER" >> "$GITHUB_OUTPUT"
           else
-            echo "owner=${{ inputs.repo_owner }}" >> $GITHUB_OUTPUT
+            echo "owner=$INPUT_REPO_OWNER" >> "$GITHUB_OUTPUT"
           fi
-          echo "repo_created=false" >> $GITHUB_OUTPUT
 
       - name: Set license holder
         id: set-license
+        env:
+          INPUT_LICENSE_HOLDER: ${{ inputs.license_holder }}
+          DEFAULT_LICENSE_HOLDER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ inputs.license_holder }}" ]; then
-            echo "holder=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+          if [ -z "$INPUT_LICENSE_HOLDER" ]; then
+            echo "holder=$DEFAULT_LICENSE_HOLDER" >> "$GITHUB_OUTPUT"
           else
-            echo "holder=${{ inputs.license_holder }}" >> $GITHUB_OUTPUT
+            echo "holder=$INPUT_LICENSE_HOLDER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate bootstrap inputs
@@ -437,11 +437,19 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || steps.set-owner.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ steps.set-owner.outputs.owner }}
+          permission_profile: repository-creation
+
+      - name: Reject internal visibility for personal accounts
+        if: steps.resolve-token.outputs.auth_mode == 'app-user' && inputs.visibility == 'internal'
+        shell: bash
+        run: |
+          echo "::error::Internal visibility is supported only for organization repositories; personal-account repositories must use public or private visibility." >&2
+          exit 1
 
       - name: Audit bootstrap request
         uses: ./.github/actions/audit-bootstrap-request
@@ -455,28 +463,21 @@ jobs:
         id: create-repo
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ steps.set-owner.outputs.owner }}
+          AUTH_MODE: ${{ steps.resolve-token.outputs.auth_mode }}
+          VISIBILITY: ${{ inputs.visibility }}
+          REPO_NAME: ${{ inputs.repo_name }}
+          REPO_DESC: ${{ inputs.repo_description }}
         run: |
-          OWNER="${{ steps.set-owner.outputs.owner }}"
-          VISIBILITY="${{ inputs.visibility }}"
-
+          set -euo pipefail
           # Determine if creating under user or organization
-          if [ "$OWNER" = "${{ github.repository_owner }}" ]; then
-            # Check if it's a user or organization
-            ORG_TYPE=$(gh api /users/$OWNER --jq '.type')
-            if [ "$ORG_TYPE" = "Organization" ]; then
-              ENDPOINT="/orgs/$OWNER/repos"
-            else
-              ENDPOINT="/user/repos"
-            fi
+          if [ "$AUTH_MODE" = "app-user" ]; then
+            ENDPOINT="/user/repos"
           else
-            # Assume organization if owner is specified
             ENDPOINT="/orgs/$OWNER/repos"
           fi
 
           # Create repository with appropriate visibility
-          REPO_NAME="${{ inputs.repo_name }}"
-          REPO_DESC="${{ inputs.repo_description }}"
-
           if [ "$ENDPOINT" = "/user/repos" ]; then
             # User repos: use 'private' field (boolean)
             if [ "$VISIBILITY" = "public" ]; then
@@ -509,7 +510,7 @@ jobs:
               "$ENDPOINT" \
               --input -
           fi
-          echo "repo_created=true" >> $GITHUB_OUTPUT
+            echo "repo_created=true" >> "$GITHUB_OUTPUT"
 
       - name: Wait for repository initialization
         run: sleep 5
@@ -517,9 +518,12 @@ jobs:
       - name: Clone new repository
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ steps.set-owner.outputs.owner }}
+          REPO_NAME: ${{ inputs.repo_name }}
         run: |
-          git clone https://x-access-token:${GH_TOKEN}@${GH_HOST}/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}.git new-repo
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" clone "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git" new-repo
           cd new-repo
+          git remote set-url origin "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -561,12 +565,12 @@ jobs:
           case "$RELEASE_TOOL" in
             "release-please")
               rm -f $GC_FILES
-              echo "Release tool: **release-please** — PR-based semantic versioning (language-aware, ~7k ⭐)" >> $GITHUB_STEP_SUMMARY
+              echo "Release tool: **release-please** — PR-based semantic versioning (language-aware, ~7k ⭐)" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
               # Default: git-cliff
               rm -f $RP_FILES
-              echo "Release tool: **git-cliff** — tag-triggered changelog + GitHub Release (any language, ~9k ⭐)" >> $GITHUB_STEP_SUMMARY
+              echo "Release tool: **git-cliff** — tag-triggered changelog + GitHub Release (any language, ~9k ⭐)" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
@@ -644,7 +648,7 @@ jobs:
           case "$WORKFLOWS_INPUT" in
             "all"|"")
               echo "quality_kept=true" >> "$GITHUB_OUTPUT"
-              echo "Keeping all workflows" >> $GITHUB_STEP_SUMMARY
+              echo "Keeping all workflows" >> "$GITHUB_STEP_SUMMARY"
               exit 0
               ;;
           esac
@@ -674,7 +678,7 @@ jobs:
                     esac
                     ;;
                   *)
-                    echo "⚠️ Unknown workflow name: '$name' (valid: quality, codeql, ai-code-review, release; signed-off-by is always included)" >> $GITHUB_STEP_SUMMARY
+                    echo "⚠️ Unknown workflow name: '$name' (valid: quality, codeql, ai-code-review, release; signed-off-by is always included)" >> "$GITHUB_STEP_SUMMARY"
                     ;;
                 esac
               done
@@ -691,7 +695,7 @@ jobs:
             filename=$(basename "$file")
             [[ " $KEEP_FILES " == *" $filename "* ]] && continue
             rm -f "$file"
-            echo "⏭️ Skipped workflow: $filename" >> $GITHUB_STEP_SUMMARY
+            echo "⏭️ Skipped workflow: $filename" >> "$GITHUB_STEP_SUMMARY"
           done
 
           echo "quality_kept=$QUALITY_KEPT" >> "$GITHUB_OUTPUT"
@@ -701,40 +705,66 @@ jobs:
             case "${{ inputs.release_tool }}" in
               "release-please")
                 rm -f release-please-config.json .release-please-manifest.json
-                echo "⏭️ Removed release-please config files" >> $GITHUB_STEP_SUMMARY
+                echo "⏭️ Removed release-please config files" >> "$GITHUB_STEP_SUMMARY"
                 ;;
               *)
                 rm -f cliff.toml
-                echo "⏭️ Removed git-cliff config file" >> $GITHUB_STEP_SUMMARY
+                echo "⏭️ Removed git-cliff config file" >> "$GITHUB_STEP_SUMMARY"
                 ;;
             esac
           fi
 
       - name: Configure CODEOWNERS
+        env:
+          ENABLE_CODEOWNERS: ${{ inputs.enable_codeowners }}
+          TEAM_NAME: ${{ inputs.team_name }}
         run: |
           cd new-repo
-          case "${{ inputs.enable_codeowners }}" in
+          case "$ENABLE_CODEOWNERS" in
             "true")
-              sed -i "s/team-leads/${{ inputs.team_name }}/g" .github/CODEOWNERS
+              TEAM_NAME="$TEAM_NAME" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path(".github/CODEOWNERS")
+          path.write_text(path.read_text().replace("team-leads", os.environ["TEAM_NAME"]))
+          PY
               ;;
             *)
               rm -f .github/CODEOWNERS
-              echo "⏭️ CODEOWNERS skipped" >> $GITHUB_STEP_SUMMARY
+              echo "⏭️ CODEOWNERS skipped" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
       - name: Update LICENSE with current year and holder
+        env:
+          LICENSE_HOLDER: ${{ steps.set-license.outputs.holder }}
         run: |
           cd new-repo
-          CURRENT_YEAR=$(date +%Y)
-          sed -i "s/\[year\]/$CURRENT_YEAR/g" LICENSE
-          sed -i "s/\[fullname\]/${{ steps.set-license.outputs.holder }}/g" LICENSE
+          CURRENT_YEAR=$(date +%Y) LICENSE_HOLDER="$LICENSE_HOLDER" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path("LICENSE")
+          text = path.read_text()
+          text = text.replace("[year]", os.environ["CURRENT_YEAR"])
+          path.write_text(text.replace("[fullname]", os.environ["LICENSE_HOLDER"]))
+          PY
 
       - name: Update README with repository details
+        env:
+          REPOSITORY_OWNER: ${{ steps.set-owner.outputs.owner }}
+          REPOSITORY_NAME: ${{ inputs.repo_name }}
         run: |
           cd new-repo
-          sed -i "s/{{REPOSITORY_OWNER}}/${{ steps.set-owner.outputs.owner }}/g" README.md
-          sed -i "s/{{REPOSITORY_NAME}}/${{ inputs.repo_name }}/g" README.md
+          REPOSITORY_OWNER="$REPOSITORY_OWNER" REPOSITORY_NAME="$REPOSITORY_NAME" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path("README.md")
+          text = path.read_text().replace("{{REPOSITORY_OWNER}}", os.environ["REPOSITORY_OWNER"])
+          path.write_text(text.replace("{{REPOSITORY_NAME}}", os.environ["REPOSITORY_NAME"]))
+          PY
 
       - name: Log language tooling selection
         run: |
@@ -777,12 +807,14 @@ jobs:
 
       - name: Commit and push files
         id: push-files
+        env:
+          GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
         run: |
           cd new-repo
           git add .
           git commit -m "chore: initialize repository from bootstrap template"
-          git push
-          echo "✅ Template files pushed" >> $GITHUB_STEP_SUMMARY
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" push
+          echo "✅ Template files pushed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Apply repository settings
         uses: ./.github/actions/apply-repo-settings
@@ -802,74 +834,74 @@ jobs:
 
       - name: Summary
         run: |
-          echo "✅ Repository created successfully!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository:** https://github.com/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Visibility:** ${{ inputs.visibility }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Languages:** ${{ steps.validate-inputs.outputs.languages }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment manager:** ${{ steps.validate-inputs.outputs.env_manager }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Runtime versions:** python=${{ steps.validate-inputs.outputs.python_version }}, node=${{ steps.validate-inputs.outputs.node_version }}, go=${{ steps.validate-inputs.outputs.go_version }}, java=${{ steps.validate-inputs.outputs.java_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Release tool:** ${{ inputs.release_tool || 'git-cliff' }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Created Resources" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Repository created successfully!" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Repository:** https://github.com/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Visibility:** ${{ inputs.visibility }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Languages:** ${{ steps.validate-inputs.outputs.languages }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Environment manager:** ${{ steps.validate-inputs.outputs.env_manager }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Runtime versions:** python=${{ steps.validate-inputs.outputs.python_version }}, node=${{ steps.validate-inputs.outputs.node_version }}, go=${{ steps.validate-inputs.outputs.go_version }}, java=${{ steps.validate-inputs.outputs.java_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release tool:** ${{ inputs.release_tool || 'git-cliff' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Created Resources" >> "$GITHUB_STEP_SUMMARY"
 
           case "${{ inputs.enable_codeowners }}" in
-            "true") echo "- ✅ CODEOWNERS" >> $GITHUB_STEP_SUMMARY ;;
-            *)      echo "- ⏭️ CODEOWNERS (skipped)" >> $GITHUB_STEP_SUMMARY ;;
+            "true") echo "- ✅ CODEOWNERS" >> "$GITHUB_STEP_SUMMARY" ;;
+            *)      echo "- ⏭️ CODEOWNERS (skipped)" >> "$GITHUB_STEP_SUMMARY" ;;
           esac
 
           case "${{ inputs.enable_repo_settings }}" in
             "true")
-              echo "- ✅ Vulnerability alerts and Dependabot security updates enabled" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Development environment" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Production environment" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Vulnerability alerts and Dependabot security updates enabled" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Development environment" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Production environment" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
-              echo "- ⏭️ Vulnerability alerts and Dependabot security updates (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Development environment (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Production environment (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
+              echo "- ⏭️ Vulnerability alerts and Dependabot security updates (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Development environment (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Production environment (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
-          echo "- ✅ Dependabot configuration" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Dependabot configuration" >> "$GITHUB_STEP_SUMMARY"
 
-          echo "- ✅ .editorconfig (4 spaces code, 2 spaces config)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ .gitignore, .gitattributes" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Documentation templates" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ SECURITY.md (security policy)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ CONTRIBUTING.md (contribution guide)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ LICENSE (MIT)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ .editorconfig (4 spaces code, 2 spaces config)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ .gitignore, .gitattributes" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Documentation templates" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ SECURITY.md (security policy)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ CONTRIBUTING.md (contribution guide)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ LICENSE (MIT)" >> "$GITHUB_STEP_SUMMARY"
           if [ -f new-repo/environment.yml ]; then
-            echo "- ✅ provider/micromamba config selected (environment.yml)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/micromamba config selected (environment.yml)" >> "$GITHUB_STEP_SUMMARY"
           elif [ -f new-repo/mise.toml ]; then
-            echo "- ✅ provider/mise config selected (mise.toml)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/mise config selected (mise.toml)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ✅ provider/system config selected (Makefile only)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/system config selected (Makefile only)" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- ✅ .pre-commit-config.yaml (all language: system hooks)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Conventional commits (pre-commit)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Makefile (run 'make lint' locally)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ .pre-commit-config.yaml (all language: system hooks)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Conventional commits (pre-commit)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Makefile (run 'make lint' locally)" >> "$GITHUB_STEP_SUMMARY"
 
           case "${{ inputs.workflows }}" in
             "all"|"")
-              echo "- ✅ Quality workflow (${{ steps.validate-inputs.outputs.env_manager }} + selected capabilities)" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Quality workflow (${{ steps.validate-inputs.outputs.env_manager }} + selected capabilities)" >> "$GITHUB_STEP_SUMMARY"
               case "${{ inputs.release_tool }}" in
                 "release-please")
-                  echo "- ✅ Release Please workflow (PR-based semantic versioning)" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ Release Please workflow (PR-based semantic versioning)" >> "$GITHUB_STEP_SUMMARY"
                   ;;
                 *)
-                  echo "- ✅ git-cliff release workflow (tag-based changelog + GitHub Release)" >> $GITHUB_STEP_SUMMARY
-                  echo "- ✅ cliff.toml (changelog configuration)" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ git-cliff release workflow (tag-based changelog + GitHub Release)" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- ✅ cliff.toml (changelog configuration)" >> "$GITHUB_STEP_SUMMARY"
                   ;;
               esac
               ;;
             "none")
-              echo "- ⏭️ All workflows skipped" >> $GITHUB_STEP_SUMMARY
+              echo "- ⏭️ All workflows skipped" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
-              echo "- ✅ Selected workflows: ${{ inputs.workflows }}" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Selected workflows: ${{ inputs.workflows }}" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
@@ -929,22 +961,23 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || needs.create-repository.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ needs.create-repository.outputs.owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ inputs.repo_name }}
 
       - name: Delete repository on failure
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ needs.create-repository.outputs.owner }}
+          REPO: ${{ inputs.repo_name }}
         run: |
-          OWNER="${{ needs.create-repository.outputs.owner }}"
-          REPO="${{ inputs.repo_name }}"
-
           # Check if repository exists before attempting deletion
           if gh repo view "$OWNER/$REPO" &>/dev/null; then
-            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> $GITHUB_STEP_SUMMARY
+            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> "$GITHUB_STEP_SUMMARY"
 
             # Delete the repository
             gh api \
@@ -952,9 +985,9 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               /repos/$OWNER/$REPO
 
-            echo "✅ Repository deleted successfully" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Repository deleted successfully" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Repository does not exist, nothing to clean up" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Repository does not exist, nothing to clean up" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   teardown-no-approval:
@@ -991,22 +1024,23 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || needs.create-repository.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ needs.create-repository.outputs.owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ inputs.repo_name }}
 
       - name: Delete repository on failure
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ needs.create-repository.outputs.owner }}
+          REPO: ${{ inputs.repo_name }}
         run: |
-          OWNER="${{ needs.create-repository.outputs.owner }}"
-          REPO="${{ inputs.repo_name }}"
-
           # Check if repository exists before attempting deletion
           if gh repo view "$OWNER/$REPO" &>/dev/null; then
-            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> $GITHUB_STEP_SUMMARY
+            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> "$GITHUB_STEP_SUMMARY"
 
             # Delete the repository
             gh api \
@@ -1014,7 +1048,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               /repos/$OWNER/$REPO
 
-            echo "✅ Repository deleted successfully" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Repository deleted successfully" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Repository does not exist, nothing to clean up" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Repository does not exist, nothing to clean up" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/delete-repo.yml
+++ b/.github/workflows/delete-repo.yml
@@ -12,27 +12,24 @@ on:
         required: false
         default: false
         type: boolean
-      gh_token:
-        description: >-
-          Personal Access Token with delete_repo scope.
-          WARNING: This input is NOT treated as a secret — its value may be
-          visible in the run's inputs/metadata to anyone who can view the run.
-          Prefer using the repository secret GH_PAT whenever possible.
-          Only use this input when you do not have permission to set repository
-          secrets and use a short-lived token with minimum required scopes.
-        required: false
+      client_id:
+        description: GitHub App client ID.
+        required: true
+        type: string
+      app_owner:
+        description: Organization whose installation owns the repository.
+        required: true
         type: string
 
 jobs:
   delete-repo:
     runs-on: ubuntu-latest
-    # This workflow uses a personal access token (GH_PAT or gh_token input) with repo deletion permissions.
-    # Create a secret named GH_PAT with `delete_repo` scope (or an admin token) in the repository where you run this,
-    # or provide the token directly via the 'gh_token' workflow input.
     steps:
       - name: Dry-run check
+        env:
+          FORCE: ${{ github.event.inputs.force }}
         run: |
-          if [ "${{ github.event.inputs.force }}" != "true" ]; then
+          if [ "$FORCE" != "true" ]; then
             echo "Force flag is not set. This is a dry run. No deletion will occur."
             echo "To actually delete, re-run the workflow and set 'force' to true."
             exit 0
@@ -43,17 +40,44 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Validate delete target
+        id: target
+        env:
+          REPO_INPUT: ${{ inputs.repo }}
+          APP_OWNER: ${{ inputs.app_owner }}
+        run: |
+          set -euo pipefail
+          case "$REPO_INPUT" in
+            */*) ;;
+            *) echo "::error::Repository must be provided as OWNER/REPOSITORY." >&2; exit 1 ;;
+          esac
+          TARGET_OWNER="${REPO_INPUT%%/*}"
+          TARGET_REPOSITORY="${REPO_INPUT#*/}"
+          case "$TARGET_OWNER/$TARGET_REPOSITORY" in
+            */*/*|*/|/*) echo "::error::Repository must contain exactly one non-empty owner and repository." >&2; exit 1 ;;
+          esac
+          if [ "${TARGET_OWNER,,}" != "${APP_OWNER,,}" ]; then
+            echo "::error::Repository owner '$TARGET_OWNER' must match app_owner '$APP_OWNER'." >&2
+            exit 1
+          fi
+          echo "owner=$TARGET_OWNER" >> "$GITHUB_OUTPUT"
+          echo "repository=$TARGET_REPOSITORY" >> "$GITHUB_OUTPUT"
+
       - name: Resolve GitHub token
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ github.event.inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ steps.target.outputs.owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ steps.target.outputs.repository }}
 
       - name: Delete repository via REST API
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
-          REPO_FULL: ${{ inputs.repo }}
+          REPO_FULL: ${{ steps.target.outputs.owner }}/${{ steps.target.outputs.repository }}
         run: |
           echo "Deleting repository: $REPO_FULL"
           HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \

--- a/.github/workflows/setup-agent-instructions.yml
+++ b/.github/workflows/setup-agent-instructions.yml
@@ -33,16 +33,16 @@ on:
           - pull-request
           - direct
       client_id:
-        description: "GitHub App client ID for App-based auth"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner whose GitHub App installation token should be used"
-        required: false
+        description: "Organization whose GitHub App installation token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
   workflow_call:
     inputs:
@@ -60,21 +60,17 @@ on:
         default: pull-request
         type: string
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
-        required: false
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/setup-coderabbit.yml
+++ b/.github/workflows/setup-coderabbit.yml
@@ -31,16 +31,16 @@ on:
         default: false
         type: boolean
       client_id:
-        description: "GitHub App client ID for App-based auth"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner whose GitHub App installation token should be used"
-        required: false
+        description: "Organization whose GitHub App installation token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
   workflow_call:
     inputs:
@@ -63,21 +63,17 @@ on:
         default: false
         type: boolean
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
-        required: false
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/setup-existing-repository.yml
+++ b/.github/workflows/setup-existing-repository.yml
@@ -91,22 +91,17 @@ on:
         required: false
         default: github.com
         type: string
-      gh_token:
-        description: >-
-          PAT fallback. Prefer GH_PAT secret or GitHub App auth for shared usage.
-        required: false
-        type: string
       client_id:
-        description: "GitHub App client ID for App-based auth"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner whose GitHub App installation token should be used"
-        required: false
+        description: "Organization whose GitHub App installation token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
   workflow_call:
     inputs:
@@ -160,25 +155,18 @@ on:
         required: false
         default: github.com
         type: string
-      gh_token:
-        required: false
-        type: string
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
-        required: false
+        required: true
     outputs:
       labels_changed:
         description: Whether labels were created or updated.
@@ -271,11 +259,12 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || inputs.repo_owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ inputs.repo_owner }}
+          permission_profile: repository-setup
+          repositories: ${{ inputs.repo_name }}
 
       - name: Apply repository settings
         id: apply_repo_settings

--- a/.github/workflows/setup-labels-and-security.yml
+++ b/.github/workflows/setup-labels-and-security.yml
@@ -20,16 +20,16 @@ on:
           - create-missing
           - create-and-update
       client_id:
-        description: "GitHub App client ID for App-based auth"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner whose GitHub App installation token should be used"
-        required: false
+        description: "Organization whose GitHub App installation token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
   workflow_call:
     inputs:
@@ -44,21 +44,17 @@ on:
         default: create-and-update
         type: string
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
-        required: false
+        required: true
 
 permissions:
   contents: read

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -128,16 +128,16 @@ on:
         default: "github.com"
         type: string
       client_id:
-        description: "GitHub App client ID for App-based auth (recommended)"
-        required: false
+        description: "GitHub App client ID"
+        required: true
         type: string
       app_owner:
-        description: "Owner (user/org) whose GitHub App installation token should be used"
-        required: false
+        description: "Owner whose GitHub App installation or user token should be used"
+        required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of permitted target owners"
-        required: false
+        description: "Comma-separated allowlist of permitted target owners"
+        required: true
         type: string
       require_cleanup_approval:
         description: "Require environment approval before deleting a failed repo"
@@ -236,28 +236,23 @@ on:
         required: false
         default: "github.com"
         type: string
-      gh_token:
-        required: false
-        type: string
       client_id:
-        required: false
+        required: true
         type: string
       app_owner:
-        required: false
+        required: true
         type: string
       allowed_repo_owners:
-        required: false
+        required: true
         type: string
       require_cleanup_approval:
         required: false
         default: true
         type: boolean
     secrets:
-      GH_PAT:
-        required: false
-      app_private_key:
-        required: false
       BOOTSTRAP_APP_PRIVATE_KEY:
+        required: false
+      BOOTSTRAP_APP_USER_TOKEN:
         required: false
 
 jobs:
@@ -305,20 +300,26 @@ jobs:
 
       - name: Set repository owner
         id: set-owner
+        env:
+          INPUT_REPO_OWNER: ${{ inputs.repo_owner }}
+          DEFAULT_REPO_OWNER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ inputs.repo_owner }}" ]; then
-            echo "owner=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+          if [ -z "$INPUT_REPO_OWNER" ]; then
+            echo "owner=$DEFAULT_REPO_OWNER" >> "$GITHUB_OUTPUT"
           else
-            echo "owner=${{ inputs.repo_owner }}" >> $GITHUB_OUTPUT
+            echo "owner=$INPUT_REPO_OWNER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Set license holder
         id: set-license
+        env:
+          INPUT_LICENSE_HOLDER: ${{ inputs.license_holder }}
+          DEFAULT_LICENSE_HOLDER: ${{ github.repository_owner }}
         run: |
-          if [ -z "${{ inputs.license_holder }}" ]; then
-            echo "holder=${{ github.repository_owner }}" >> $GITHUB_OUTPUT
+          if [ -z "$INPUT_LICENSE_HOLDER" ]; then
+            echo "holder=$DEFAULT_LICENSE_HOLDER" >> "$GITHUB_OUTPUT"
           else
-            echo "holder=${{ inputs.license_holder }}" >> $GITHUB_OUTPUT
+            echo "holder=$INPUT_LICENSE_HOLDER" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Validate bootstrap inputs
@@ -443,11 +444,19 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || steps.set-owner.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ steps.set-owner.outputs.owner }}
+          permission_profile: repository-creation
+
+      - name: Reject internal visibility for personal accounts
+        if: steps.resolve-token.outputs.auth_mode == 'app-user' && inputs.visibility == 'internal'
+        shell: bash
+        run: |
+          echo "::error::Internal visibility is supported only for organization repositories; personal-account repositories must use public or private visibility." >&2
+          exit 1
 
       - name: Audit bootstrap request
         uses: ./.github/actions/audit-bootstrap-request
@@ -502,11 +511,13 @@ jobs:
         if: always()
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ steps.set-owner.outputs.owner }}
+          REPO_NAME: ${{ inputs.repo_name }}
         run: |
-          if gh repo view "${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}" &>/dev/null; then
-            echo "repo_created=true" >> $GITHUB_OUTPUT
+          if gh repo view "$OWNER/$REPO_NAME" &>/dev/null; then
+            echo "repo_created=true" >> "$GITHUB_OUTPUT"
           else
-            echo "repo_created=false" >> $GITHUB_OUTPUT
+            echo "repo_created=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Fail job if Terraform apply failed
@@ -519,9 +530,12 @@ jobs:
       - name: Clone new repository
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ steps.set-owner.outputs.owner }}
+          REPO_NAME: ${{ inputs.repo_name }}
         run: |
-          git clone https://x-access-token:${GH_TOKEN}@${GH_HOST}/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}.git new-repo
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" clone "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git" new-repo
           cd new-repo
+          git remote set-url origin "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
@@ -560,12 +574,12 @@ jobs:
           case "$RELEASE_TOOL" in
             "release-please")
               rm -f $GC_FILES
-              echo "Release tool: **release-please** — PR-based semantic versioning (language-aware, ~7k ⭐)" >> $GITHUB_STEP_SUMMARY
+              echo "Release tool: **release-please** — PR-based semantic versioning (language-aware, ~7k ⭐)" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
               # Default: git-cliff
               rm -f $RP_FILES
-              echo "Release tool: **git-cliff** — tag-triggered changelog + GitHub Release (any language, ~9k ⭐)" >> $GITHUB_STEP_SUMMARY
+              echo "Release tool: **git-cliff** — tag-triggered changelog + GitHub Release (any language, ~9k ⭐)" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
@@ -610,31 +624,57 @@ jobs:
           fi
 
       - name: Configure CODEOWNERS
+        env:
+          ENABLE_CODEOWNERS: ${{ inputs.enable_codeowners }}
+          TEAM_NAME: ${{ inputs.team_name }}
         run: |
           cd new-repo
-          case "${{ inputs.enable_codeowners }}" in
+          case "$ENABLE_CODEOWNERS" in
             "true")
-              sed -i "s/team-leads/${{ inputs.team_name }}/g" .github/CODEOWNERS
-              echo "✅ CODEOWNERS configured with team: ${{ inputs.team_name }}" >> $GITHUB_STEP_SUMMARY
+              TEAM_NAME="$TEAM_NAME" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path(".github/CODEOWNERS")
+          path.write_text(path.read_text().replace("team-leads", os.environ["TEAM_NAME"]))
+          PY
+              echo "✅ CODEOWNERS configured with team: $TEAM_NAME" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
               rm -f .github/CODEOWNERS
-              echo "⏭️ CODEOWNERS skipped (enable_codeowners=false)" >> $GITHUB_STEP_SUMMARY
+              echo "⏭️ CODEOWNERS skipped (enable_codeowners=false)" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
 
       - name: Update LICENSE with current year and holder
+        env:
+          LICENSE_HOLDER: ${{ steps.set-license.outputs.holder }}
         run: |
           cd new-repo
-          CURRENT_YEAR=$(date +%Y)
-          sed -i "s/\[year\]/$CURRENT_YEAR/g" LICENSE
-          sed -i "s/\[fullname\]/${{ steps.set-license.outputs.holder }}/g" LICENSE
+          CURRENT_YEAR=$(date +%Y) LICENSE_HOLDER="$LICENSE_HOLDER" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path("LICENSE")
+          text = path.read_text()
+          text = text.replace("[year]", os.environ["CURRENT_YEAR"])
+          path.write_text(text.replace("[fullname]", os.environ["LICENSE_HOLDER"]))
+          PY
 
       - name: Update README with repository details
+        env:
+          REPOSITORY_OWNER: ${{ steps.set-owner.outputs.owner }}
+          REPOSITORY_NAME: ${{ inputs.repo_name }}
         run: |
           cd new-repo
-          sed -i "s/{{REPOSITORY_OWNER}}/${{ steps.set-owner.outputs.owner }}/g" README.md
-          sed -i "s/{{REPOSITORY_NAME}}/${{ inputs.repo_name }}/g" README.md
+          REPOSITORY_OWNER="$REPOSITORY_OWNER" REPOSITORY_NAME="$REPOSITORY_NAME" python - <<'PY'
+          from pathlib import Path
+          import os
+
+          path = Path("README.md")
+          text = path.read_text().replace("{{REPOSITORY_OWNER}}", os.environ["REPOSITORY_OWNER"])
+          path.write_text(text.replace("{{REPOSITORY_NAME}}", os.environ["REPOSITORY_NAME"]))
+          PY
 
       - name: Log language tooling selection
         run: |
@@ -695,7 +735,7 @@ jobs:
           case "$WORKFLOWS_INPUT" in
             "all")
               echo "quality_kept=true" >> "$GITHUB_OUTPUT"
-              echo "✅ All workflows kept" >> $GITHUB_STEP_SUMMARY
+              echo "✅ All workflows kept" >> "$GITHUB_STEP_SUMMARY"
               ;;
             "none")
               echo "quality_kept=false" >> "$GITHUB_OUTPUT"
@@ -706,7 +746,7 @@ jobs:
                 "release-please") rm -f .github/workflows/release-please.yml release-please-config.json .release-please-manifest.json ;;
                 *) rm -f .github/workflows/git-cliff-release.yml cliff.toml ;;
               esac
-              echo "⏭️ All workflows removed (workflows=none)" >> $GITHUB_STEP_SUMMARY
+              echo "⏭️ All workflows removed (workflows=none)" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
               VALID_NAMES="quality codeql ai-code-review release"
@@ -718,7 +758,7 @@ jobs:
                 case "$name" in
                   quality) KEEP_LIST="$KEEP_LIST $name"; QUALITY_KEPT=true ;;
                   codeql|ai-code-review|release) KEEP_LIST="$KEEP_LIST $name" ;;
-                  *) echo "⚠️ Unknown workflow name: $name (ignored)" >> $GITHUB_STEP_SUMMARY ;;
+                  *) echo "⚠️ Unknown workflow name: $name (ignored)" >> "$GITHUB_STEP_SUMMARY" ;;
                 esac
               done
 
@@ -739,7 +779,7 @@ jobs:
                   *) rm -f .github/workflows/git-cliff-release.yml cliff.toml ;;
                 esac
               fi
-              echo "✅ Selected workflows:$KEEP_LIST" >> $GITHUB_STEP_SUMMARY
+              echo "✅ Selected workflows:$KEEP_LIST" >> "$GITHUB_STEP_SUMMARY"
               echo "quality_kept=$QUALITY_KEPT" >> "$GITHUB_OUTPUT"
               ;;
           esac
@@ -757,12 +797,14 @@ jobs:
 
       - name: Commit and push files
         id: push-files
+        env:
+          GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
         run: |
           cd new-repo
           git add .
           git commit -m "chore: initialize repository from bootstrap template"
-          git push
-          echo "✅ Template files pushed" >> $GITHUB_STEP_SUMMARY
+          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" push
+          echo "✅ Template files pushed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Apply repository settings
         uses: ./.github/actions/apply-repo-settings
@@ -785,82 +827,82 @@ jobs:
 
       - name: Summary
         run: |
-          echo "✅ Repository created successfully via Terraform!" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "**Repository:** https://github.com/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Visibility:** ${{ inputs.visibility }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Languages:** ${{ steps.validate-inputs.outputs.languages }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Environment manager:** ${{ steps.validate-inputs.outputs.env_manager }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Runtime versions:** python=${{ steps.validate-inputs.outputs.python_version }}, node=${{ steps.validate-inputs.outputs.node_version }}, go=${{ steps.validate-inputs.outputs.go_version }}, java=${{ steps.validate-inputs.outputs.java_version }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Workflows:** ${{ inputs.workflows }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Release tool:** ${{ inputs.release_tool || 'git-cliff' }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Created Resources (via Terraform)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ GitHub repository" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Repository settings (squash merge, auto-delete branches)" >> $GITHUB_STEP_SUMMARY
+          echo "✅ Repository created successfully via Terraform!" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Repository:** https://github.com/${{ steps.set-owner.outputs.owner }}/${{ inputs.repo_name }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Visibility:** ${{ inputs.visibility }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Languages:** ${{ steps.validate-inputs.outputs.languages }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Environment manager:** ${{ steps.validate-inputs.outputs.env_manager }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Runtime versions:** python=${{ steps.validate-inputs.outputs.python_version }}, node=${{ steps.validate-inputs.outputs.node_version }}, go=${{ steps.validate-inputs.outputs.go_version }}, java=${{ steps.validate-inputs.outputs.java_version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Workflows:** ${{ inputs.workflows }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Release tool:** ${{ inputs.release_tool || 'git-cliff' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Created Resources (via Terraform)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ GitHub repository" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Repository settings (squash merge, auto-delete branches)" >> "$GITHUB_STEP_SUMMARY"
           case "${{ inputs.enable_repo_settings }}" in
             "true")
-              echo "- ✅ Vulnerability alerts enabled" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Dependabot security updates enabled" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Development environment (Terraform-managed; not modified here)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Production environment (Terraform-managed; not modified here)" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Vulnerability alerts enabled" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Dependabot security updates enabled" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Development environment (Terraform-managed; not modified here)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Production environment (Terraform-managed; not modified here)" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
-              echo "- ⏭️ Vulnerability alerts and Dependabot security updates (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
-              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Development environment (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
-              echo "- ⏭️ Production environment (skipped; enable_repo_settings=false)" >> $GITHUB_STEP_SUMMARY
+              echo "- ⏭️ Vulnerability alerts and Dependabot security updates (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ✅ Repository ruleset applied (or skipped with warning on unsupported plans)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Development environment (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
+              echo "- ⏭️ Production environment (skipped; enable_repo_settings=false)" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "### Created Resources (via Template)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Created Resources (via Template)" >> "$GITHUB_STEP_SUMMARY"
           case "${{ inputs.enable_codeowners }}" in
-            "true") echo "- ✅ CODEOWNERS" >> $GITHUB_STEP_SUMMARY ;;
-            *) echo "- ⏭️ CODEOWNERS skipped" >> $GITHUB_STEP_SUMMARY ;;
+            "true") echo "- ✅ CODEOWNERS" >> "$GITHUB_STEP_SUMMARY" ;;
+            *) echo "- ⏭️ CODEOWNERS skipped" >> "$GITHUB_STEP_SUMMARY" ;;
           esac
-          echo "- ✅ Dependabot configuration" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ .editorconfig (4 spaces code, 2 spaces config)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ .gitignore, .gitattributes" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Documentation templates" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ SECURITY.md (security policy)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ CONTRIBUTING.md (contribution guide)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ LICENSE (MIT)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Dependabot configuration" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ .editorconfig (4 spaces code, 2 spaces config)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ .gitignore, .gitattributes" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Documentation templates" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ SECURITY.md (security policy)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ CONTRIBUTING.md (contribution guide)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ LICENSE (MIT)" >> "$GITHUB_STEP_SUMMARY"
           case "${{ inputs.workflows }}" in
             "all"|"")
-              echo "- ✅ Quality workflow (${{ steps.validate-inputs.outputs.env_manager }} + selected capabilities)" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Quality workflow (${{ steps.validate-inputs.outputs.env_manager }} + selected capabilities)" >> "$GITHUB_STEP_SUMMARY"
               ;;
             "none")
-              echo "- ⏭️ All workflows skipped" >> $GITHUB_STEP_SUMMARY
+              echo "- ⏭️ All workflows skipped" >> "$GITHUB_STEP_SUMMARY"
               ;;
             *)
-              echo "- ✅ Selected workflows: ${{ inputs.workflows }}" >> $GITHUB_STEP_SUMMARY
+              echo "- ✅ Selected workflows: ${{ inputs.workflows }}" >> "$GITHUB_STEP_SUMMARY"
               ;;
           esac
           if [ -f new-repo/environment.yml ]; then
-            echo "- ✅ provider/micromamba config selected (environment.yml)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/micromamba config selected (environment.yml)" >> "$GITHUB_STEP_SUMMARY"
           elif [ -f new-repo/mise.toml ]; then
-            echo "- ✅ provider/mise config selected (mise.toml)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/mise config selected (mise.toml)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- ✅ provider/system config selected (Makefile only)" >> $GITHUB_STEP_SUMMARY
+            echo "- ✅ provider/system config selected (Makefile only)" >> "$GITHUB_STEP_SUMMARY"
           fi
-          echo "- ✅ .pre-commit-config.yaml (all language: system hooks)" >> $GITHUB_STEP_SUMMARY
-          echo "- ✅ Conventional commits (pre-commit)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ .pre-commit-config.yaml (all language: system hooks)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- ✅ Conventional commits (pre-commit)" >> "$GITHUB_STEP_SUMMARY"
           case "${{ inputs.workflows }}" in
             "none") ;;
             *)
               case "${{ inputs.release_tool }}" in
                 "release-please")
-                  echo "- ✅ Release Please workflow (PR-based semantic versioning)" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ Release Please workflow (PR-based semantic versioning)" >> "$GITHUB_STEP_SUMMARY"
                   ;;
                 *)
-                  echo "- ✅ git-cliff release workflow (tag-based changelog + GitHub Release)" >> $GITHUB_STEP_SUMMARY
-                  echo "- ✅ cliff.toml (changelog configuration)" >> $GITHUB_STEP_SUMMARY
+                  echo "- ✅ git-cliff release workflow (tag-based changelog + GitHub Release)" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- ✅ cliff.toml (changelog configuration)" >> "$GITHUB_STEP_SUMMARY"
                   ;;
               esac
               ;;
           esac
-          echo "- ✅ Makefile (run 'make lint' locally)" >> $GITHUB_STEP_SUMMARY
+          echo "- ✅ Makefile (run 'make lint' locally)" >> "$GITHUB_STEP_SUMMARY"
 
   cleanup-approval:
     name: Await Cleanup Approval
@@ -917,28 +959,29 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || needs.terraform-create-repository.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ needs.terraform-create-repository.outputs.owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ inputs.repo_name }}
 
       - name: Delete repository on failure
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ needs.terraform-create-repository.outputs.owner }}
+          REPO: ${{ inputs.repo_name }}
         run: |
-          OWNER="${{ needs.terraform-create-repository.outputs.owner }}"
-          REPO="${{ inputs.repo_name }}"
-
           if gh repo view "$OWNER/$REPO" &>/dev/null; then
-            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> $GITHUB_STEP_SUMMARY
+            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> "$GITHUB_STEP_SUMMARY"
             gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               /repos/$OWNER/$REPO
-            echo "✅ Repository deleted successfully" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Repository deleted successfully" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Repository does not exist, nothing to clean up" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Repository does not exist, nothing to clean up" >> "$GITHUB_STEP_SUMMARY"
           fi
 
   teardown-no-approval:
@@ -975,26 +1018,27 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
           client_id: ${{ inputs.client_id }}
-          app_private_key: ${{ secrets.app_private_key || secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
-          app_owner: ${{ inputs.app_owner || needs.terraform-create-repository.outputs.owner }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_user_token: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ needs.terraform-create-repository.outputs.owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ inputs.repo_name }}
 
       - name: Delete repository on failure
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          OWNER: ${{ needs.terraform-create-repository.outputs.owner }}
+          REPO: ${{ inputs.repo_name }}
         run: |
-          OWNER="${{ needs.terraform-create-repository.outputs.owner }}"
-          REPO="${{ inputs.repo_name }}"
-
           if gh repo view "$OWNER/$REPO" &>/dev/null; then
-            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> $GITHUB_STEP_SUMMARY
+            echo "🗑️ Deleting repository $OWNER/$REPO due to failure..." >> "$GITHUB_STEP_SUMMARY"
             gh api \
               --method DELETE \
               -H "Accept: application/vnd.github+json" \
               /repos/$OWNER/$REPO
-            echo "✅ Repository deleted successfully" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Repository deleted successfully" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Repository does not exist, nothing to clean up" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Repository does not exist, nothing to clean up" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/test-generated-repository-e2e.yml
+++ b/.github/workflows/test-generated-repository-e2e.yml
@@ -8,6 +8,14 @@ on:
         required: false
         default: main
         type: string
+      client_id:
+        description: GitHub App client ID for the credentialed E2E run.
+        required: true
+        type: string
+      app_owner:
+        description: Organization used by the credentialed E2E run.
+        required: true
+        type: string
       central_repository:
         description: Existing user-owned central workflow repository for centralized scenarios.
         required: false
@@ -97,8 +105,12 @@ jobs:
         id: token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ secrets.GH_PAT }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: repository-setup
+          repositories: ${{ github.event.repository.name }}
 
       - name: Select requested creation workflow
         id: scenario

--- a/.github/workflows/test-local-setup-scripts.yml
+++ b/.github/workflows/test-local-setup-scripts.yml
@@ -31,12 +31,13 @@ on:
         required: false
         default: true
         type: boolean
-      gh_token:
-        description: >-
-          Personal Access Token with repository creation, administration, and
-          label/Issues write access. Prefer using the repository secret GH_PAT
-          whenever possible.
-        required: false
+      client_id:
+        description: GitHub App client ID.
+        required: true
+        type: string
+      app_owner:
+        description: Organization whose installation owns the test repository.
+        required: true
         type: string
 
 permissions: {}
@@ -60,8 +61,11 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: repository-creation
 
       - name: Generate unique test repository name
         id: generate-name
@@ -175,8 +179,12 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ needs.test-local-setup-scripts.outputs.test_repo_name }}
 
       - name: Cleanup temporary test repository
         env:

--- a/.github/workflows/test-repository-creation.yml
+++ b/.github/workflows/test-repository-creation.yml
@@ -121,15 +121,13 @@ on:
         required: false
         default: "all"
         type: string
-      gh_token:
-        description: >-
-          Personal Access Token with repo and admin:org scopes.
-          WARNING: This input is NOT treated as a secret — its value may be
-          visible in the run's inputs/metadata to anyone who can view the run.
-          Prefer using the repository secret GH_PAT whenever possible.
-          Only use this input when you do not have permission to set repository
-          secrets and use a short-lived token with minimum required scopes.
-        required: false
+      client_id:
+        description: GitHub App client ID.
+        required: true
+        type: string
+      app_owner:
+        description: Organization whose installation owns the test repository.
+        required: true
         type: string
 
 jobs:
@@ -161,15 +159,18 @@ jobs:
         run: |
           TIMESTAMP=$(date +"%Y%m%d-%H%M%S")
           REPO_NAME="test-${{ github.event.inputs.test_repo_name }}-${TIMESTAMP}"
-          echo "repo_name=${REPO_NAME}" >> $GITHUB_OUTPUT
+          echo "repo_name=${REPO_NAME}" >> "$GITHUB_OUTPUT"
           echo "Generated test repository name: ${REPO_NAME}"
 
       - name: Resolve GitHub token
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ github.event.inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: repository-creation
 
       - name: Validate test inputs
         id: validate-inputs
@@ -452,10 +453,10 @@ jobs:
 
           if gh repo view ${{ github.repository_owner }}/${REPO_NAME} &>/dev/null; then
             echo "✅ Repository verified: https://github.com/${{ github.repository_owner }}/${REPO_NAME}"
-            echo "created=true" >> $GITHUB_OUTPUT
+            echo "created=true" >> "$GITHUB_OUTPUT"
           else
             echo "❌ Repository not found after workflow completion"
-            echo "created=false" >> $GITHUB_OUTPUT
+            echo "created=false" >> "$GITHUB_OUTPUT"
             exit 1
           fi
 
@@ -804,7 +805,7 @@ jobs:
           OWNER="${{ github.repository_owner }}"
           REPO_URL="https://github.com/${OWNER}/${REPO_NAME}"
 
-          cat >> $GITHUB_STEP_SUMMARY << EOF
+          cat >> "$GITHUB_STEP_SUMMARY" << EOF
           ## Test Repository Created
 
           | Item | Status |
@@ -846,8 +847,12 @@ jobs:
         id: resolve-token
         uses: ./.github/actions/resolve-gh-token
         with:
-          gh_token: ${{ github.event.inputs.gh_token }}
-          gh_pat_secret: ${{ secrets.GH_PAT }}
+          client_id: ${{ inputs.client_id }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ inputs.app_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: repository-cleanup
+          repositories: ${{ needs.create-test-repo.outputs.test_repo_name }}
 
       - name: Delete test repository
         env:
@@ -864,7 +869,7 @@ jobs:
               -H "Accept: application/vnd.github+json" \
               /repos/${OWNER}/${REPO_NAME}
 
-            echo "✅ Repository deleted successfully" >> $GITHUB_STEP_SUMMARY
+            echo "✅ Repository deleted successfully" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "ℹ️ Repository does not exist or was already deleted" >> $GITHUB_STEP_SUMMARY
+            echo "ℹ️ Repository does not exist or was already deleted" >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -13,12 +13,9 @@ jobs:
   update-tooling:
     name: Update non-Dependabot tooling
     runs-on: ubuntu-latest
-    # Required to commit/push changes and create/edit/merge the weekly PR.
+    # The App installation token handles repository writes and PR operations.
     permissions:
-      contents: write
-      pull-requests: write
-    env:
-      GH_TOKEN: ${{ secrets.GH_PAT || github.token }}
+      contents: read
 
     steps:
       - name: Checkout code
@@ -26,6 +23,28 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+
+      - name: Derive repository name
+        id: repository
+        shell: bash
+        env:
+          GITHUB_REPOSITORY_NAME: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          repository_name="${GITHUB_REPOSITORY_NAME#*/}"
+          [ -n "$repository_name" ] || { echo "Unable to derive repository name" >&2; exit 1; }
+          echo "name=$repository_name" >> "$GITHUB_OUTPUT"
+
+      - name: Resolve GitHub App token
+        id: resolve-token
+        uses: ./.github/actions/resolve-gh-token
+        with:
+          client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
+          app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          app_owner: ${{ github.repository_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: weekly-tooling
+          repositories: ${{ steps.repository.outputs.name }}
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -55,6 +74,8 @@ jobs:
 
       - name: Create or update tooling update PR (gh CLI)
         shell: bash
+        env:
+          GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
         run: |
           set -euo pipefail
 

--- a/README.md
+++ b/README.md
@@ -26,17 +26,21 @@ Creates fully configured repositories with:
 ## Setup
 
 Recommended: use a **tenant-installed GitHub App** (safer, short-lived installation tokens).
-Fallback: use a PAT when App setup is not available.
 
-### Option A — GitHub App (recommended)
+### GitHub App setup
 
 1. Create or use an existing GitHub App with the following minimum permissions:
 
-   | Permission scope | Level          | Required for                                   |
-   | ---------------- | -------------- | ---------------------------------------------- |
-   | `Contents`       | Read and write | Clone template, push initial commits           |
-   | `Administration` | Read and write | Create repos, configure settings, delete repos |
-   | `Metadata`       | Read-only      | Read repository info (auto-granted)            |
+   | Permission scope              | Level          | Required for                                            |
+   | ----------------------------- | -------------- | ------------------------------------------------------- |
+   | `Contents`                    | Read and write | Clone template, push initial commits                    |
+   | `Administration`              | Read and write | Configure settings, environments, rulesets, and cleanup |
+   | `Metadata`                    | Read-only      | Read repository info (auto-granted)                     |
+   | `Organization administration` | Read and write | Create repositories in the target organization          |
+   | `Issues`                      | Read and write | Create and update repository labels                     |
+
+   The weekly tooling workflow additionally requires `Pull requests` write permission when
+   App-authenticated weekly PR creation and auto-merge are enabled.
 
    For **organization** repositories also add:
 
@@ -44,54 +48,24 @@ Fallback: use a PAT when App setup is not available.
    | ---------------- | --------- | ------------------------------------- |
    | `Members`        | Read-only | Resolve org membership for team setup |
 
-2. Install the App in each target user/org (tenant isolation). The App must be installed
-   on every `app_owner` value you intend to target.
+2. Install the App in each target organization (tenant isolation), or authorize it for the
+   personal account that will own a personal repository. The `app_owner` value must match the
+   target owner.
 3. In the repository that runs bootstrap, set:
-   - `BOOTSTRAP_APP_PRIVATE_KEY` (Actions secret — the PEM private key of the App)
+   - `BOOTSTRAP_APP_PRIVATE_KEY` (protected Actions secret — required for organization installation-token mode)
+   - `BOOTSTRAP_APP_USER_TOKEN` (protected reusable-workflow secret — required for personal-account mode; must be the `ghu_` GitHub App user token)
 4. When running the workflow, provide:
    - `client_id` (the GitHub App client ID, visible in the App's settings)
-   - `app_owner` (target tenant owner)
+   - `app_owner` (target organization or personal-account owner)
 
-The workflow mints a short-lived installation token for that owner and uses it for all API calls.
+Organization creation mints a short-lived installation token for that owner. Personal creation uses
+the App user access token, verifies its `/user` login against the target owner, and then calls
+`/user/repos`. No PAT fallback exists.
 
-> **Organization targets only:** GitHub App installation tokens (server-to-server) cannot
-> create repositories under a personal user account — this is a GitHub API constraint.
-> The target `repo_owner` must be a GitHub **Organization**.
-> For personal user account targets, use the PAT fallback (Option B) instead.
-
-### Option B — PAT (fallback)
-
-There are two ways to supply the token, listed from most to least recommended:
-
-#### Option A — Repository secret (recommended for shared/team use)
-
-1. Fork this repository **or** click **Use this template** → **Create a new repository**
-   (for company use, create the fork/template repo inside your organization)
-2. Go to your fork → **Settings** → **Secrets and variables** → **Actions**
-3. Click **New repository secret**
-4. Name: `GH_PAT`, Value: your token from step 1
-5. Click **Add secret**
-
-The workflows will automatically pick up `GH_PAT` without any extra input.
-
-#### Option B — Workflow input (for users without secret-management access)
-
-If you are working in an enterprise or internal repository where you cannot add repository secrets,
-you can pass your token directly when triggering a workflow:
-
-1. Go to **Actions** → select the workflow → **Run workflow**
-2. Fill in the **Personal Access Token (gh_token)** field with your `ghp_…` token
-
-> **Security note:** The token is immediately masked with `::add-mask::` at the start of each job
-> so it never appears in plain text in the workflow logs. Masking only prevents the token from
-> being printed in logs; the raw workflow input value may still be visible in the run's
-> inputs/metadata to anyone who can view the run. Prefer
-> [Option A — Repository secret](#option-a--repository-secret-recommended-for-sharedteam-use)
-> whenever possible, and if you must use Option B, use a short-lived token with the minimum
-> required scopes.
+> Private keys and user access tokens are accepted only as protected caller secrets. Never put a
+> private key, token, PAT, or credential in workflow inputs, generated repositories, or this repository.
 
 **Note:** `internal` visibility is only available for repositories inside a GitHub Organization.
-Use `private` for personal account repositories.
 
 ## Quick Start
 
@@ -134,7 +108,9 @@ jobs:
       allowed_repo_owners: ${{ vars.ALLOWED_REPO_OWNERS }}
       require_cleanup_approval: true
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      # For personal-account creation, use this App user access token instead.
+      BOOTSTRAP_APP_USER_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
 ```
 
 This example calls the standard Actions bootstrap workflow (`create-repository.yml`).
@@ -165,18 +141,10 @@ If you prefer Terraform orchestration, call
 
 ### Option C — Terraform IaC
 
-1. Complete the [Setup](#setup) steps above
-2. Go to **Actions** → **Terraform Create Repository**
-3. Click **Run workflow** and fill in the inputs, **or** apply locally:
-
-   ```bash
-   cd terraform
-   terraform init
-   terraform apply \
-     -var="github_token=ghp_yourtoken" \
-     -var="repo_name=my-new-repo" \
-     -var="repo_owner=my-org"
-   ```
+1. Complete the [Setup](#setup) steps above.
+2. Go to **Actions** → **Terraform Create Repository**.
+3. Click **Run workflow** and fill in the App client ID, target owner,
+   approved-owner allowlist, and repository settings.
 
 See [`terraform/README.md`](terraform/README.md) for full documentation.
 
@@ -206,23 +174,14 @@ For exact workflow inputs, secrets, and outputs, read the `workflow_call` block 
 the reusable workflow file. For capability behavior, read the relevant composite
 action metadata under [`.github/actions/`](.github/actions/).
 
-Launcher workflows pass non-secret values as explicit inputs and private values
-as secrets from the launcher repository. Target repository access comes from the
-resolved GitHub App token or PAT.
+Launcher workflows pass non-secret values as explicit inputs and the private key as a secret from
+the launcher repository. Target repository access comes from the resolved GitHub App token.
 
 ### Permissions and Authentication
 
-For organization usage, prefer a GitHub App installation token. For personal
-repositories or local use, a PAT can be used as a fallback.
-
-Typical permissions needed by the resolved token:
-
-| Capability area        | Required access                                                                 |
-| ---------------------- | ------------------------------------------------------------------------------- |
-| Repo settings/rulesets | Repository administration read/write                                            |
-| Security settings      | Repository administration read/write; some features require GitHub plan support |
-| Labels                 | Issue/label write access or repository administration access                    |
-| File pull requests     | Contents read/write and pull requests write                                     |
+Organization repository creation uses a short-lived GitHub App installation token; personal-account
+creation uses a verified GitHub App user access token. See the
+[permission-to-endpoint matrix](docs/github-app-permission-matrix.md) for the exact scope rationale.
 
 CodeRabbit setup has one extra prerequisite: install the
 [CodeRabbit GitHub App](https://github.com/apps/coderabbitai) on the target
@@ -582,9 +541,8 @@ preset for the path you are validating (`api-*` or `terraform-*`).
 
 ## Requirements
 
-- Recommended: GitHub App credentials (`client_id` + `BOOTSTRAP_APP_PRIVATE_KEY`) installed in each target tenant owner
-- Fallback: GitHub personal access token (PAT) with `repo` scope (add `admin:org` for organization repositories)
-  — stored as a `GH_PAT` repository secret **or** provided via the `gh_token` workflow input
+- GitHub App credentials: `client_id` plus either the protected installation private key for an
+  organization or the protected App user access token for a personal account
   — see [Setup](#setup)
 - One of: `micromamba`, `mise`, or system-installed tooling for local linting with `make lint`
 

--- a/docs/github-app-e2e-plan.md
+++ b/docs/github-app-e2e-plan.md
@@ -1,0 +1,25 @@
+# Credentialed GitHub App E2E follow-up
+
+This change verifies App authentication locally through deterministic action and workflow contract
+tests. It does not fake an App key or claim live authentication.
+
+The follow-up E2E change should cover both supported owner types:
+
+1. Register a disposable GitHub App with the App Manifest flow and only the permissions in the
+   permission matrix. Exchange the one-time manifest code for the App credentials programmatically.
+2. For organization coverage, install it on a disposable test organization. For personal coverage,
+   authorize it for a disposable test user and provide the resulting App user access token only as
+   a protected caller/environment secret (`BOOTSTRAP_APP_USER_TOKEN`, a `ghu_` GitHub App user token).
+3. Keep private keys and user access tokens in an ephemeral runner or external secret manager, never
+   in Git, a generated repository, or a test repository secret. Store only the Client ID as non-secret
+   configuration.
+4. Run both creation workflows for organization and personal targets. Owner mismatch, user-token
+   identity mismatch, and user-token-to-organization misuse must fail before creation.
+5. Verify repository creation, generated files, token scope, cleanup, and isolation from the upstream
+   repository and unrelated owners.
+6. Revoke the installation and App authorization, then delete disposable resources after the run.
+
+The local contract tests do not mint credentials or call live GitHub authentication. This plan must
+not be implemented by faking a private key or user token locally.
+
+Vault/OIDC credential delivery remains tracked by issue #92 and is not part of this plan.

--- a/docs/github-app-permission-matrix.md
+++ b/docs/github-app-permission-matrix.md
@@ -1,0 +1,36 @@
+# GitHub App permission-to-endpoint matrix
+
+Organization repository creation uses an installation token for the requested `app_owner` only.
+Personal repository creation uses an explicitly supplied GitHub App user access token whose `/user`
+identity is checked against the target owner. The resolver passes permissions explicitly so an
+installation token does not inherit unused permissions from the App installation.
+
+| Permission profile    | Explicit App permissions                                                                          | Used for                                         |
+| --------------------- | ------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| `repository-creation` | `organization-administration: write`, `administration: write`, `contents: write`, `issues: write` | Create and configure a repository.               |
+| `repository-setup`    | `administration: write`, `contents: write`, `issues: write`                                       | Configure an existing repository.                |
+| `repository-cleanup`  | `administration: write`                                                                           | Delete a failed repository.                      |
+| `weekly-tooling`      | `contents: write`, `pull-requests: write`                                                         | Commit tooling updates and manage the weekly PR. |
+
+| App permission                | Level | Endpoint or operation                                                      | Why it is required                                     |
+| ----------------------------- | ----- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
+| `organization-administration` | write | `POST /orgs/{org}/repos`                                                   | Create the repository in the target organization.      |
+| `administration`              | write | `PATCH /repos/{owner}/{repo}`, environments, rulesets, repository deletion | Configure the repository and clean up failed creation. |
+| `contents`                    | write | Git push and repository contents API                                       | Add generated bootstrap files.                         |
+| `issues`                      | write | Labels API                                                                 | Apply default repository labels.                       |
+| `pull-requests`               | write | Weekly tooling PR creation, updates, and auto-merge                        | Run the App-authenticated weekly tooling automation.   |
+
+`metadata: read` is automatically available for repository access. Members, actions,
+security-events, and unrelated-owner permissions are not granted by this resolver. Pull-request
+write permission is granted only by the `weekly-tooling` profile.
+
+Creation installation tokens intentionally omit a repository list because the target repository
+does not exist yet. Existing-repository setup, cleanup, and weekly tooling callers pass the
+repository name to scope the installation token to that repository. Personal creation uses
+`POST /user/repos`, which is tied to the authenticated user; user access tokens are never accepted
+as workflow-dispatch inputs or used for organization creation.
+
+| Creation target | Authentication         | Endpoint                 | Why                                                                                      |
+| --------------- | ---------------------- | ------------------------ | ---------------------------------------------------------------------------------------- |
+| Organization    | App installation token | `POST /orgs/{org}/repos` | Organization-scoped repository creation.                                                 |
+| Personal user   | App user access token  | `POST /user/repos`       | The API requires a token for the authenticated user; `/user` identity is verified first. |

--- a/docs/superpowers/plans/2026-08-25-app-user-token-personal-creation.md
+++ b/docs/superpowers/plans/2026-08-25-app-user-token-personal-creation.md
@@ -1,0 +1,147 @@
+# App User-Token Personal Repository Creation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Support personal-account repository creation with a GitHub App user access token while retaining installation-token organization creation as the default.
+
+**Architecture:** Extend the shared resolver with an explicit `app-user` mode selected only when a protected App user token is supplied. Validate `/user` identity against the target owner before creation, then use the existing installation-token path for organization owners. No PATs, dispatch credential inputs, or generated-repository secrets are introduced.
+
+**Tech Stack:** GitHub Actions YAML, composite Bash action, GitHub CLI, deterministic shell contract tests, Markdown documentation.
+
+**Spec:** Approved design in the current conversation; official GitHub REST repository-authentication documentation.
+
+## Global Constraints
+
+- Installation tokens remain the default documented organization path.
+- App user tokens are the only personal-account path; PATs remain unsupported.
+- Private keys, PATs, and tokens are never workflow-dispatch inputs.
+- Personal mode must prove the App user-token identity matches `target_owner` before creation.
+- Organization mode must retain App installation owner binding and repository scoping.
+- No Vault/OIDC implementation is included.
+
+---
+
+### Task 1: Add failing resolver and workflow contract tests
+
+**Files:**
+
+- Modify: `scripts/github-setup/test-app-auth-contract.sh`
+- Modify: `scripts/github-setup/test-profile.sh`
+
+- [x] **Step 1: Add assertions for explicit App user-token mode.**
+
+Assert the resolver exposes `app_user_token`, validates the authenticated user, emits `mode=app-user`, and does not use PAT terminology.
+
+- [x] **Step 2: Add assertions for personal workflow wiring.**
+
+Assert both creation workflows expose an optional `BOOTSTRAP_APP_USER_TOKEN` reusable secret and pass it only to the resolver. Assert the old organization-only audit error is removed or updated.
+
+- [x] **Step 3: Run the contract tests and verify failure.**
+
+Run:
+
+```bash
+scripts/github-setup/test-app-auth-contract.sh
+```
+
+Expected: fail because the resolver and creation workflows do not yet expose the App user-token path.
+
+### Task 2: Implement the resolver’s App user-token path
+
+**Files:**
+
+- Modify: `.github/actions/resolve-gh-token/action.yml`
+- Modify: `scripts/github-setup/validate-app-auth.sh`
+
+- [x] **Step 1: Add optional `app_user_token` input.**
+
+Keep existing App installation inputs required for organization mode, but allow the user-token mode to select an App user token explicitly.
+
+- [x] **Step 2: Validate user-token identity fail-closed.**
+
+Use `gh api /user --jq .login` with the masked token, compare case-insensitively to `TARGET_OWNER`, and reject mismatches before emitting any auth mode output.
+
+- [x] **Step 3: Preserve installation-token validation and scope.**
+
+When no App user token is supplied, retain current profile validation, owner matching, repository scoping, permission profiles, and pinned `actions/create-github-app-token` invocation unchanged.
+
+- [x] **Step 4: Run the contract tests and verify they pass.**
+
+Run the auth and profile contract tests; expected result is PASS.
+
+### Task 3: Wire personal creation through both creation workflows
+
+**Files:**
+
+- Modify: `.github/workflows/create-repository.yml`
+- Modify: `.github/workflows/terraform-create-repository.yml`
+- Modify: `.github/actions/audit-bootstrap-request/action.yml`
+
+- [x] **Step 1: Add optional reusable workflow secret.**
+
+Add `BOOTSTRAP_APP_USER_TOKEN` as an optional `workflow_call` secret and pass it to the resolver. Do not add it to `workflow_dispatch` inputs.
+
+- [x] **Step 2: Make owner-type auditing match the selected mode.**
+
+Permit personal owners when `auth_mode=app-user`; continue rejecting personal owners for installation-token mode. Keep organization owner allowlist validation mandatory.
+
+- [x] **Step 3: Ensure cleanup uses the correct token path.**
+
+For personal creation, retain the App user token for cleanup and validate its identity against the created repository owner. For organization creation, retain the scoped installation-token cleanup path.
+
+- [x] **Step 4: Run YAML and contract checks.**
+
+Run `actionlint`, the auth/profile tests, and `git diff --check`.
+
+### Task 4: Update secure documentation and E2E plan
+
+**Files:**
+
+- Modify: `README.md`
+- Modify: `terraform/README.md`
+- Modify: `docs/github-app-e2e-plan.md`
+- Modify: `docs/github-app-permission-matrix.md`
+
+- [x] **Step 1: Document both App modes.**
+
+Explain that organization creation uses installation tokens by default, while personal creation uses an App user token obtained through App authorization. State that neither PATs nor dispatch credential inputs are supported.
+
+- [x] **Step 2: Clarify secret delivery.**
+
+Require protected caller/environment or external secret delivery for the App private key and App user token; never store either in Git, generated repositories, or test repositories. Keep Vault/OIDC explicitly deferred to issue #92.
+
+- [x] **Step 3: Update the E2E plan.**
+
+Require credentialed tests for organization installation-token creation and personal App user-token creation, identity mismatch rejection, cleanup, and cross-owner isolation. State that organization deletion/App revocation require explicit authorized cleanup.
+
+### Task 5: Verify, review, and amend the focused commit
+
+**Files:**
+
+- All files changed by Tasks 1–4.
+
+- [x] **Step 1: Run targeted tests and complete lint.**
+
+```bash
+scripts/github-setup/test-app-auth-contract.sh
+scripts/github-setup/test-profile.sh
+actionlint -ignore 'SC[0-9]+' .github/workflows/*.yml
+LINT_MODE=check make lint
+git diff --check
+```
+
+- [x] **Step 2: Run a separate Superpowers security review.**
+
+Review owner identity binding, App user-token exposure, installation-token scope, workflow secrets, cleanup behavior, and PAT exclusion. Fix every actionable finding.
+
+- [ ] **Step 3: Amend and push the existing signed-off conventional commit.**
+
+```bash
+git add <changed-files>
+git commit --amend --no-edit -s
+git push --force-with-lease origin github-app-auth-issue-86
+```
+
+- [ ] **Step 4: Reply to and resolve review threads only after verification.**
+
+Confirm the remote PR head matches the final commit and all actionable threads are resolved.

--- a/examples/launcher-actions.yml
+++ b/examples/launcher-actions.yml
@@ -6,10 +6,11 @@
 # Prerequisites in YOUR launcher repository
 # ──────────────────────────────────────────
 # Secrets:
-#   BOOTSTRAP_APP_PRIVATE_KEY — PEM private key of your GitHub App
+#   BOOTSTRAP_APP_PRIVATE_KEY — PEM private key of your GitHub App (organization mode)
+#   BOOTSTRAP_APP_USER_TOKEN — authorized App user access token (personal mode)
 #
 # Variables (Settings → Secrets and variables → Actions → Variables):
-#   BOOTSTRAP_APP_ID          — Numeric App ID (found in the App's settings page)
+#   BOOTSTRAP_APP_CLIENT_ID   — App client ID (found in the App's settings page)
 #
 # GitHub App requirements:
 #   The App must be installed on every owner you want to create repos under.
@@ -29,7 +30,7 @@
 # ──────
 # 1. Copy this file to .github/workflows/bootstrap-repository.yml in your repo
 # 2. Replace BOOTSTRAP_OWNER with the GitHub user/org that owns github-bootstrap
-# 3. Set BOOTSTRAP_APP_PRIVATE_KEY secret and BOOTSTRAP_APP_ID variable
+# 3. Set the protected App secret for your target type and the BOOTSTRAP_APP_CLIENT_ID variable
 # 4. Create the bootstrap-cleanup environment (or set require_cleanup_approval: false)
 # 5. Go to Actions → Bootstrap Repository → Run workflow
 # ============================================================================
@@ -118,8 +119,8 @@ jobs:
       java_version: ${{ inputs.java_version }}
       release_tool: ${{ inputs.release_tool }}
       cleanup_on_failure: ${{ inputs.cleanup_on_failure }}
-      # GitHub App auth — recommended over PAT
-      app_id: ${{ vars.BOOTSTRAP_APP_ID }}
+      # GitHub App authentication
+      client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.repo_owner }}
       # Restrict which owners this launcher may target.
       # Use a fixed owner or a repo/org variable — NOT a user-controlled input.
@@ -134,4 +135,6 @@ jobs:
       # Needs a "bootstrap-cleanup" environment in THIS repository.
       require_cleanup_approval: true
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      # Use this instead of the private key for personal-account creation.
+      BOOTSTRAP_APP_USER_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}

--- a/examples/launcher-agent-templates.yml
+++ b/examples/launcher-agent-templates.yml
@@ -3,9 +3,9 @@
 #
 # Create these in THIS launcher repository, not in the target repo:
 # - Secret: BOOTSTRAP_APP_PRIVATE_KEY
-# - Workflow input: app_id
-# - Optional workflow input: allowed_repo_owners
-# The GitHub App or PAT must have access to the target repository selected by
+# - Workflow input: client_id
+# - Required workflow input: allowed_repo_owners
+# The GitHub App must have access to the target repository selected by
 # repo_owner/repo_name.
 
 name: Setup Agent Instructions
@@ -21,13 +21,13 @@ on:
         description: "Existing repository name"
         required: true
         type: string
-      app_id:
-        description: "GitHub App ID used to configure the target repository"
+      client_id:
+        description: "GitHub App client ID used to configure the target repository"
         required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
       agent_provider:
         description: "AI agent provider"
@@ -62,8 +62,8 @@ jobs:
       repo_name: ${{ inputs.repo_name }}
       agent_provider: ${{ inputs.agent_provider }}
       mode: ${{ inputs.mode }}
-      app_id: ${{ inputs.app_id }}
+      client_id: ${{ inputs.client_id }}
       app_owner: ${{ inputs.repo_owner }}
       allowed_repo_owners: ${{ inputs.allowed_repo_owners }}
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}

--- a/examples/launcher-coderabbit.yml
+++ b/examples/launcher-coderabbit.yml
@@ -8,9 +8,9 @@
 #
 # Create these in THIS launcher repository, not in the target repo:
 # - Secret: BOOTSTRAP_APP_PRIVATE_KEY
-# - Workflow input: app_id
-# - Optional workflow input: allowed_repo_owners
-# The GitHub App or PAT must have access to the target repository selected by
+# - Workflow input: client_id
+# - Required workflow input: allowed_repo_owners
+# The GitHub App must have access to the target repository selected by
 # repo_owner/repo_name.
 
 name: Setup CodeRabbit
@@ -26,13 +26,13 @@ on:
         description: "Existing repository name"
         required: true
         type: string
-      app_id:
-        description: "GitHub App ID used to configure the target repository"
+      client_id:
+        description: "GitHub App client ID used to configure the target repository"
         required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
       mode:
         description: "CodeRabbit apply mode"
@@ -66,8 +66,8 @@ jobs:
       mode: ${{ inputs.mode }}
       include_labels: ${{ inputs.include_labels }}
       include_ruleset: ${{ inputs.include_ruleset }}
-      app_id: ${{ inputs.app_id }}
+      client_id: ${{ inputs.client_id }}
       app_owner: ${{ inputs.repo_owner }}
       allowed_repo_owners: ${{ inputs.allowed_repo_owners }}
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}

--- a/examples/launcher-existing-repo.yml
+++ b/examples/launcher-existing-repo.yml
@@ -8,9 +8,9 @@
 # Recommended auth:
 # - Create these in THIS launcher repository, not in the target repo:
 #   - Secret: BOOTSTRAP_APP_PRIVATE_KEY
-#   - Workflow input: app_id
-#   - Optional workflow input: allowed_repo_owners
-# The GitHub App or PAT must have access to the target repository selected by
+#   - Workflow input: client_id
+#   - Required workflow input: allowed_repo_owners
+# The GitHub App must have access to the target repository selected by
 # repo_owner/repo_name.
 
 name: Setup Existing Repository
@@ -26,13 +26,13 @@ on:
         description: "Existing repository name"
         required: true
         type: string
-      app_id:
-        description: "GitHub App ID used to configure the target repository"
+      client_id:
+        description: "GitHub App client ID used to configure the target repository"
         required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
       apply_labels:
         description: "Apply default labels"
@@ -92,8 +92,8 @@ jobs:
       ruleset_profile: ${{ inputs.ruleset_profile }}
       coderabbit_mode: ${{ inputs.coderabbit_mode }}
       agent_provider: ${{ inputs.agent_provider }}
-      app_id: ${{ inputs.app_id }}
+      client_id: ${{ inputs.client_id }}
       app_owner: ${{ inputs.repo_owner }}
       allowed_repo_owners: ${{ inputs.allowed_repo_owners }}
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}

--- a/examples/launcher-security-labels.yml
+++ b/examples/launcher-security-labels.yml
@@ -3,9 +3,9 @@
 #
 # Create these in THIS launcher repository, not in the target repo:
 # - Secret: BOOTSTRAP_APP_PRIVATE_KEY
-# - Workflow input: app_id
-# - Optional workflow input: allowed_repo_owners
-# The GitHub App or PAT must have access to the target repository selected by
+# - Workflow input: client_id
+# - Required workflow input: allowed_repo_owners
+# The GitHub App must have access to the target repository selected by
 # repo_owner/repo_name.
 
 name: Setup Labels and Security
@@ -21,13 +21,13 @@ on:
         description: "Existing repository name"
         required: true
         type: string
-      app_id:
-        description: "GitHub App ID used to configure the target repository"
+      client_id:
+        description: "GitHub App client ID used to configure the target repository"
         required: true
         type: string
       allowed_repo_owners:
-        description: "Optional comma-separated allowlist of target owners"
-        required: false
+        description: "Comma-separated allowlist of target owners"
+        required: true
         type: string
       label_policy:
         description: "Label apply policy"
@@ -48,8 +48,8 @@ jobs:
       repo_owner: ${{ inputs.repo_owner }}
       repo_name: ${{ inputs.repo_name }}
       label_policy: ${{ inputs.label_policy }}
-      app_id: ${{ inputs.app_id }}
+      client_id: ${{ inputs.client_id }}
       app_owner: ${{ inputs.repo_owner }}
       allowed_repo_owners: ${{ inputs.allowed_repo_owners }}
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}

--- a/examples/launcher-terraform.yml
+++ b/examples/launcher-terraform.yml
@@ -9,10 +9,11 @@
 # Prerequisites in YOUR launcher repository
 # ──────────────────────────────────────────
 # Secrets:
-#   BOOTSTRAP_APP_PRIVATE_KEY — PEM private key of your GitHub App
+#   BOOTSTRAP_APP_PRIVATE_KEY — PEM private key of your GitHub App (organization mode)
+#   BOOTSTRAP_APP_USER_TOKEN — authorized App user access token (personal mode)
 #
 # Variables (Settings → Secrets and variables → Actions → Variables):
-#   BOOTSTRAP_APP_ID          — Numeric App ID (found in the App's settings page)
+#   BOOTSTRAP_APP_CLIENT_ID   — App client ID (found in the App's settings page)
 #
 # GitHub App requirements:
 #   Same as launcher-actions.yml. See that file for the full list.
@@ -26,7 +27,7 @@
 # ──────
 # 1. Copy this file to .github/workflows/bootstrap-repository-terraform.yml
 # 2. Replace BOOTSTRAP_OWNER with the GitHub user/org that owns github-bootstrap
-# 3. Set BOOTSTRAP_APP_PRIVATE_KEY secret and BOOTSTRAP_APP_ID variable
+# 3. Set the protected App secret for the target type and BOOTSTRAP_APP_CLIENT_ID variable
 # 4. Create the bootstrap-cleanup environment (or set require_cleanup_approval: false)
 # 5. Go to Actions → Bootstrap Repository (Terraform) → Run workflow
 # ============================================================================
@@ -115,8 +116,8 @@ jobs:
       java_version: ${{ inputs.java_version }}
       release_tool: ${{ inputs.release_tool }}
       cleanup_on_failure: ${{ inputs.cleanup_on_failure }}
-      # GitHub App auth — recommended over PAT
-      app_id: ${{ vars.BOOTSTRAP_APP_ID }}
+      # GitHub App authentication
+      client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.repo_owner }}
       # Restrict which owners this launcher may target.
       # Use a fixed owner or a repo/org variable — NOT a user-controlled input.
@@ -131,4 +132,6 @@ jobs:
       # Needs a "bootstrap-cleanup" environment in THIS repository.
       require_cleanup_approval: true
     secrets:
-      app_private_key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      # Use this instead of the private key for personal-account creation.
+      BOOTSTRAP_APP_USER_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "$script_dir/../.." && pwd)"
+resolver="$repo_root/.github/actions/resolve-gh-token/action.yml"
+app_validator="$script_dir/validate-app-auth.sh"
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+    grep -Fq "$needle" "$file" || {
+        echo "expected '$needle' in $file" >&2
+        exit 1
+    }
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local file="$2"
+    if grep -Fq "$needle" "$file"; then
+        echo "unexpected '$needle' in $file" >&2
+        exit 1
+    fi
+}
+
+assert_contains "client-id: \${{ inputs.client_id }}" "$resolver"
+assert_contains "private-key: \${{ inputs.app_private_key }}" "$resolver"
+assert_contains "app_user_token" "$resolver"
+assert_contains "GH_TOKEN=\"\$APP_USER_TOKEN\" gh api /user --jq '.login'" "$resolver"
+assert_contains "ghu_ prefix" "$resolver"
+assert_contains "target_owner_type=\"\$(env -u GH_TOKEN -u GITHUB_TOKEN gh api \"/users/\$TARGET_OWNER\" --jq '.type')\"" "$resolver"
+assert_contains "AUTH_MODE=owner-only bash ./scripts/github-setup/validate-app-auth.sh" "$resolver"
+assert_contains "AUTH_MODE=app-user bash ./scripts/github-setup/validate-app-auth.sh" "$resolver"
+assert_contains "echo \"::add-mask::\$APP_USER_TOKEN\"" "$resolver"
+assert_contains "case \"\$target_owner_type\" in" "$resolver"
+assert_contains "Organization)" "$resolver"
+assert_contains "repository-creation|repository-cleanup" "$resolver"
+assert_contains "mode=app-user" "$resolver"
+assert_contains "owner: \${{ inputs.app_owner }}" "$resolver"
+assert_contains "permission-administration:" "$resolver"
+assert_contains "permission-contents:" "$resolver"
+assert_contains "permission-issues:" "$resolver"
+assert_contains "permission-organization-administration:" "$resolver"
+assert_contains "permission_profile:" "$resolver"
+assert_contains "repositories:" "$resolver"
+assert_contains "repositories: \${{ inputs.repositories }}" "$resolver"
+assert_contains "permission-pull-requests:" "$resolver"
+assert_contains "Repository scoping is required" "$resolver"
+assert_contains "Unsupported GitHub App permission profile '\$PERMISSION_PROFILE'" "$resolver"
+assert_contains "required except for repository-creation" "$resolver"
+assert_not_contains "gh_pat_secret" "$resolver"
+assert_not_contains "gh_token" "$resolver"
+
+for workflow in create-repository.yml terraform-create-repository.yml; do
+    workflow_path="$repo_root/.github/workflows/$workflow"
+    assert_contains "client_id: \${{ inputs.client_id }}" "$workflow_path"
+    assert_contains "app_private_key: \${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}" "$workflow_path"
+    assert_contains "app_user_token: \${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}" "$workflow_path"
+    assert_contains "target_owner:" "$workflow_path"
+    assert_contains "Reject internal visibility for personal accounts" "$workflow_path"
+    assert_contains "inputs.visibility == 'internal'" "$workflow_path"
+    assert_contains "Internal visibility is supported only for organization repositories" "$workflow_path"
+    assert_contains "git remote set-url origin" "$workflow_path"
+    assert_contains "http.extraheader=\"AUTHORIZATION: bearer \$GH_TOKEN\"" "$workflow_path"
+    assert_contains "allowed_repo_owners:" "$workflow_path"
+    assert_not_contains "GH_PAT" "$workflow_path"
+    assert_not_contains "gh_token: \${{ inputs.gh_token }}" "$workflow_path"
+    assert_not_contains "REPO_NAME=\"\${{ inputs.repo_name }}\"" "$workflow_path"
+    assert_not_contains "VISIBILITY=\"\${{ inputs.visibility }}\"" "$workflow_path"
+    assert_not_contains "if [ -z \"\${{ inputs.repo_owner }}\" ]" "$workflow_path"
+    assert_not_contains "git clone https://x-access-token:\${GH_TOKEN}@\${GH_HOST}/\${{" "$workflow_path"
+    assert_not_contains "sed -i \"s/team-leads/\${{ inputs.team_name }}/g\"" "$workflow_path"
+    assert_not_contains "OWNER=\"\${{ needs." "$workflow_path"
+done
+
+assert_contains "AUTH_MODE: \${{ steps.resolve-token.outputs.auth_mode }}" "$repo_root/.github/workflows/create-repository.yml"
+assert_contains "set -euo pipefail" "$repo_root/.github/workflows/create-repository.yml"
+assert_not_contains "echo \"repo_created=false\" >> \"\$GITHUB_OUTPUT\"" "$repo_root/.github/workflows/create-repository.yml"
+
+for workflow in create-repository.yml terraform-create-repository.yml; do
+    assert_contains "BOOTSTRAP_APP_USER_TOKEN:" "$repo_root/.github/workflows/$workflow"
+    assert_contains "required: false" "$repo_root/.github/workflows/$workflow"
+done
+
+assert_contains "target_owner: \${{ steps.target.outputs.owner }}" "$repo_root/.github/workflows/delete-repo.yml"
+assert_contains "repositories: \${{ steps.target.outputs.repository }}" "$repo_root/.github/workflows/delete-repo.yml"
+assert_contains "bash ./scripts/github-setup/validate-app-auth.sh" "$resolver"
+assert_contains "repositories: \${{ inputs.repo_name }}" "$repo_root/.github/workflows/setup-existing-repository.yml"
+assert_contains "repositories: \${{ github.event.repository.name }}" "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+assert_contains "repositories: \${{ needs.create-test-repo.outputs.test_repo_name }}" "$repo_root/.github/workflows/test-repository-creation.yml"
+assert_contains "permission_profile: weekly-tooling" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains "uses: ./.github/actions/resolve-gh-token" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains "GITHUB_REPOSITORY_NAME: \${{ github.repository }}" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains "repositories: \${{ steps.repository.outputs.name }}" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_not_contains "GH_TOKEN: \${{ github.token }}" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains "set -euo pipefail" "$resolver"
+assert_not_contains ">> \$GITHUB_OUTPUT" "$resolver"
+assert_not_contains ">> \$GITHUB_OUTPUT" "$repo_root/.github/workflows/test-repository-creation.yml"
+for workflow in create-repository.yml terraform-create-repository.yml test-repository-creation.yml; do
+    assert_not_contains ">> \$GITHUB_STEP_SUMMARY" "$repo_root/.github/workflows/$workflow"
+done
+
+for example in "$repo_root"/examples/launcher-*.yml; do
+    assert_not_contains "PAT" "$example"
+    assert_not_contains "app_id" "$example"
+done
+
+assert_not_contains "app_id" "$repo_root/README.md"
+assert_not_contains "app_id" "$repo_root/terraform/README.md"
+assert_contains "allowed_repo_owners" "$repo_root/terraform/README.md"
+assert_contains "personal-account mode" "$repo_root/README.md"
+assert_not_contains "BOOTSTRAP_APP_ID" "$repo_root/examples/launcher-actions.yml"
+assert_not_contains "BOOTSTRAP_APP_ID" "$repo_root/examples/launcher-terraform.yml"
+assert_contains "Owner allowlist is required" "$repo_root/.github/actions/validate-bootstrap-owner/action.yml"
+assert_not_contains 'default: ""' "$repo_root/.github/actions/validate-bootstrap-owner/action.yml"
+assert_contains "GitHub App user access token for personal targets" "$repo_root/terraform/README.md"
+assert_contains "empty uses the authenticated token owner" "$repo_root/terraform/variables.tf"
+assert_contains "When empty, the GitHub provider uses the authenticated token owner" "$repo_root/terraform/README.md"
+assert_not_contains "Members, pull requests, actions" "$repo_root/docs/github-app-permission-matrix.md"
+assert_contains "Pull-request" "$repo_root/docs/github-app-permission-matrix.md"
+assert_contains "does not match target repository owner" "$app_validator"
+assert_contains "GitHub App user-token owner" "$app_validator"
+assert_contains "Configured GitHub App owner" "$app_validator"
+assert_contains "AUTH_MODE=\"\${AUTH_MODE:-app}\"" "$app_validator"
+assert_contains "AUTH_MODE=app-user" "$resolver"
+assert_contains "GitHub App user access tokens are reserved" "$repo_root/.github/actions/audit-bootstrap-request/action.yml"
+assert_contains "set -euo pipefail" "$repo_root/.github/actions/audit-bootstrap-request/action.yml"
+assert_contains ">> \"\$GITHUB_OUTPUT\"" "$repo_root/.github/workflows/terraform-create-repository.yml"
+assert_not_contains ">> \$GITHUB_OUTPUT" "$repo_root/.github/workflows/create-repository.yml"
+
+expect_rejected() {
+    if env "$@" > /dev/null 2>&1; then
+        echo "expected App configuration to be rejected: $*" >&2
+        exit 1
+    fi
+}
+
+APP_CLIENT_ID=client APP_PRIVATE_KEY=key APP_OWNER=acme TARGET_OWNER=acme \
+    bash "$app_validator" > /dev/null
+AUTH_MODE=app-user APP_OWNER=alice TARGET_OWNER=Alice \
+    bash "$app_validator" > /dev/null
+AUTH_MODE=owner-only APP_OWNER=alice TARGET_OWNER=Alice \
+    bash "$app_validator" > /dev/null
+expect_rejected APP_CLIENT_ID=client APP_PRIVATE_KEY=key APP_OWNER=acme TARGET_OWNER=other \
+    bash "$app_validator"
+expect_rejected AUTH_MODE=app-user APP_OWNER=alice TARGET_OWNER=other \
+    bash "$app_validator"
+expect_rejected APP_CLIENT_ID=client APP_PRIVATE_KEY= APP_OWNER=acme TARGET_OWNER=acme \
+    bash "$app_validator"
+expect_rejected APP_CLIENT_ID=client APP_PRIVATE_KEY=key APP_OWNER= TARGET_OWNER=acme \
+    bash "$app_validator"
+
+echo "GitHub App auth contract checks passed."

--- a/scripts/github-setup/test-profile.sh
+++ b/scripts/github-setup/test-profile.sh
@@ -79,7 +79,7 @@ for creation_workflow in \
     "$repo_root/.github/workflows/terraform-create-repository.yml"; do
     grep -q 'cp AGENTS.md new-repo/' "$creation_workflow"
     grep -q 'cp WORKTREES.md new-repo/' "$creation_workflow"
-    grep -q 'tr -d '\''[:space:]'\''' "$creation_workflow"
+    grep -qF "tr -d '[:space:]'" "$creation_workflow"
     grep -q 'DELIVERY_MODE.*CENTRAL_REPOSITORY.*CENTRAL_REF' "$creation_workflow"
     grep -q '^      app_owner:' "$creation_workflow"
     grep -q '^      allowed_repo_owners:' "$creation_workflow"
@@ -94,7 +94,7 @@ if grep -Eq '^    if: .*matrix\.' "$repo_root/.github/workflows/test-generated-r
 fi
 grep -q '^      - name: Select requested creation workflow$' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
 for runtime_input in python_version node_version go_version java_version; do
-    runtime_env="${runtime_input^^}"
+    runtime_env="$(printf '%s' "$runtime_input" | tr '[:lower:]' '[:upper:]')"
     grep -q -- "--field ${runtime_input}=\"\$${runtime_env}\"" \
         "$repo_root/.github/workflows/test-repository-creation.yml"
 done
@@ -138,7 +138,8 @@ for json_quality_file in \
     "$repo_root/templates/.github/actions/quality/run-capability/action.yml" \
     "$repo_root/templates/centralized-actions-workflows/.github/workflows/quality.yml"; do
     grep -q 'provider_run bash -c' "$json_quality_file"
-    grep -q "cd \"\$WORKING_DIRECTORY\" && find" "$json_quality_file"
+    grep -Eq -- "-path ['\"]\\./\\.git['\"] -prune -o -path ['\"]\\./node_modules['\"] -prune -o" "$json_quality_file"
+    grep -Eq -- "-type f -name ['\"]\\*\.json['\"] -exec jq empty \\{\\} \\+" "$json_quality_file"
     if grep -Eq 'while .*provider_run jq empty' "$json_quality_file"; then
         echo "lint-json must enter the provider once per capability: $json_quality_file" >&2
         exit 1

--- a/scripts/github-setup/validate-app-auth.sh
+++ b/scripts/github-setup/validate-app-auth.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_value() {
+    local name="$1"
+    local value="${!name:-}"
+    if [ -z "$value" ]; then
+        echo "::error::GitHub App authentication requires $name." >&2
+        exit 1
+    fi
+}
+
+AUTH_MODE="${AUTH_MODE:-app}"
+case "$AUTH_MODE" in
+    owner-only | app-user) ;;
+    app)
+        required_value APP_CLIENT_ID
+        required_value APP_PRIVATE_KEY
+        ;;
+    *)
+        echo "::error::Unsupported GitHub App authentication mode '$AUTH_MODE'." >&2
+        exit 1
+        ;;
+esac
+required_value APP_OWNER
+required_value TARGET_OWNER
+
+owner_pattern='^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$'
+for owner_name in APP_OWNER TARGET_OWNER; do
+    owner_value="${!owner_name}"
+    if [[ ! "$owner_value" =~ $owner_pattern ]]; then
+        echo "::error::Invalid GitHub owner in $owner_name: '$owner_value'." >&2
+        exit 1
+    fi
+done
+
+normalized_app_owner="$(printf '%s' "$APP_OWNER" | tr '[:upper:]' '[:lower:]')"
+normalized_target_owner="$(printf '%s' "$TARGET_OWNER" | tr '[:upper:]' '[:lower:]')"
+if [ "$normalized_app_owner" != "$normalized_target_owner" ]; then
+    case "$AUTH_MODE" in
+        app)
+            owner_binding="GitHub App installation owner"
+            ;;
+        app-user)
+            owner_binding="GitHub App user-token owner"
+            ;;
+        owner-only)
+            owner_binding="Configured GitHub App owner"
+            ;;
+    esac
+    echo "::error::$owner_binding '$APP_OWNER' does not match target repository owner '$TARGET_OWNER'." >&2
+    exit 1
+fi

--- a/templates/.github/actions/quality/run-capability/action.yml
+++ b/templates/.github/actions/quality/run-capability/action.yml
@@ -46,7 +46,9 @@ runs:
             provider_run markdownlint --config .github/linters/.markdownlint.json --ignore CHANGELOG.md --ignore node_modules --ignore .git .
             ;;
           lint-json)
-            provider_run bash -c "cd \"$WORKING_DIRECTORY\" && find . -path './.git' -prune -o -path './node_modules' -prune -o -type f -name '*.json' -exec jq empty {} +"
+            provider_run bash -c "cd \"$WORKING_DIRECTORY\" && find . \\
+              -path './.git' -prune -o -path './node_modules' -prune -o \\
+              -type f -name '*.json' -exec jq empty {} +"
             ;;
           lint-yaml)
             provider_run yamllint --config-file .github/linters/.yaml-lint.yml .

--- a/templates/.github/actions/quality/run-quality/action.yml
+++ b/templates/.github/actions/quality/run-quality/action.yml
@@ -50,7 +50,9 @@ runs:
                   "$WORKING_DIRECTORY"
                 ;;
               lint-json)
-                provider_run bash -c "cd \"$WORKING_DIRECTORY\" && find . -path './.git' -prune -o -path './node_modules' -prune -o -type f -name '*.json' -exec jq empty {} +"
+                provider_run bash -c "cd \"$WORKING_DIRECTORY\" && find . \\
+                  -path './.git' -prune -o -path './node_modules' -prune -o \\
+                  -type f -name '*.json' -exec jq empty {} +"
                 ;;
               lint-yaml) provider_run yamllint --config-file "$WORKING_DIRECTORY/.github/linters/.yaml-lint.yml" "$WORKING_DIRECTORY" ;;
               lint-actions)

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,73 +19,36 @@ This Terraform module creates a fully configured GitHub repository with the same
 
 ### Prerequisites
 
-Recommended: a tenant-installed GitHub App with `app_id` + private key.
-Fallback: a GitHub Personal Access Token (PAT).
+Use the Terraform workflow with a GitHub App. Organization targets use a tenant-installed App and
+a short-lived installation token. Personal targets use an App user access token; personal access
+tokens are not supported.
 Terraform CLI version **1.5 or later** is required (see `versions.tf`).
-
-| Use case                                           | Required PAT scopes (fallback mode)  |
-| -------------------------------------------------- | ------------------------------------ |
-| Personal account repository                        | `repo`                               |
-| Organization repository                            | `repo` + `admin:org`                 |
-| Cleanup on failure (`delete_repo`) — personal repo | `repo` + `delete_repo`               |
-| Cleanup on failure (`delete_repo`) — org repo      | `repo` + `admin:org` + `delete_repo` |
-
-### Apply via CLI — personal repository
-
-```bash
-# Option 1: pass token via environment variable (recommended — avoids shell history)
-export TF_VAR_github_token="ghp_yourtoken"
-
-cd terraform
-terraform init
-terraform apply \
-  -var="repo_name=my-new-repo"
-
-# Option 2: pass token inline
-cd terraform
-terraform init
-terraform apply \
-  -var="github_token=ghp_yourtoken" \
-  -var="repo_name=my-new-repo"
-```
-
-### Apply via CLI — organization repository
-
-```bash
-cd terraform
-
-terraform init
-
-terraform apply \
-  -var="github_token=ghp_yourtoken" \
-  -var="repo_name=my-new-repo" \
-  -var="repo_owner=my-org" \
-  -var="visibility=private" \
-  -var="team_name=my-team"
-```
-
-> **Note:** `internal` visibility is only available for repositories inside a GitHub Organization.
 
 ### Apply via GitHub Actions
 
 1. Fork this repository **or** click **Use this template** inside your organization
-2. Recommended App mode:
-   - add `BOOTSTRAP_APP_PRIVATE_KEY` as an Actions secret
-   - pass `app_id` and `app_owner` when running the workflow
-3. PAT fallback mode:
-   - add a `GH_PAT` repository secret (see [Setup](../README.md#setup))
-4. Trigger the
+2. Configure App mode:
+   - for an organization target, add `BOOTSTRAP_APP_PRIVATE_KEY` as a protected Actions secret
+   - for a personal target, add the authorized App user access token as the protected
+     `BOOTSTRAP_APP_USER_TOKEN` reusable-workflow secret
+   - pass `client_id`, the target owner as `app_owner`, and a comma-separated
+     `allowed_repo_owners` value containing the permitted target owners when running the workflow
+   - never pass credentials through workflow inputs
+3. Trigger the
    [**Terraform Create Repository**](../.github/workflows/terraform-create-repository.yml) workflow
    from the **Actions** tab. It runs `terraform apply` and then copies the bootstrap template files
    into the new repository.
+
+The target owner must be present in `allowed_repo_owners`; the workflow rejects empty
+allowlists and targets outside that explicit list.
 
 ## Input Variables
 
 | Variable                   | Required | Default                                    | Description                                                                                                                                                                                                                                |
 | -------------------------- | -------- | ------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `github_token`             | **Yes**  | -                                          | GitHub PAT — `repo` scope for personal repos; add `admin:org` for organization repos                                                                                                                                                       |
+| `github_token`             | **Yes**  | -                                          | GitHub App installation token for organization targets or GitHub App user access token for personal targets, supplied internally by the workflow                                                                                           |
 | `repo_name`                | **Yes**  | -                                          | New repository name                                                                                                                                                                                                                        |
-| `repo_owner`               | No       | `""` (uses token owner)                    | Repository owner (user or organization)                                                                                                                                                                                                    |
+| `repo_owner`               | No       | `""`                                       | Repository owner; may be an organization or the authorized personal account. When empty, the GitHub provider uses the authenticated token owner.                                                                                           |
 | `repo_description`         | No       | `"Repository following SOLID principles…"` | Repository description                                                                                                                                                                                                                     |
 | `visibility`               | No       | `"public"`                                 | `public`, `private`, or `internal`                                                                                                                                                                                                         |
 | `enable_branch_protection` | No       | `false`                                    | Opt-in: create a Terraform-managed branch protection ruleset for `main`. Disabled by default; bootstrap workflows apply the default ruleset via `apply-repository-ruleset`. Enable only when managing rulesets through Terraform directly. |
@@ -159,7 +122,7 @@ Common failure signatures and quick triage:
 
 | Failure signature                                      | Where it appears                                 | Likely cause                                                    | What to do                                                                                                                              |
 | ------------------------------------------------------ | ------------------------------------------------ | --------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
-| `Error: creating repository`                           | Terraform apply output                           | token lacks required permissions/scopes                         | Verify App installation scope or PAT scopes (`repo`, plus `admin:org` for org repos).                                                   |
+| `Error: creating repository`                           | Terraform apply output                           | App installation lacks required permissions                     | Verify the App installation and the [permission matrix](../docs/github-app-permission-matrix.md).                                       |
 | `Error: creating repository ruleset`                   | Terraform apply output                           | plan/features do not support rulesets or settings conflict      | Keep `enable_branch_protection=false` unless Terraform should own rulesets, and avoid dual ownership with workflow ruleset application. |
 | `Error: creating environment`                          | Terraform apply output                           | missing admin rights or existing environment policy constraints | Confirm token has administration rights and inspect existing environment configuration.                                                 |
 | Workflow succeeds but expected files are missing       | Post-apply template copy step                    | wrapper workflow failed after Terraform apply                   | Inspect `terraform-create-repository.yml` run logs after the apply step.                                                                |

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 variable "github_token" {
-  description = "GitHub personal access token with repository permissions"
+  description = "GitHub App installation or user access token supplied by the workflow"
   type        = string
   sensitive   = true
 }
@@ -10,7 +10,7 @@ variable "repo_name" {
 }
 
 variable "repo_owner" {
-  description = "Repository owner (user or organization). Defaults to the token owner."
+  description = "Repository owner (organization or authorized personal account); empty uses the authenticated token owner"
   type        = string
   default     = ""
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

- Require short-lived GitHub App installation tokens for repository workflows.
- Validate complete App credentials, owner binding, mandatory owner allowlists, and repository scoping.
- Apply operation-specific permission profiles and remove PAT/token workflow inputs.
- Keep embedded and centralized delivery behavior unchanged.
- Document the permission matrix and credentialed E2E follow-up plan.

## Related Issue

Closes #86

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Exact checks run:

- `scripts/github-setup/test-app-auth-contract.sh`
- `scripts/github-setup/test-profile.sh`
- `bash -n` for changed shell scripts
- `actionlint -ignore 'SC[0-9]+' .github/workflows/*.yml`
- `LINT_MODE=check make lint`
- `git diff --check`

The complete lint suite passed, including ShellCheck, yamllint, generated workflow assets, Terraform formatting, Go formatting, Go vet, and Go tests.

Live App authentication was not run because no disposable credentialed test App was available. The credentialed E2E implementation plan is documented in `docs/github-app-e2e-plan.md`.

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer