### PR TITLE
fix: sign off weekly tooling update commits

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -90,7 +90,7 @@ jobs:
 
           git checkout -B "$branch"
           git add -A
-          git commit --no-verify -m "$commit_msg"
+          git commit --no-verify -s -m "$commit_msg"
           git push --force-with-lease origin "$branch"
 
           pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"

--- a/scripts/check-commit-policy-fixtures.sh
+++ b/scripts/check-commit-policy-fixtures.sh
@@ -11,6 +11,13 @@ policy_actions=(
     ".github/actions/verify-signed-off-by/action.yml"
 )
 
+weekly_workflow="$ROOT_DIR/.github/workflows/weekly-tooling-updates.yml"
+# shellcheck disable=SC2016
+if ! grep -qF 'git commit --no-verify -s -m "$commit_msg"' "$weekly_workflow"; then
+    echo "MISSING_SIGNED_OFF_BY: weekly tooling workflow commit" >&2
+    exit 1
+fi
+
 for relative_path in "${policy_actions[@]}"; do
     root_path="$ROOT_DIR/$relative_path"
     template_path="$ROOT_DIR/templates/$relative_path"


### PR DESCRIPTION
## Summary
- add a Signed-off-by trailer to commits created by the weekly tooling workflow
- add regression coverage to the commit-policy fixture

## Verification
- bash scripts/check-commit-policy-fixtures.sh
- LINT_MODE=check make quality