### PR TITLE
ci: make action linting opt-in

### DIFF
--- a/.github/actions/setup-lint-system/action.yml
+++ b/.github/actions/setup-lint-system/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-3c116961091b50bd1a08ffefe916469d4d90093c
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-1.29.0
     - name: Install system tools
       shell: bash
       run: |
@@ -27,6 +27,6 @@ runs:
         GOBIN="$HOME/.local/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
         python3 -m pip install --user \
           pre-commit==4.6.2 yamllint==1.38.0 editorconfig-checker==3.11.1 \
-          'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'
+          zizmor==1.29.0
         npm install -g prettier@3.9.6 markdownlint-cli@0.49.1 @taplo/cli@0.7.0
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -216,7 +216,7 @@ on:
         type: string
       profile_capabilities:
         required: false
-        default: lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests
+        default: lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests
         type: string
       delivery_mode:
         required: false
@@ -336,7 +336,7 @@ jobs:
           GO_VERSION="${GO_VERSION:-1.26}"
           JAVA_VERSION="${JAVA_VERSION:-25}"
           PROFILE="${PROFILE:-baseline}"
-          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
+          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
           PROFILE_CAPABILITIES="$(printf '%s' "$PROFILE_CAPABILITIES" | tr -d '[:space:]')"
           DELIVERY_MODE="${DELIVERY_MODE:-embedded}"
           if [ -z "$CENTRAL_REF" ] && [[ "$CENTRAL_REPOSITORY" == *@* ]]; then
@@ -580,7 +580,7 @@ jobs:
         run: |
           cd new-repo
           PROFILE_CAPABILITIES='${{ inputs.profile_capabilities }}'
-          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
+            PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
           PROFILE_CAPABILITIES="$(printf '%s' "$PROFILE_CAPABILITIES" | tr -d '[:space:]')"
           DELIVERY_MODE='${{ inputs.delivery_mode }}'
           CENTRAL_REPOSITORY='${{ inputs.central_repository }}'

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -216,7 +216,7 @@ on:
         type: string
       profile_capabilities:
         required: false
-        default: lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests
+        default: lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests
         type: string
       delivery_mode:
         required: false
@@ -343,7 +343,7 @@ jobs:
           GO_VERSION="${GO_VERSION:-1.26}"
           JAVA_VERSION="${JAVA_VERSION:-25}"
           PROFILE="${PROFILE:-baseline}"
-          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
+          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
           PROFILE_CAPABILITIES="$(printf '%s' "$PROFILE_CAPABILITIES" | tr -d '[:space:]')"
           DELIVERY_MODE="${DELIVERY_MODE:-embedded}"
           if [ -z "$CENTRAL_REF" ] && [[ "$CENTRAL_REPOSITORY" == *@* ]]; then
@@ -587,7 +587,7 @@ jobs:
         run: |
           cd new-repo
           PROFILE_CAPABILITIES='${{ inputs.profile_capabilities }}'
-          PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
+            PROFILE_CAPABILITIES="${PROFILE_CAPABILITIES:-lint-markdown,lint-json,lint-yaml,lint-shell,lint-python,lint-terraform,lint-format,lint-tests}"
           PROFILE_CAPABILITIES="$(printf '%s' "$PROFILE_CAPABILITIES" | tr -d '[:space:]')"
           DELIVERY_MODE='${{ inputs.delivery_mode }}'
           CENTRAL_REPOSITORY='${{ inputs.central_repository }}'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,14 @@ repos:
         pass_filenames: false
         files: '(^|/)(\.github/(skills|agents|ISSUE_TEMPLATE)|\.github/pull_request_template\.md|templates/)'
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
       # ── Terraform: formatting (terraform fmt) ─────────────────────────────
       - id: terraform-fmt
         name: terraform fmt

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@
 #   make install              Bootstrap env + hooks
 #   make quality              Auto-format + quality checks (local dev)
 #   LINT_MODE=check make quality  Check-only (CI mode, no auto-fix)
+#   make quality-actions         Opt-in actionlint + zizmor checks
 #   make test                 Trigger repository creation tests
 #
 # Env manager options:

--- a/environment.yml
+++ b/environment.yml
@@ -23,6 +23,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - jq=1.8.2 # JSON processor
@@ -32,4 +33,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/make/lint.mk
+++ b/make/lint.mk
@@ -10,3 +10,7 @@ quality: setup-env ## Run all quality checks via pre-commit (ENV_MANAGER=microma
 	@$(RUN) pre-commit install --install-hooks >/dev/null 2>&1 || true
 	@$(CMD_ECHO) "+ LINT_MODE=$(LINT_MODE) $(RUN) pre-commit run --all-files --color=always"
 	@LINT_MODE=$(LINT_MODE) $(RUN) pre-commit run --all-files --color=always
