### PR TITLE
fix: authenticate Git operations with App user tokens

### DIFF
--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -521,7 +521,8 @@ jobs:
           OWNER: ${{ steps.set-owner.outputs.owner }}
           REPO_NAME: ${{ inputs.repo_name }}
         run: |
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" clone "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git" new-repo
+          GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+          git -c http.extraheader="AUTHORIZATION: basic $GIT_AUTH_HEADER" clone "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git" new-repo
           cd new-repo
           git remote set-url origin "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git"
           git config user.name "github-actions[bot]"
@@ -813,7 +814,8 @@ jobs:
           cd new-repo
           git add .
           git commit -m "chore: initialize repository from bootstrap template"
-          git -c http.extraheader="AUTHORIZATION: bearer $GH_TOKEN" push
+          GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+          git -c http.extraheader="AUTHORIZATION: basic $GIT_AUTH_HEADER" push
           echo "✅ Template files pushed" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Apply repository settings

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -522,6 +522,7 @@ jobs:
           REPO_NAME: ${{ inputs.repo_name }}
         run: |
           GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+          printf '::add-mask::%s\n' "$GIT_AUTH_HEADER"
           git -c http.extraheader="AUTHORIZATION: basic $GIT_AUTH_HEADER" clone "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git" new-repo
           cd new-repo
           git remote set-url origin "https://${GH_HOST}/${OWNER}/${REPO_NAME}.git"
@@ -815,6 +816,7 @@ jobs:
           git add .
           git commit -m "chore: initialize repository from bootstrap template"
           GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+          printf '::add-mask::%s\n' "$GIT_AUTH_HEADER"
           git -c http.extraheader="AUTHORIZATION: basic $GIT_AUTH_HEADER" push
           echo "✅ Template files pushed" >> "$GITHUB_STEP_SUMMARY"
 

--- a/.github/workflows/test-personal-app-e2e.yml
+++ b/.github/workflows/test-personal-app-e2e.yml
@@ -43,6 +43,7 @@ jobs:
       visibility: public
       cleanup_on_failure: true
       env_manager: system
+      workflows: none
       client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.personal_owner }}
       allowed_repo_owners: ${{ inputs.personal_owner }}
@@ -61,6 +62,7 @@ jobs:
       visibility: private
       cleanup_on_failure: true
       env_manager: system
+      workflows: none
       client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.personal_owner }}
       allowed_repo_owners: ${{ inputs.personal_owner }}

--- a/.github/workflows/test-personal-app-e2e.yml
+++ b/.github/workflows/test-personal-app-e2e.yml
@@ -43,7 +43,6 @@ jobs:
       visibility: public
       cleanup_on_failure: true
       env_manager: system
-      workflows: none
       client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.personal_owner }}
       allowed_repo_owners: ${{ inputs.personal_owner }}
@@ -62,7 +61,6 @@ jobs:
       visibility: private
       cleanup_on_failure: true
       env_manager: system
-      workflows: none
       client_id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
       app_owner: ${{ inputs.personal_owner }}
       allowed_repo_owners: ${{ inputs.personal_owner }}

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -63,7 +63,11 @@ for workflow in create-repository.yml terraform-create-repository.yml; do
     assert_contains "inputs.visibility == 'internal'" "$workflow_path"
     assert_contains "Internal visibility is supported only for organization repositories" "$workflow_path"
     assert_contains "git remote set-url origin" "$workflow_path"
-    assert_contains "http.extraheader=\"AUTHORIZATION: bearer \$GH_TOKEN\"" "$workflow_path"
+    if [ "$workflow" = create-repository.yml ]; then
+        assert_contains "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$workflow_path"
+    else
+        assert_contains "http.extraheader=\"AUTHORIZATION: bearer \$GH_TOKEN\"" "$workflow_path"
+    fi
     assert_contains "allowed_repo_owners:" "$workflow_path"
     assert_not_contains "GH_PAT" "$workflow_path"
     assert_not_contains "gh_token: \${{ inputs.gh_token }}" "$workflow_path"

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -18,6 +18,10 @@ grep -Fq 'gh api /user --jq' "$workflow"
 grep -Fq "gh api \"/users/\$PERSONAL_OWNER\" --jq" "$workflow"
 grep -Fq 'App user token identity does not match personal owner' "$workflow"
 grep -Fq 'GitHub owner is not a personal user' "$workflow"
+if [ "$(grep -Fc 'workflows: none' "$workflow")" -ne 2 ]; then
+    echo "personal E2E must avoid workflow files because the least-privilege App has no Workflows permission" >&2
+    exit 1
+fi
 create_workflow="$repo_root/.github/workflows/create-repository.yml"
 grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
 grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -21,6 +21,10 @@ grep -Fq 'GitHub owner is not a personal user' "$workflow"
 create_workflow="$repo_root/.github/workflows/create-repository.yml"
 grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
 grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"
