### PR TITLE
feat: add personal App credential bootstrap E2E

### DIFF
--- a/.github/actions/resolve-gh-token/action.yml
+++ b/.github/actions/resolve-gh-token/action.yml
@@ -96,6 +96,10 @@ runs:
             echo "mode=app-user" >> "$GITHUB_OUTPUT"
             ;;
           Organization)
+            if [ -n "$APP_USER_TOKEN" ]; then
+              echo "::error::User access tokens cannot be used for organization targets; use an installation token." >&2
+              exit 1
+            fi
             AUTH_MODE=app bash ./scripts/github-setup/validate-app-auth.sh
             echo "mode=app" >> "$GITHUB_OUTPUT"
             ;;

--- a/.github/workflows/test-personal-app-e2e.yml
+++ b/.github/workflows/test-personal-app-e2e.yml
@@ -1,0 +1,112 @@
+name: Test Personal GitHub App E2E
+
+on:
+  workflow_dispatch:
+    inputs:
+      personal_owner:
+        description: Personal GitHub owner authorized for the App user token.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  contract-preflight:
+    name: Personal auth negative contracts
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout bootstrap repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Verify personal fail-closed contracts
+        env:
+          PERSONAL_OWNER: ${{ inputs.personal_owner }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -Fq "Internal visibility is supported only for organization repositories" .github/workflows/create-repository.yml
+          grep -Fq "requires a GitHub App user access token (ghu_ prefix)" .github/actions/resolve-gh-token/action.yml
+          grep -Fq "does not match target repository owner" scripts/github-setup/validate-app-auth.sh
+          grep -Fq "User access tokens cannot be used for organization targets" .github/actions/resolve-gh-token/action.yml
+          [[ "$PERSONAL_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]
+
+  create-public:
+    name: Create public personal repository
+    needs: contract-preflight
+    uses: ./.github/workflows/create-repository.yml
+    with:
+      repo_name: bootstrap-app-e2e-${{ github.run_id }}-public
+      repo_owner: ${{ inputs.personal_owner }}
+      visibility: public
+      cleanup_on_failure: true
+      env_manager: system
+      client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
+      app_owner: ${{ inputs.personal_owner }}
+      allowed_repo_owners: ${{ inputs.personal_owner }}
+      require_cleanup_approval: false
+    secrets:
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_USER_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+
+  create-private:
+    name: Create private personal repository
+    needs: create-public
+    uses: ./.github/workflows/create-repository.yml
+    with:
+      repo_name: bootstrap-app-e2e-${{ github.run_id }}-private
+      repo_owner: ${{ inputs.personal_owner }}
+      visibility: private
+      cleanup_on_failure: true
+      env_manager: system
+      client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
+      app_owner: ${{ inputs.personal_owner }}
+      allowed_repo_owners: ${{ inputs.personal_owner }}
+      require_cleanup_approval: false
+    secrets:
+      BOOTSTRAP_APP_PRIVATE_KEY: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+      BOOTSTRAP_APP_USER_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+
+  cleanup:
+    name: Delete only personal E2E repositories
+    if: ${{ always() }}
+    needs: [create-public, create-private]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Delete exact test repositories
+        env:
+          GH_TOKEN: ${{ secrets.BOOTSTRAP_APP_USER_TOKEN }}
+          PERSONAL_OWNER: ${{ inputs.personal_owner }}
+          PUBLIC_REPO: bootstrap-app-e2e-${{ github.run_id }}-public
+          PRIVATE_REPO: bootstrap-app-e2e-${{ github.run_id }}-private
+        shell: bash
+        run: |
+          set -euo pipefail
+          if ! [[ "$PERSONAL_OWNER" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]]; then
+            echo "Invalid personal owner; refusing cleanup API calls" >&2
+            exit 1
+          fi
+          owner_type="$(gh api "/users/$PERSONAL_OWNER" --jq '.type')"
+          if [ "$owner_type" != "User" ]; then
+            echo "GitHub owner is not a personal user; refusing cleanup API calls" >&2
+            exit 1
+          fi
+          authenticated_user="$(gh api /user --jq '.login')"
+          normalized_user="$(printf '%s' "$authenticated_user" | tr '[:upper:]' '[:lower:]')"
+          normalized_owner="$(printf '%s' "$PERSONAL_OWNER" | tr '[:upper:]' '[:lower:]')"
+          if [ "$normalized_user" != "$normalized_owner" ]; then
+            echo "App user token identity does not match personal owner; refusing cleanup API calls" >&2
+            exit 1
+          fi
+          for repository in "$PUBLIC_REPO" "$PRIVATE_REPO"; do
+            if gh api "/repos/$PERSONAL_OWNER/$repository" >/dev/null 2>&1; then
+              gh api --method DELETE "/repos/$PERSONAL_OWNER/$repository" >/dev/null
+              echo "Deleted $PERSONAL_OWNER/$repository"
+            else
+              echo "No repository found at $PERSONAL_OWNER/$repository"
+            fi
+          done

--- a/README.md
+++ b/README.md
@@ -67,6 +67,55 @@ the App user access token, verifies its `/user` login against the target owner, 
 
 **Note:** `internal` visibility is only available for repositories inside a GitHub Organization.
 
+### Personal App Manifest E2E setup
+
+For a disposable personal-account E2E, create the App through GitHub's App Manifest flow. GitHub
+generates the private key during conversion; do not generate one locally:
+
+```bash
+credential_dir="$HOME/.local/state/github-bootstrap"
+scripts/github-setup/github-app-manifest.sh url
+# Open the printed URL, approve the App, and copy the one-time conversion code.
+scripts/github-setup/github-app-manifest.sh convert CODE "$credential_dir"
+```
+
+The conversion command writes GitHub's private key, client ID, and client secret only under the
+0700 output directory, with each file set to 0600. The example keeps that directory outside the
+repository checkout; remove it after setup. Use the App client ID and secret to authorize the
+personal account, then exchange the callback code:
+
+```bash
+credential_dir="$HOME/.local/state/github-bootstrap"
+redirect_uri="https://github.com/settings/apps/new"
+scripts/github-setup/github-app-user-token.sh url CLIENT_ID OWNER "$redirect_uri" STATE
+APP_CLIENT_SECRET_FILE="$credential_dir/app-client-secret" \
+APP_REDIRECT_URI="$redirect_uri" \
+  scripts/github-setup/github-app-user-token.sh exchange CLIENT_ID CODE OWNER "$credential_dir/app-user-token"
+scripts/github-setup/install-app-secrets.sh OWNER/github-bootstrap \
+  "$credential_dir/app-client-id" \
+  "$credential_dir/app-private-key.pem" \
+  "$credential_dir/app-user-token"
+```
+
+The installer sets `BOOTSTRAP_APP_CLIENT_ID` as a repository variable and installs only
+`BOOTSTRAP_APP_PRIVATE_KEY` and the verified `BOOTSTRAP_APP_USER_TOKEN` as repository secrets. It
+never accepts a PAT or passes credentials through workflow-dispatch inputs. Run
+`Test Personal GitHub App E2E` with the personal owner; it creates and cleans up only the two
+repositories named for that run. Organization installation-token E2E remains pending without a
+disposable organization.
+
+After the disposable E2E, remove the repository configuration and revoke or rotate the App
+credentials. This deletes the stored values without exposing them:
+
+```bash
+gh secret delete BOOTSTRAP_APP_PRIVATE_KEY --repo OWNER/github-bootstrap --confirm
+gh secret delete BOOTSTRAP_APP_USER_TOKEN --repo OWNER/github-bootstrap --confirm
+gh variable delete BOOTSTRAP_APP_CLIENT_ID --repo OWNER/github-bootstrap --confirm
+```
+
+Also revoke the App user authorization and delete or rotate the App private key in GitHub if the
+App will not be reused. Remove the external local credential directory afterward.
+
 ## Quick Start
 
 Choose one of three methods to bootstrap a new repository:

--- a/docs/superpowers/plans/2026-08-25-app-manifest-personal-e2e.md
+++ b/docs/superpowers/plans/2026-08-25-app-manifest-personal-e2e.md
@@ -1,0 +1,64 @@
+# GitHub App Manifest Personal E2E Implementation Plan
+
+> Steps use checkbox (`- [ ]`) syntax for tracking. The repository-level workflow skills are supplied by the active agent environment; this plan does not require copies under `.github/skills/`.
+
+**Goal:** Add safe GitHub App Manifest/OAuth bootstrap helpers and a guarded personal-account E2E path using GitHub-generated credentials.
+
+**Architecture:** Shell helpers handle App Manifest conversion and user OAuth without placing credentials in Git, workflows, generated repositories, or logs. Protected local files are the temporary handoff boundary for GitHub-generated credentials. Existing workflows remain the only repository-creation implementation; the E2E harness supplies protected secrets and verifies ownership and cleanup.
+
+**Tech Stack:** Bash, GitHub CLI, GitHub REST API, GitHub Actions reusable workflows.
+
+**Spec:** `docs/superpowers/specs/2026-08-25-app-manifest-personal-e2e-design.md`
+
+## Global Constraints
+
+- GitHub generates the App private key; local code never generates or fabricates one.
+- Personal user tokens must have the `ghu_` prefix and match `/user` to the target owner.
+- Credentials never enter Git, generated repositories, test repositories, workflow inputs, or logs.
+- Organization installation-token E2E remains pending.
+
+### Task 1: Manifest bootstrap helper
+
+**Files:**
+
+- Create: `scripts/github-setup/github-app-manifest.sh`
+- Test: `scripts/github-setup/test-app-manifest-contract.sh`
+
+- [ ] Add subcommands `url` and `convert`, strict validation, exact personal permission payload, and protected output behavior.
+- [ ] Add contract assertions for permissions and credential-safe output.
+- [ ] Run `bash scripts/github-setup/test-app-manifest-contract.sh`.
+
+### Task 2: User-token authorization helper
+
+**Files:**
+
+- Create: `scripts/github-setup/github-app-user-token.sh`
+- Test: `scripts/github-setup/test-app-user-token-contract.sh`
+
+- [ ] Implement URL generation and code exchange using a protected client-secret file.
+- [ ] Verify the resulting token starts with `ghu_` and `/user` matches the requested owner.
+- [ ] Add contract assertions preventing PAT fallback and token logging.
+- [ ] Run shell syntax and contract tests.
+
+### Task 3: Protected secret delivery and E2E entry point
+
+**Files:**
+
+- Create: `scripts/github-setup/install-app-secrets.sh`
+- Create: `scripts/github-setup/test-personal-app-e2e-contract.sh`
+- Modify: `.github/workflows/test-repository-creation.yml`
+- Modify: `README.md`
+
+- [ ] Deliver only `BOOTSTRAP_APP_PRIVATE_KEY` and `BOOTSTRAP_APP_USER_TOKEN` from explicit protected files using `gh secret set`.
+- [ ] Refuse missing files, non-`ghu_` user tokens, and PAT-like values before any workflow dispatch.
+- [ ] Add a guarded personal E2E workflow that runs only the personal scenarios and records no credential values.
+- [ ] Document manual App authorization and organization limitation.
+- [ ] Run all local contracts and inspect the resulting diff.
+
+### Task 4: Full verification
+
+- [ ] Run deterministic resolver and profile tests.
+- [ ] Run YAML/action validation.
+- [ ] Run `LINT_MODE=check make lint`.
+- [ ] Run the guarded live personal E2E only if real App authorization and protected secrets are present.
+- [ ] Re-run final status, diff, and verification checks.

--- a/docs/superpowers/specs/2026-08-25-app-manifest-personal-e2e-design.md
+++ b/docs/superpowers/specs/2026-08-25-app-manifest-personal-e2e-design.md
@@ -1,0 +1,29 @@
+# GitHub App Manifest Personal E2E Design
+
+## Goal
+
+Provide a safe, repeatable bootstrap path for creating or configuring a GitHub App and obtaining a real personal-account App user token for the existing personal repository-creation workflow.
+
+## Boundaries
+
+- GitHub generates the App private key; local code never generates or fabricates one.
+- The App uses `administration: write`, `contents: write`, and `issues: write`; metadata remains automatic read.
+- `organization-administration` is excluded from the personal profile.
+- Client ID is non-secret configuration. Private key, client secret, refresh token, and `ghu_` user token are never committed or passed as workflow inputs.
+- Organization installation-token E2E remains pending because no disposable organization is available.
+
+## Design
+
+Add a local shell helper that creates a GitHub App Manifest authorization URL and a second command that exchanges the one-time conversion code with GitHub. The conversion response is stored only under a caller-selected 0700 directory, with the returned private key, client ID, and client secret written to separate 0600 files. This allows the caller to put the GitHub-generated private key into `BOOTSTRAP_APP_PRIVATE_KEY` without logging it.
+
+Add a separate authorization helper that accepts the App client ID as an argument and the client secret through a protected file path, starts the GitHub App user OAuth flow, exchanges the callback code, verifies `/user` is the intended personal owner, and emits token metadata without the token value. Secret delivery remains an explicit `gh secret set` operation from protected files.
+
+Add contract tests for manifest permissions, secret boundaries, token prefix/identity checks, and the absence of workflow-dispatch credential inputs. Add a credentialed personal E2E entry point that is manually dispatched with explicit personal-owner input and never falls back to PAT authentication.
+
+## Failure handling
+
+Every helper uses strict shell mode, validates owner and token identity before repository creation, rejects non-`ghu_` tokens, and refuses to print credentials. If GitHub authorization or protected secret delivery is unavailable, the live E2E exits before creating a repository.
+
+## Verification
+
+Run deterministic auth/profile contracts, helper shell syntax checks, YAML/action validation, complete `LINT_MODE=check make lint`, then the explicitly enabled personal E2E. Report organization E2E as pending.

--- a/scripts/github-setup/github-app-manifest.sh
+++ b/scripts/github-setup/github-app-manifest.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2218
+set -euo pipefail
+umask 077
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/github-setup/gh-common.sh
+source "$script_dir/gh-common.sh"
+
+usage() {
+    cat >&2 << 'EOF'
+Usage:
+    github-app-manifest.sh url [app-name] [redirect-url]
+    github-app-manifest.sh convert CODE OUTPUT_DIRECTORY
+
+The convert command writes GitHub's returned App private key and metadata to
+0600 files in OUTPUT_DIRECTORY. It never prints credentials.
+EOF
+    exit 2
+}
+
+main() {
+    command_name="${1:-}"
+    case "$command_name" in
+        url)
+            require_command python3
+            python3 - "${2:-github-bootstrap-personal-e2e}" "${3:-https://github.com/settings/apps/new}" << 'PY'
+import json
+import sys
+import urllib.parse
+
+app_name, redirect_url = sys.argv[1:]
+manifest = {
+    "name": app_name,
+    "url": "https://github.com",
+    "redirect_url": redirect_url,
+    "public": False,
+    "default_events": [],
+    "default_permissions": {
+        "administration": "write",
+        "contents": "write",
+        "issues": "write",
+        "metadata": "read",
+    },
+}
+encoded_manifest = urllib.parse.quote(json.dumps(manifest, separators=(",", ":")), safe="")
+print(f"https://github.com/settings/apps/new?manifest={encoded_manifest}")
+PY
+            ;;
+        convert)
+            require_command curl
+            require_command jq
+            code="${2:-}"
+            output_dir="${3:-}"
+            [ -n "$code" ] && [ -n "$output_dir" ] || usage
+            [[ "$code" =~ ^[A-Za-z0-9_-]+$ ]] || {
+                echo "invalid App Manifest conversion code" >&2
+                exit 1
+            }
+            mkdir -p "$output_dir"
+            chmod 700 "$output_dir"
+            response_file="$(mktemp "$output_dir/response.XXXXXX")"
+            trap 'rm -f "$response_file"' EXIT
+            chmod 600 "$response_file"
+            curl --fail --silent --show-error --location \
+                --header 'Accept: application/vnd.github+json' \
+                --header 'Content-Type: application/json' \
+                --data '{}' \
+                "https://api.github.com/app-manifests/$code/conversions" > "$response_file"
+            jq -e '.pem | type == "string" and length > 0' "$response_file" > /dev/null
+            jq -e '.client_id | type == "string" and length > 0' "$response_file" > /dev/null
+            jq -e '.client_secret | type == "string" and length > 0' "$response_file" > /dev/null
+            jq -r '.pem' "$response_file" > "$output_dir/app-private-key.pem"
+            jq -j '.client_id' "$response_file" > "$output_dir/app-client-id"
+            jq -j '.client_secret' "$response_file" > "$output_dir/app-client-secret"
+            chmod 600 "$output_dir/app-private-key.pem" "$output_dir/app-client-id" "$output_dir/app-client-secret"
+            printf 'GitHub App conversion completed; protected metadata written under %s\n' "$output_dir"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+main "$@"

--- a/scripts/github-setup/github-app-user-token.sh
+++ b/scripts/github-setup/github-app-user-token.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091,SC2218
+set -euo pipefail
+umask 077
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/github-setup/gh-common.sh
+source "$script_dir/gh-common.sh"
+
+write_protected_token() {
+    local token_value="$1"
+    local output_path="$2"
+    local output_dir
+    local output_base
+    local temporary_path
+
+    output_dir="$(dirname "$output_path")"
+    output_base="$(basename "$output_path")"
+    if [ ! -d "$output_dir" ]; then
+        echo "token output directory does not exist: $output_dir" >&2
+        exit 1
+    fi
+    temporary_path="$(mktemp "$output_dir/.$output_base.XXXXXX")"
+    chmod 600 "$temporary_path"
+    if ! printf '%s' "$token_value" > "$temporary_path"; then
+        rm -f "$temporary_path"
+        exit 1
+    fi
+    if ! mv -f "$temporary_path" "$output_path"; then
+        rm -f "$temporary_path"
+        exit 1
+    fi
+}
+
+usage() {
+    cat >&2 << 'EOF'
+Usage:
+    github-app-user-token.sh url CLIENT_ID OWNER REDIRECT_URI STATE
+    github-app-user-token.sh device-start CLIENT_ID RESPONSE_FILE
+    github-app-user-token.sh device-poll CLIENT_ID RESPONSE_FILE OWNER TOKEN_FILE
+    APP_CLIENT_SECRET_FILE=... APP_REDIRECT_URI=... github-app-user-token.sh exchange CLIENT_ID CODE OWNER TOKEN_FILE
+    APP_CLIENT_SECRET_FILE=... APP_REDIRECT_URI=... github-app-user-token.sh exchange-file CLIENT_ID CODE_FILE OWNER TOKEN_FILE
+
+The exchange command verifies the token's /user identity and writes only the
+short-lived access token to TOKEN_FILE with mode 0600. Other OAuth response
+credentials are never written or printed.
+EOF
+    exit 2
+}
+
+device_start() {
+    require_command curl
+    require_command jq
+    client_id="${2:-}"
+    response_file="${3:-}"
+    [ -n "$client_id" ] && [ -n "$response_file" ] || usage
+    curl --fail --silent --show-error --location \
+        --header 'Accept: application/json' \
+        --data-urlencode "client_id=$client_id" \
+        'https://github.com/login/device/code' > "$response_file"
+    chmod 600 "$response_file"
+    jq -e '.device_code and .user_code and .verification_uri' "$response_file" > /dev/null
+    verification_uri="$(jq -r '.verification_uri' "$response_file")"
+    user_code="$(jq -r '.user_code' "$response_file")"
+    printf 'Open %s and enter user code %s. Protected device response: %s\n' \
+        "$verification_uri" "$user_code" "$response_file"
+}
+
+verify_token_owner() {
+    local token_value="$1"
+    local expected_owner="$2"
+    local authenticated_user
+    local normalized_user
+    local normalized_owner
+
+    authenticated_user="$(GH_TOKEN="$token_value" gh api /user --jq '.login')"
+    normalized_user="$(printf '%s' "$authenticated_user" | tr '[:upper:]' '[:lower:]')"
+    normalized_owner="$(printf '%s' "$expected_owner" | tr '[:upper:]' '[:lower:]')"
+    if [ "$normalized_user" != "$normalized_owner" ]; then
+        echo "App user token identity does not match the requested personal owner." >&2
+        return 1
+    fi
+}
+
+device_poll() {
+    require_command curl
+    require_command jq
+    require_command gh
+    client_id="${2:-}"
+    response_file="${3:-}"
+    owner="${4:-}"
+    token_file="${5:-}"
+    [ -n "$client_id" ] && [ -f "$response_file" ] && [ -n "$owner" ] && [ -n "$token_file" ] || usage
+    device_code="$(jq -er '.device_code' "$response_file")"
+    interval="$(jq -er '.interval // 5' "$response_file")"
+    expires_in="$(jq -er '.expires_in // 900' "$response_file")"
+    deadline=$(($(date +%s) + expires_in))
+    poll_file="$(mktemp)"
+    chmod 600 "$poll_file"
+    trap 'rm -f "$poll_file"' EXIT
+    while [ "$(date +%s)" -lt "$deadline" ]; do
+        curl --fail --silent --show-error --location \
+            --header 'Accept: application/json' \
+            --data-urlencode "client_id=$client_id" \
+            --data-urlencode "device_code=$device_code" \
+            --data-urlencode 'grant_type=urn:ietf:params:oauth:grant-type:device_code' \
+            'https://github.com/login/oauth/access_token' > "$poll_file"
+        if token="$(jq -er '.access_token // empty' "$poll_file")"; then
+            case "$token" in
+                ghu_*) ;;
+                *)
+                    echo "GitHub returned a non-App user token; refusing to continue." >&2
+                    exit 1
+                    ;;
+            esac
+            verify_token_owner "$token" "$owner"
+            write_protected_token "$token" "$token_file"
+            printf 'Verified GitHub App user token for %s; protected token written to %s\n' "$owner" "$token_file"
+            exit 0
+        fi
+        oauth_error="$(jq -r '.error // "missing_access_token"' "$poll_file")"
+        case "$oauth_error" in
+            authorization_pending) sleep "$interval" ;;
+            slow_down)
+                interval=$((interval + 5))
+                sleep "$interval"
+                ;;
+            *)
+                echo "GitHub device authorization failed: $oauth_error" >&2
+                exit 1
+                ;;
+        esac
+    done
+    echo "GitHub device authorization expired before approval." >&2
+    exit 1
+}
+
+print_url() {
+    require_command python3
+    client_id="${2:-}"
+    owner="${3:-}"
+    redirect_uri="${4:-}"
+    state="${5:-}"
+    [ -n "$client_id" ] && [ -n "$owner" ] && [ -n "$redirect_uri" ] && [ -n "$state" ] || usage
+    python3 - "$client_id" "$owner" "$redirect_uri" "$state" << 'PY'
+import sys
+import urllib.parse
+
+client_id, owner, redirect_uri, state = sys.argv[1:]
+query = urllib.parse.urlencode({
+    "client_id": client_id,
+    "login": owner,
+    "redirect_uri": redirect_uri,
+    "state": state,
+})
+print(f"https://github.com/login/oauth/authorize?{query}")
+PY
+}
+
+exchange_token() {
+    command_name="$1"
+    require_command curl
+    require_command jq
+    require_command gh
+    client_id="${2:-}"
+    code_or_file="${3:-}"
+    owner="${4:-}"
+    token_file="${5:-}"
+    redirect_uri="${6:-${APP_REDIRECT_URI:-}}"
+    if [ "$command_name" = exchange-file ] && [ ! -f "$code_or_file" ]; then
+        echo "OAuth authorization code file is missing" >&2
+        exit 1
+    fi
+    [ -n "${APP_CLIENT_SECRET_FILE:-}" ] && [ -f "$APP_CLIENT_SECRET_FILE" ] || {
+        echo "APP_CLIENT_SECRET_FILE must name a protected App client secret file" >&2
+        exit 1
+    }
+    [ -n "$client_id" ] && [ -n "$code_or_file" ] && [ -n "$owner" ] && [ -n "$token_file" ] && [ -n "$redirect_uri" ] || usage
+    response_file="$(mktemp)"
+    chmod 600 "$response_file"
+    sanitized_code_file=""
+    sanitized_secret_file="$(mktemp)"
+    chmod 600 "$sanitized_secret_file"
+    trap 'rm -f "$response_file"; if [ -n "$sanitized_code_file" ]; then rm -f "$sanitized_code_file"; fi; rm -f "$sanitized_secret_file"' EXIT
+    tr -d '\r\n' < "$APP_CLIENT_SECRET_FILE" > "$sanitized_secret_file"
+    [ -s "$sanitized_secret_file" ] || {
+        echo "App client secret file is empty" >&2
+        exit 1
+    }
+    if [ "$command_name" = exchange-file ]; then
+        sanitized_code_file="$(mktemp)"
+        chmod 600 "$sanitized_code_file"
+        sanitized_code="$(tr -d '\r\n' < "$code_or_file")"
+        if [[ ! "$sanitized_code" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "invalid OAuth authorization code file" >&2
+            exit 1
+        fi
+        printf '%s' "$sanitized_code" > "$sanitized_code_file"
+        code_field="@$sanitized_code_file"
+    else
+        if [[ ! "$code_or_file" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "invalid OAuth authorization code" >&2
+            exit 1
+        fi
+        code_field="=$code_or_file"
+    fi
+    curl --fail --silent --show-error --location \
+        --header 'Accept: application/json' \
+        --data-urlencode "client_id=$client_id" \
+        --data-urlencode "client_secret@$sanitized_secret_file" \
+        --data-urlencode "redirect_uri=$redirect_uri" \
+        --data-urlencode "code$code_field" \
+        'https://github.com/login/oauth/access_token' > "$response_file"
+    if ! token="$(jq -er '.access_token // empty' "$response_file")"; then
+        oauth_error="$(jq -r '.error // "missing_access_token"' "$response_file")"
+        echo "GitHub OAuth exchange failed: $oauth_error" >&2
+        exit 1
+    fi
+    case "$token" in
+        ghu_*) ;;
+        *)
+            echo "GitHub returned a non-App user token; refusing to continue." >&2
+            exit 1
+            ;;
+    esac
+    verify_token_owner "$token" "$owner"
+    write_protected_token "$token" "$token_file"
+    printf 'Verified GitHub App user token for %s; protected token written to %s\n' "$owner" "$token_file"
+}
+
+main() {
+    case "${1:-}" in
+        device-start) device_start "$@" ;;
+        device-poll) device_poll "$@" ;;
+        url) print_url "$@" ;;
+        exchange | exchange-file) exchange_token "$@" ;;
+        *) usage ;;
+    esac
+}
+
+main "$@"