+
+quality-actions: setup-env ## Opt-in GitHub Actions linting with actionlint and zizmor
+	@$(CMD_ECHO) "+ $(RUN) pre-commit run lint-actions --all-files --color=always"
+	@$(RUN) pre-commit run lint-actions --all-files --color=always

--- a/mise.toml
+++ b/mise.toml
@@ -11,6 +11,6 @@ taplo = "0.10.0"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
 ]

--- a/scripts/github-setup/test-profile.sh
+++ b/scripts/github-setup/test-profile.sh
@@ -145,8 +145,8 @@ for json_quality_file in \
         exit 1
     fi
 done
-grep -q 'zizmor.*3c116961091b50bd1a08ffefe916469d4d90093c' "$repo_root/environment.yml"
-grep -q 'zizmor.*3c116961091b50bd1a08ffefe916469d4d90093c' "$repo_root/mise.toml"
+grep -q 'zizmor.*1.29.0' "$repo_root/environment.yml"
+grep -q 'zizmor.*1.29.0' "$repo_root/mise.toml"
 grep -q 'actionlint=1.7.12' "$repo_root/environment.yml"
 grep -q 'actionlint = "1.7.12"' "$repo_root/mise.toml"
 for setup_action in \
@@ -157,10 +157,10 @@ for setup_action in \
     grep -q 'cache: false' "$setup_action"
     grep -q "mkdir -p \"\\\$HOME/.local/bin\"" "$setup_action"
     grep -q 'setup-terraform' "$setup_action"
-    grep -q 'zizmor.*3c116961091b50bd1a08ffefe916469d4d90093c' "$setup_action"
+    grep -q 'zizmor.*1.29.0' "$setup_action"
     grep -q 'actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae' "$setup_action"
     grep -q 'path: ~/.cache/pip' "$setup_action"
-    grep -q 'pip-zizmor-3c116961091b50bd1a08ffefe916469d4d90093c' "$setup_action"
+    grep -q 'pip-zizmor-1.29.0' "$setup_action"
 done
 for rendered_quality_file in \
     "$repo_root/templates/.github/workflows/quality.yml" \
@@ -191,11 +191,11 @@ awk '/lint-shell\)/ { in_block=1 } in_block && /node_modules/ { found=1 } in_blo
     "$repo_root/templates/centralized-actions-workflows/.github/workflows/quality.yml"
 for provider_file in "$repo_root"/templates/languages/*/providers/micromamba/environment.yml; do
     grep -q 'actionlint=1.7.12' "$provider_file"
-    grep -q 'zizmor.*3c116961091b50bd1a08ffefe916469d4d90093c' "$provider_file"
+    grep -q 'zizmor.*1.29.0' "$provider_file"
 done
 for provider_file in "$repo_root"/templates/languages/*/providers/mise/mise.toml; do
     grep -q 'actionlint = "1.7.12"' "$provider_file"