+if [ "$(grep -Fc "printf '::add-mask::%s\\n' \"\$GIT_AUTH_HEADER\"" "$create_workflow")" -ne 2 ]; then
+    echo "derived Git credentials must be masked at each use" >&2
+    exit 1
+fi
 grep -Fq "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\" clone" "$create_workflow"
 grep -Fq "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\" push" "$create_workflow"
 grep -Fq "git remote set-url origin \"https://\${GH_HOST}/\${OWNER}/\${REPO_NAME}.git\"" "$create_workflow"

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -21,6 +21,8 @@ grep -Fq 'GitHub owner is not a personal user' "$workflow"
 create_workflow="$repo_root/.github/workflows/create-repository.yml"
 grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
 grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"
+grep -Fq "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\" clone" "$create_workflow"
+grep -Fq "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\" push" "$create_workflow"
 grep -Fq "git remote set-url origin \"https://\${GH_HOST}/\${OWNER}/\${REPO_NAME}.git\"" "$create_workflow"
 if grep -Fq "http.extraheader=\"AUTHORIZATION: bearer \$GH_TOKEN\"" "$create_workflow"; then
     echo "repository Git operations must not use bearer authentication" >&2

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -21,8 +21,10 @@ grep -Fq 'GitHub owner is not a personal user' "$workflow"
 create_workflow="$repo_root/.github/workflows/create-repository.yml"
 grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
 grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"
-if [ "$(grep -Fc "printf '::add-mask::%s\\n' \"\$GIT_AUTH_HEADER\"" "$create_workflow")" -ne 2 ]; then
-    echo "derived Git credentials must be masked at each use" >&2
+basic_auth_uses="$(grep -Fc "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow" || true)"
+masked_auth_uses="$(grep -Fc "printf '::add-mask::%s\\n' \"\$GIT_AUTH_HEADER\"" "$create_workflow" || true)"
+if [ "$basic_auth_uses" -eq 0 ] || [ "$masked_auth_uses" -ne "$basic_auth_uses" ]; then
+    echo "each Basic-authenticated Git operation must mask its derived credential" >&2
     exit 1
 fi
 grep -Fq "git -c http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\" clone" "$create_workflow"

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -18,10 +18,6 @@ grep -Fq 'gh api /user --jq' "$workflow"
 grep -Fq "gh api \"/users/\$PERSONAL_OWNER\" --jq" "$workflow"
 grep -Fq 'App user token identity does not match personal owner' "$workflow"
 grep -Fq 'GitHub owner is not a personal user' "$workflow"
-if [ "$(grep -Fc 'workflows: none' "$workflow")" -ne 2 ]; then
-    echo "personal E2E must avoid workflow files because the least-privilege App has no Workflows permission" >&2
-    exit 1
-fi
 create_workflow="$repo_root/.github/workflows/create-repository.yml"
 grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
 grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"

--- a/scripts/github-setup/test-personal-app-e2e-contract.sh
+++ b/scripts/github-setup/test-personal-app-e2e-contract.sh
@@ -18,6 +18,14 @@ grep -Fq 'gh api /user --jq' "$workflow"
 grep -Fq "gh api \"/users/\$PERSONAL_OWNER\" --jq" "$workflow"
 grep -Fq 'App user token identity does not match personal owner' "$workflow"
 grep -Fq 'GitHub owner is not a personal user' "$workflow"
+create_workflow="$repo_root/.github/workflows/create-repository.yml"
+grep -Fq "printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64" "$create_workflow"
+grep -Fq "http.extraheader=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" "$create_workflow"
+grep -Fq "git remote set-url origin \"https://\${GH_HOST}/\${OWNER}/\${REPO_NAME}.git\"" "$create_workflow"
+if grep -Fq "http.extraheader=\"AUTHORIZATION: bearer \$GH_TOKEN\"" "$create_workflow"; then
+    echo "repository Git operations must not use bearer authentication" >&2
+    exit 1
+fi
 dispatch_block="$(sed -n '/^  workflow_dispatch:/,/^permissions:/p' "$workflow")"
 if printf '%s\n' "$dispatch_block" | grep -Eq '^[[:space:]]{6}[A-Za-z0-9_-]*(token|secret|pat|private)'; then
     echo "personal E2E must not accept PATs, credential inputs, or organization permissions" >&2


### PR DESCRIPTION
## Summary

Fix Git clone and push authentication for GitHub App user tokens in repository creation. API calls continue to use the scoped App user token; Git operations now use an in-memory Basic header encoded as x-access-token credentials. The remote URL is reset to a credential-free URL after clone.

## Related Issue

- None

## Validation

- [x] Focused personal App E2E contract passes
- [x] ShellCheck and shell syntax pass
- [x] `LINT_MODE=check make lint` passes
- [ ] Credentialed personal E2E rerun pending this fix
- [ ] Organization installation-token E2E pending disposable organization access

## Review checklist

- [x] No PAT fallback or credential workflow inputs
- [x] No credential-bearing remote URL retained
- [x] Signed-off commit included