--- a/scripts/github-setup/install-app-secrets.sh
+++ b/scripts/github-setup/install-app-secrets.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC1091
+set -euo pipefail
+umask 077
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/github-setup/gh-common.sh
+source "$script_dir/gh-common.sh"
+
+usage() {
+    cat >&2 << 'EOF'
+Usage: install-app-secrets.sh REPOSITORY CLIENT_ID_FILE PRIVATE_KEY_FILE USER_TOKEN_FILE
+
+Installs the GitHub-generated private key and ghu_-prefixed App user token as
+repository secrets, and the client ID as a repository variable. The installer
+verifies the token owner identity before writing any repository values.
+EOF
+    exit 2
+}
+
+repo="${1:-}"
+client_id_file="${2:-}"
+private_key_file="${3:-}"
+user_token_file="${4:-}"
+[ "$#" -eq 4 ] || usage
+require_command gh
+owner_pattern='[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?'
+[[ "$repo" =~ ^${owner_pattern}/[A-Za-z0-9._-]+$ ]] || {
+    echo "repository must match OWNER/REPOSITORY" >&2
+    exit 1
+}
+require_file "$client_id_file" "client ID file"
+require_file "$private_key_file" "private key file"
+require_file "$user_token_file" "user token file"
+
+pem_first_line="$(sed -n '1p' "$private_key_file" | tr -d '\r')"
+pem_last_line="$(tail -n 1 "$private_key_file" | tr -d '\r')"
+if [[ "$pem_first_line" =~ ^-----BEGIN\ ([A-Z0-9]+\ )?PRIVATE\ KEY-----$ ]]; then
+    pem_label="${BASH_REMATCH[1]}"
+    expected_pem_end="-----END ${pem_label}PRIVATE KEY-----"
+else
+    expected_pem_end=""
+fi
+if [ -z "$expected_pem_end" ] || [ "$pem_last_line" != "$expected_pem_end" ]; then
+    echo "private key file is not a PEM private key returned by GitHub" >&2
+    exit 1
+fi
+client_id="$(tr -d '\r\n' < "$client_id_file")"
+token="$(tr -d '\r\n' < "$user_token_file")"
+[ -n "$client_id" ] || {
+    echo "client ID file is empty" >&2
+    exit 1
+}
+case "$token" in
+    ghu_*) ;;
+    *)
+        echo "user token file must contain a GitHub App user token with ghu_ prefix" >&2
+        exit 1
+        ;;
+esac
+repository_owner="${repo%%/*}"
+authenticated_user="$(GH_TOKEN="$token" gh api /user --jq '.login')"
+normalized_user="$(printf '%s' "$authenticated_user" | tr '[:upper:]' '[:lower:]')"
+normalized_owner="$(printf '%s' "$repository_owner" | tr '[:upper:]' '[:lower:]')"
+if [ "$normalized_user" != "$normalized_owner" ]; then
+    echo "App user token identity does not match repository owner" >&2
+    exit 1
+fi
+
+sanitized_private_key_file="$(mktemp)"
+chmod 600 "$sanitized_private_key_file"
+sanitized_token_file="$(mktemp)"
+chmod 600 "$sanitized_token_file"
+trap 'rm -f "$sanitized_private_key_file" "$sanitized_token_file"' EXIT
+tr -d '\r' < "$private_key_file" > "$sanitized_private_key_file"
+printf '%s' "$token" > "$sanitized_token_file"
+
+gh variable set BOOTSTRAP_APP_CLIENT_ID --repo "$repo" --body "$client_id"
+gh secret set BOOTSTRAP_APP_PRIVATE_KEY --repo "$repo" < "$sanitized_private_key_file"
+gh secret set BOOTSTRAP_APP_USER_TOKEN --repo "$repo" < "$sanitized_token_file"
+printf 'Installed App client ID configuration and two protected App credentials for %s\n' "$repo"

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -35,6 +35,7 @@ assert_contains "AUTH_MODE=app-user bash ./scripts/github-setup/validate-app-aut
 assert_contains "echo \"::add-mask::\$APP_USER_TOKEN\"" "$resolver"
 assert_contains "case \"\$target_owner_type\" in" "$resolver"
 assert_contains "Organization)" "$resolver"
