### PR TITLE
ci: reconcile weekly tooling updates after merges

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -1,13 +1,16 @@
 name: Weekly Tooling Updates
 
 on:
+  # Reconcile the single tooling PR after every change to main, including merges.
+  push:
+    branches: [main]
   schedule:
     - cron: "0 4 * * 1"
   workflow_dispatch:
 
 concurrency:
   group: weekly-tooling-updates
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   update-tooling:


### PR DESCRIPTION
## Summary
- trigger the tooling update workflow after every push to `main`
- cancel stale runs when newer main changes arrive
- preserve the single idempotent tooling branch/PR flow

This is intentionally separate from the quality-provider cleanup PR.