-    grep -q 'zizmor.*3c116961091b50bd1a08ffefe916469d4d90093c' "$provider_file"
+    grep -q 'zizmor.*1.29.0' "$provider_file"
 done
 for provider_file in "$repo_root"/templates/languages/*/providers/micromamba/environment.yml; do
     grep -q 'terraform' "$provider_file"

--- a/scripts/lint-github-actions.sh
+++ b/scripts/lint-github-actions.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -d '' workflow_files < <(
+    find .github/workflows -type f -name '*.y*ml' -print0
+)
+mapfile -d '' action_files < <(
+    find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0
+)
+
+if [ "${#workflow_files[@]}" -eq 0 ] && [ "${#action_files[@]}" -eq 0 ]; then
+    echo "No GitHub Actions workflows or actions found; skipping action lint."
+    exit 0
+fi
+
+if [ "${#workflow_files[@]}" -gt 0 ]; then
+    actionlint -ignore 'SC[0-9]+' "${workflow_files[@]}"
+fi
+zizmor --pedantic .github

--- a/scripts/test-action-lint-contract.sh
+++ b/scripts/test-action-lint-contract.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+assert_contains() {
+    local needle="$1"
+    local file="$2"
+    grep -Fq -- "$needle" "$file" || {
+        echo "expected '$needle' in $file" >&2
+        exit 1
+    }
+}
+
+assert_not_contains() {
+    local needle="$1"
+    local file="$2"
+    if grep -Fq -- "$needle" "$file"; then
+        echo "unexpected '$needle' in $file" >&2
+        exit 1
+    fi
+}
+
+for config in \
+    "$repo_root/.pre-commit-config.yaml" \
+    "$repo_root/templates/languages/agnostic/.pre-commit-config.yaml" \
+    "$repo_root/templates/languages/golang/.pre-commit-config.yaml" \
+    "$repo_root/templates/languages/java/.pre-commit-config.yaml" \
+    "$repo_root/templates/languages/python/.pre-commit-config.yaml" \
+    "$repo_root/templates/languages/typescript/.pre-commit-config.yaml"; do
+    assert_contains "id: lint-actions" "$config"
+    assert_contains "entry: ./scripts/lint-github-actions.sh" "$config"
+    assert_contains ".github/(workflows|actions)" "$config"
+    assert_contains "stages: [manual]" "$config"
+done
+
+assert_contains "actionlint" "$repo_root/scripts/lint-github-actions.sh"
+assert_contains "zizmor --pedantic" "$repo_root/scripts/lint-github-actions.sh"
+assert_contains ".github/workflows" "$repo_root/scripts/lint-github-actions.sh"
+assert_contains ".github/actions" "$repo_root/scripts/lint-github-actions.sh"
+assert_contains "actionlint" "$repo_root/templates/scripts/lint-github-actions.sh"
+assert_contains "zizmor --pedantic" "$repo_root/templates/scripts/lint-github-actions.sh"
+assert_contains "quality-actions" "$repo_root/make/lint.mk"
+for workflow in create-repository.yml terraform-create-repository.yml; do
+    assert_not_contains "default: lint-markdown,lint-json,lint-yaml,lint-actions" "$repo_root/.github/workflows/$workflow"
+done
+
+for manifest in "$repo_root/environment.yml" \
+    "$repo_root/templates/languages/agnostic/providers/micromamba/environment.yml"; do
+    assert_contains "- actionlint=1.7.12" "$manifest"
+    assert_contains "- zizmor=1.29.0" "$manifest"
+done
+
+echo "Action lint contract checks passed."

--- a/templates/.github/actions/quality/run-capability/action.yml
+++ b/templates/.github/actions/quality/run-capability/action.yml
@@ -54,8 +54,8 @@ runs:
             provider_run yamllint --config-file .github/linters/.yaml-lint.yml .
             ;;
           lint-actions)
-            provider_run actionlint
-            provider_run zizmor --pedantic .github/workflows
+            provider_run actionlint -ignore 'SC[0-9]+'
+            provider_run zizmor --pedantic .github
             ;;
           lint-shell)
             mapfile -d '' shell_files < <(

--- a/templates/.github/actions/setup-lint-system/action.yml
+++ b/templates/.github/actions/setup-lint-system/action.yml
@@ -17,7 +17,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-3c116961091b50bd1a08ffefe916469d4d90093c
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-1.29.0
     - name: Install system tools
       shell: bash
       run: |
@@ -27,6 +27,6 @@ runs:
         GOBIN="$HOME/.local/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
         python3 -m pip install --user \
           pre-commit==4.6.2 yamllint==1.38.0 editorconfig-checker==3.11.1 \
-          'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'
+          zizmor==1.29.0
         npm install -g prettier@3.9.6 markdownlint-cli@0.49.1 @taplo/cli@0.7.0
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/templates/CONTRIBUTING.md
+++ b/templates/CONTRIBUTING.md
@@ -37,6 +37,8 @@ git checkout -b feat/your-feature-name
 # 3. Make your changes and test locally
 make quality     # run quality checks with auto-fix
 LINT_MODE=check make quality  # run CI-equivalent check-only quality checks
+# Optional during the action-lint migration:
+pre-commit run lint-actions --all-files
 
 # 4. Commit using conventional commits (see below)
 git commit -m "feat: add your feature"

--- a/templates/README.md
+++ b/templates/README.md
@@ -50,6 +50,9 @@ make quality
 
 # Run quality checks in check-only mode (CI-equivalent)
 LINT_MODE=check make quality
+
+# Opt-in GitHub Actions validation while the migration is in progress
+pre-commit run lint-actions --all-files
 ```
 
 The repository includes a GitHub quality workflow backed by explicit

--- a/templates/centralized-actions-workflows/.github/actions/setup-lint-system/action.yml
+++ b/templates/centralized-actions-workflows/.github/actions/setup-lint-system/action.yml
@@ -18,7 +18,7 @@ runs:
       uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       with:
         path: ~/.cache/pip
-        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-3c116961091b50bd1a08ffefe916469d4d90093c
+        key: ${{ runner.os }}-${{ runner.arch }}-pip-zizmor-1.29.0
     - name: Install system tools
       shell: bash
       run: |
@@ -28,6 +28,6 @@ runs:
         GOBIN="$HOME/.local/bin" go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
         python3 -m pip install --user \
           pre-commit==4.6.2 yamllint==1.38.0 editorconfig-checker==3.11.1 \
-          'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'
+          zizmor==1.29.0
         npm install -g prettier@3.9.6 markdownlint-cli@0.49.1 @taplo/cli@0.7.0
         echo "$HOME/.local/bin" >> "$GITHUB_PATH"

--- a/templates/centralized-actions-workflows/.github/workflows/quality.yml
+++ b/templates/centralized-actions-workflows/.github/workflows/quality.yml
@@ -68,7 +68,7 @@ jobs:
               lint-markdown) provider_run markdownlint --config .github/linters/.markdownlint.json --ignore CHANGELOG.md --ignore node_modules --ignore .git . ;;
               lint-json) provider_run bash -c 'find . -path "./.git" -prune -o -path "./node_modules" -prune -o -type f -name "*.json" -exec jq empty {} +' ;;
               lint-yaml) provider_run yamllint --config-file .github/linters/.yaml-lint.yml . ;;
-              lint-actions) provider_run actionlint; provider_run zizmor --pedantic .github/workflows ;;
+              lint-actions) provider_run actionlint -ignore 'SC[0-9]+'; provider_run zizmor --pedantic .github ;;
               lint-shell)
                 mapfile -d '' shell_files < <(
                   find . -path './.git' -prune -o -path './node_modules' -prune -o \

--- a/templates/centralized-actions-workflows/examples/consumer-quality.yml
+++ b/templates/centralized-actions-workflows/examples/consumer-quality.yml
@@ -13,7 +13,7 @@ jobs:
     name: quality
     uses: my-org/shared-actions-workflows/.github/workflows/quality.yml@v1.0.0
     with:
-      capabilities: lint-markdown,lint-json,lint-yaml,lint-actions,lint-shell,lint-format,lint-tests
+      capabilities: lint-markdown,lint-json,lint-yaml,lint-shell,lint-format,lint-tests
       environment-manager: system
     permissions:
       contents: read

--- a/templates/languages/agnostic/.pre-commit-config.yaml
+++ b/templates/languages/agnostic/.pre-commit-config.yaml
@@ -136,6 +136,14 @@ repos:
         language: system
         types_or: [json, yaml, markdown]
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/templates/languages/agnostic/providers/micromamba/environment.yml
+++ b/templates/languages/agnostic/providers/micromamba/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - jq=1.8.2 # JSON processor
@@ -29,4 +30,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/templates/languages/agnostic/providers/mise/mise.toml
+++ b/templates/languages/agnostic/providers/mise/mise.toml
@@ -10,6 +10,6 @@ taplo = "0.10.0"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
 ]

--- a/templates/languages/golang/.pre-commit-config.yaml
+++ b/templates/languages/golang/.pre-commit-config.yaml
@@ -161,6 +161,14 @@ repos:
         language: system
         types_or: [json, yaml, markdown]
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/templates/languages/golang/providers/micromamba/environment.yml
+++ b/templates/languages/golang/providers/micromamba/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - jq=1.8.2 # JSON processor
@@ -33,4 +34,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/templates/languages/golang/providers/mise/mise.toml
+++ b/templates/languages/golang/providers/mise/mise.toml
@@ -11,7 +11,7 @@ taplo = "0.10.0"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
   "go install github.com/daixiang0/gci@v0.14.0",
   "go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8",

--- a/templates/languages/java/.pre-commit-config.yaml
+++ b/templates/languages/java/.pre-commit-config.yaml
@@ -181,6 +181,14 @@ repos:
         language: system
         types_or: [json, yaml, markdown]
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/templates/languages/java/providers/micromamba/environment.yml
+++ b/templates/languages/java/providers/micromamba/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - jq=1.8.2 # JSON processor
@@ -33,4 +34,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/templates/languages/java/providers/mise/mise.toml
+++ b/templates/languages/java/providers/mise/mise.toml
@@ -11,6 +11,6 @@ taplo = "0.10.0"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
 ]

--- a/templates/languages/python/.pre-commit-config.yaml
+++ b/templates/languages/python/.pre-commit-config.yaml
@@ -185,6 +185,14 @@ repos:
         language: system
         types_or: [json, yaml, markdown]
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/templates/languages/python/providers/micromamba/environment.yml
+++ b/templates/languages/python/providers/micromamba/environment.yml
@@ -20,6 +20,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - jq=1.8.2 # JSON processor
@@ -39,4 +40,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/templates/languages/python/providers/mise/mise.toml
+++ b/templates/languages/python/providers/mise/mise.toml
@@ -10,6 +10,6 @@ taplo = "0.10.0"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c' ruff mypy types-PyYAML pytest pytest-cov pytest-mock",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0 ruff mypy types-PyYAML pytest pytest-cov pytest-mock",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
 ]

--- a/templates/languages/typescript/.pre-commit-config.yaml
+++ b/templates/languages/typescript/.pre-commit-config.yaml
@@ -154,6 +154,14 @@ repos:
         language: system
         types_or: [json, yaml, markdown]
 
+      - id: lint-actions
+        name: actionlint and zizmor
+        entry: ./scripts/lint-github-actions.sh
+        language: system
+        pass_filenames: false
+        stages: [manual]
+        files: '^\.github/(workflows|actions)/.*\.ya?ml$'
+
   # ── Commit message: conventional commits ──────────────────────────────────
   - repo: https://github.com/compilerla/conventional-pre-commit
     rev: v4.4.0

--- a/templates/languages/typescript/providers/micromamba/environment.yml
+++ b/templates/languages/typescript/providers/micromamba/environment.yml
@@ -17,6 +17,7 @@ dependencies:
   - go-shfmt=3.13.1 # shell formatter (provides shfmt binary)
   - shellcheck=0.11.0 # shell linter
   - actionlint=1.7.12 # GitHub Actions workflow linter
+  - zizmor=1.29.0 # GitHub Actions security linter
   - terraform=1.15.6 # Terraform (includes terraform fmt)
   - libxml2=2.15.3 # provides xmllint binary for XML validation
   - jq=1.8.2 # JSON processor
@@ -29,4 +30,3 @@ dependencies:
   - pip
   - pip:
       - editorconfig-checker
-      - zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c

--- a/templates/languages/typescript/providers/mise/mise.toml
+++ b/templates/languages/typescript/providers/mise/mise.toml
@@ -13,6 +13,6 @@ MISE_NODE_COREPACK = "1"
 [tasks.install-tools]
 run = [
   "python -m pip install --upgrade pip",
-  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 'zizmor @ git+https://github.com/zizmorcore/zizmor.git@3c116961091b50bd1a08ffefe916469d4d90093c'",
+  "python -m pip install pre-commit==4.6.2 editorconfig-checker==3.11.1 yamllint==1.38.0 zizmor==1.29.0",
   "npm install -g prettier@3.9.6 markdownlint-cli@0.49.1",
 ]

--- a/templates/scripts/lint-github-actions.sh
+++ b/templates/scripts/lint-github-actions.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+mapfile -d '' workflow_files < <(
+    find .github/workflows -type f -name '*.y*ml' -print0
+)
+mapfile -d '' action_files < <(
+    find .github/actions -type f \( -name 'action.yml' -o -name 'action.yaml' \) -print0
+)
+
+if [ "${#workflow_files[@]}" -eq 0 ] && [ "${#action_files[@]}" -eq 0 ]; then
+    echo "No GitHub Actions workflows or actions found; skipping action lint."
+    exit 0
+fi
+
+if [ "${#workflow_files[@]}" -gt 0 ]; then
+    actionlint -ignore 'SC[0-9]+' "${workflow_files[@]}"
+fi
+zizmor --pedantic .github


### PR DESCRIPTION
## Summary
- add an explicit `lint-actions` hook and `make quality-actions` entry point
- keep actionlint and zizmor opt-in while existing zizmor findings are remediated
- install pinned actionlint/zizmor releases consistently across micromamba, mise, and system setup
- keep generated provider configs and centralized quality assets aligned
- remove `lint-actions` from generated default capability selections

The next follow-up will remediate the existing zizmor findings and make this capability required.

## Validation
- `bash scripts/test-action-lint-contract.sh`
- `bash scripts/github-setup/test-app-auth-contract.sh`
- `bash scripts/github-setup/test-profile.sh`
- `shellcheck` and `bash -n` for new scripts
- Ruby YAML parsing for changed YAML files
- `git diff --check`