+assert_contains "User access tokens cannot be used for organization targets" "$resolver"
 assert_contains "repository-creation|repository-cleanup" "$resolver"
 assert_contains "mode=app-user" "$resolver"
 assert_contains "owner: \${{ inputs.app_owner }}" "$resolver"

--- a/scripts/github-setup/test-app-manifest-contract.sh
+++ b/scripts/github-setup/test-app-manifest-contract.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/github-app-manifest.sh"
+
+[ -x "$helper" ] || {
+    echo "manifest helper is not executable" >&2
+    exit 1
+}
+grep -Fq "source \"\$script_dir/gh-common.sh\"" "$helper"
+
+grep -Fq '"administration": "write"' "$helper"
+grep -Fq '"contents": "write"' "$helper"
+grep -Fq '"issues": "write"' "$helper"
+grep -Fq '"metadata": "read"' "$helper"
+if grep -Fq 'organization-administration' "$helper"; then
+    echo "personal manifest must not request organization administration" >&2
+    exit 1
+fi
+grep -Fq 'app-manifests' "$helper"
+grep -Fq 'umask 077' "$helper"
+grep -Fq 'chmod 600' "$helper"
+grep -Fq 'private key' "$helper"
+grep -Fq "jq -j '.client_id'" "$helper"
+grep -Fq "jq -j '.client_secret'" "$helper"
+manifest_url="$("$helper" url 'name" injection' $'https://example.test/callback\nsecond')"
+MANIFEST_URL="$manifest_url" python3 - << 'PY'
+import json
+import os
+import urllib.parse
+
+manifest = json.loads(urllib.parse.parse_qs(urllib.parse.urlsplit(os.environ["MANIFEST_URL"]).query)["manifest"][0])
+assert manifest["name"] == 'name" injection'
+assert manifest["redirect_url"] == "https://example.test/callback\nsecond"
+assert manifest["default_permissions"] == {
+    "administration": "write",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read",
+}
+PY
+if grep -Eq 'echo.*(pem|client_secret|private_key)' "$helper"; then
+    echo "manifest helper must not print credentials" >&2
+    exit 1
+fi
+
+echo "GitHub App Manifest contract checks passed."

--- a/scripts/github-setup/test-app-user-token-contract.sh
+++ b/scripts/github-setup/test-app-user-token-contract.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/github-app-user-token.sh"
+
+[ -x "$helper" ] || {
+    echo "user-token helper is not executable" >&2
+    exit 1
+}
+grep -Fq "source \"\$script_dir/gh-common.sh\"" "$helper"
+grep -Fq 'login/oauth/authorize' "$helper"
+grep -Fq 'login/oauth/access_token' "$helper"
+grep -Fq 'ghu_' "$helper"
+grep -Fq 'GH_TOKEN=' "$helper"
+grep -Fq 'gh api /user' "$helper"
+grep -Fq 'require_command gh' "$helper"
+grep -Fq 'APP_CLIENT_SECRET_FILE' "$helper"
+grep -Fq 'exchange-file' "$helper"
+grep -Fq 'code_field="@' "$helper"
+grep -Fq 'APP_REDIRECT_URI' "$helper"
+grep -Fq 'login/device/code' "$helper"
+grep -Fq 'device-start' "$helper"
+grep -Fq 'device-poll' "$helper"
+grep -Fq 'grant_type=urn:ietf:params:oauth:grant-type:device_code' "$helper"
+grep -Fq 'umask 077' "$helper"
+grep -Fq 'chmod 600' "$helper"
+grep -Fq "poll_file=\"\$(mktemp)\"" "$helper"
+grep -Fq "sanitized_secret_file=\"\$(mktemp)\"" "$helper"
+grep -Fq "tr -d '\\r\\n' < \"\$APP_CLIENT_SECRET_FILE\"" "$helper"
+grep -Fq "client_secret@\$sanitized_secret_file" "$helper"
+grep -Fq "sanitized_code_file=\"\$(mktemp)\"" "$helper"
+grep -Fq "tr -d '\\r\\n' < \"\$code_or_file\"" "$helper"
+grep -Fq "code_field=\"@\$sanitized_code_file\"" "$helper"
+grep -Fq "if [ -n \"\$sanitized_code_file\" ]; then rm -f \"\$sanitized_code_file\"; fi" "$helper"
+if grep -Fq "code_field=\"@\$code_or_file\"" "$helper"; then
+    echo "exchange-file must not send unsanitized authorization code file contents" >&2
+    exit 1
+fi
+grep -Fq 'write_protected_token()' "$helper"
+grep -Fq "if [ ! -d \"\$output_dir\" ]; then" "$helper"
+grep -Fq "temporary_path=\"\$(mktemp \"\$output_dir/.\$output_base.XXXXXX\")\"" "$helper"
+grep -Fq "mv -f \"\$temporary_path\" \"\$output_path\"" "$helper"
+if grep -Fq "printf '%s' \"\$token\" > \"\$token_file\"" "$helper"; then
+    echo "user-token helper must not write directly to caller paths" >&2
+    exit 1
+fi
+if grep -Fq "client_secret=\$APP_CLIENT_SECRET" "$helper"; then
+    echo "user-token helper must not place the client secret in curl arguments" >&2
+    exit 1
+fi
+if grep -Eq 'GH_PAT|gh_token|refresh_token' "$helper"; then
+    echo "user-token helper must not implement PAT or refresh-token fallback" >&2
+    exit 1
+fi
+if grep -Fq "echo \"\$token\"" "$helper" || grep -Fq "echo \"\$APP_CLIENT_SECRET\"" "$helper" || grep -Fq "echo \"\$access_token\"" "$helper"; then
+    echo "user-token helper must not print credentials" >&2
+    exit 1
+fi
+
+echo "GitHub App user-token contract checks passed."

--- a/scripts/github-setup/test-install-app-secrets-contract.sh
+++ b/scripts/github-setup/test-install-app-secrets-contract.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+helper="$script_dir/install-app-secrets.sh"
+
+[ -x "$helper" ] || {
+    echo "secret installer is not executable" >&2
+    exit 1
+}
+grep -Fq "source \"\$script_dir/gh-common.sh\"" "$helper"
+grep -Fq 'BOOTSTRAP_APP_PRIVATE_KEY' "$helper"
+grep -Fq 'BOOTSTRAP_APP_USER_TOKEN' "$helper"
+grep -Fq 'BOOTSTRAP_APP_CLIENT_ID' "$helper"
+grep -Fq 'gh secret set' "$helper"
+grep -Fq 'gh variable set' "$helper"
+grep -Fq 'require_command gh' "$helper"
+grep -Fq 'owner_pattern=' "$helper"
+grep -Fq 'pem_first_line=' "$helper"
+grep -Fq 'pem_last_line=' "$helper"
+grep -Fq 'BASH_REMATCH' "$helper"
+grep -Fq "sanitized_token_file=\"\$(mktemp)\"" "$helper"
+grep -Fq "sanitized_private_key_file=\"\$(mktemp)\"" "$helper"
+grep -Fq "gh secret set BOOTSTRAP_APP_PRIVATE_KEY --repo \"\$repo\" < \"\$sanitized_private_key_file\"" "$helper"
+grep -Fq "gh secret set BOOTSTRAP_APP_USER_TOKEN --repo \"\$repo\" < \"\$sanitized_token_file\"" "$helper"
+grep -Fq 'ghu_' "$helper"
+grep -Fq "GH_TOKEN=\"\$token\" gh api /user --jq" "$helper"
+grep -Fq 'App user token identity does not match repository owner' "$helper"
+grep -Fq 'umask 077' "$helper"
+if grep -Fq 'identity must be verified before invoking this installer' "$helper"; then
+    echo "secret installer help must reflect its own token identity verification" >&2
+    exit 1
+fi
+if grep -Eq 'GH_PAT|gh_token|workflow run|workflow_dispatch' "$helper"; then
+    echo "secret installer must not implement PAT or workflow credential delivery" >&2
+    exit 1
+fi
+if grep -Fq "echo \"\$token\"" "$helper" || grep -Fq "echo \"\$private_key_file\"" "$helper" || grep -Fq "echo \"\$client_id\"" "$helper"; then
+    echo "secret installer must not print credential values" >&2
+    exit 1
+fi
+
+echo "App secret installer contract checks passed."

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+workflow="$repo_root/.github/workflows/test-personal-app-e2e.yml"
+
+grep -Fq 'BOOTSTRAP_APP_CLIENT_ID' "$workflow"
+grep -Fq 'BOOTSTRAP_APP_PRIVATE_KEY' "$workflow"
+grep -Fq 'BOOTSTRAP_APP_USER_TOKEN' "$workflow"
+grep -Fq 'create-repository.yml' "$workflow"
+grep -Fq 'visibility: public' "$workflow"
+grep -Fq 'visibility: private' "$workflow"
+grep -Fq 'gh api --method DELETE' "$workflow"
+grep -Fq 'PERSONAL_OWNER' "$workflow"
+grep -Fq 'allowed_repo_owners' "$workflow"
+grep -Fq 'Invalid personal owner' "$workflow"
+grep -Fq 'gh api /user --jq' "$workflow"
+grep -Fq "gh api \"/users/\$PERSONAL_OWNER\" --jq" "$workflow"
+grep -Fq 'App user token identity does not match personal owner' "$workflow"
+grep -Fq 'GitHub owner is not a personal user' "$workflow"
+dispatch_block="$(sed -n '/^  workflow_dispatch:/,/^permissions:/p' "$workflow")"
+if printf '%s\n' "$dispatch_block" | grep -Eq '^[[:space:]]{6}[A-Za-z0-9_-]*(token|secret|pat|private)'; then
+    echo "personal E2E must not accept PATs, credential inputs, or organization permissions" >&2
+    exit 1
+fi
+if grep -Eq 'gh_token:|GH_PAT|organization-administration' "$workflow"; then
+    echo "personal E2E must not accept PATs or organization permissions" >&2
+    exit 1
+fi
+
+echo "Personal App E2E contract checks passed."


### PR DESCRIPTION
## Summary

Add a guarded personal-account GitHub App credential bootstrap and E2E path:

- Generate a GitHub App Manifest URL and convert GitHub-generated credentials.
- Authorize a personal App user token through OAuth or Device Flow.
- Deliver only the client ID variable and repository secrets through protected setup commands.
- Exercise personal public/private repository creation with fail-closed owner, token, visibility, cleanup, and organization-token contracts.
- Keep organization installation-token E2E pending because no disposable organization is available.

## Related Issue

No linked issue. Vault/OIDC remains out of scope under issue #92 and is intentionally not closed by this PR.

## Validation

- [x] Deterministic App manifest, user-token, installer, personal E2E, and auth contract tests pass.
- [x] Shell syntax checks pass: `bash -n scripts/github-setup/*.sh`
- [x] Complete lint passes: `LINT_MODE=check make lint`
- [x] GitHub CI passes: quality, CodeQL Actions, and CodeQL Python.
- [x] Generated-file or template parity is verified when applicable (not applicable to these local helpers and workflow additions).
- [ ] Credentialed personal-account workflow E2E is pending until the merged workflow is available on the default branch.
- [ ] Organization installation-token E2E is pending until disposable organization access exists.

## Review Checklist

- [x] Scope is limited to one concern.
- [x] No secrets or mutable action references were added.
- [x] Documentation and acceptance criteria are up to date.
- [x] Commit includes a Signed-off-by trailer.