### PR TITLE
docs: define GitHub App trust boundaries

### DIFF
--- a/docs/github-app-manifests/bootstrap-e2e-admin.json
+++ b/docs/github-app-manifests/bootstrap-e2e-admin.json
@@ -1,0 +1,11 @@
+{
+  "name": "Bootstrap E2E Admin",
+  "url": "https://github.com",
+  "public": false,
+  "default_events": [],
+  "default_permissions": {
+    "administration": "write",
+    "metadata": "read",
+    "organization_administration": "write"
+  }
+}

--- a/docs/github-app-manifests/repository-bootstrap-provisioner.json
+++ b/docs/github-app-manifests/repository-bootstrap-provisioner.json
@@ -1,0 +1,12 @@
+{
+  "name": "Repository Bootstrap Provisioner",
+  "url": "https://github.com",
+  "public": false,
+  "default_events": [],
+  "default_permissions": {
+    "administration": "write",
+    "contents": "write",
+    "issues": "write",
+    "metadata": "read"
+  }
+}

--- a/docs/github-app-manifests/repository-maintenance-reviewer.json
+++ b/docs/github-app-manifests/repository-maintenance-reviewer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Repository Maintenance Reviewer",
+  "url": "https://github.com",
+  "public": false,
+  "default_events": [],
+  "default_permissions": {
+    "actions": "write",
+    "metadata": "read",
+    "pull_requests": "write"
+  }
+}

--- a/docs/github-app-manifests/repository-maintenance-writer.json
+++ b/docs/github-app-manifests/repository-maintenance-writer.json
@@ -1,0 +1,11 @@
+{
+  "name": "Repository Maintenance Writer",
+  "url": "https://github.com",
+  "public": false,
+  "default_events": [],
+  "default_permissions": {
+    "contents": "write",
+    "metadata": "read",
+    "pull_requests": "write"
+  }
+}

--- a/docs/github-app-permission-matrix.md
+++ b/docs/github-app-permission-matrix.md
@@ -1,5 +1,10 @@
 # GitHub App permission-to-endpoint matrix
 
+The reusable four-role trust boundary and manifest payloads are documented in
+[`github-app-trust-boundaries.md`](github-app-trust-boundaries.md). This
+matrix retains the operation-level profiles used by the existing bootstrap
+workflows; those profiles must remain within the corresponding App role.
+
 Organization repository creation uses an installation token for the requested `app_owner` only.
 Personal repository creation uses an explicitly supplied GitHub App user access token whose `/user`
 identity is checked against the target owner. The resolver passes permissions explicitly so an
@@ -12,13 +17,13 @@ installation token does not inherit unused permissions from the App installation
 | `repository-cleanup`  | `administration: write`                                                                           | Delete a failed repository.                      |
 | `weekly-tooling`      | `contents: write`, `pull-requests: write`                                                         | Commit tooling updates and manage the weekly PR. |
 
-| App permission                | Level | Endpoint or operation                                                      | Why it is required                                     |
-| ----------------------------- | ----- | -------------------------------------------------------------------------- | ------------------------------------------------------ |
-| `organization-administration` | write | `POST /orgs/{org}/repos`                                                   | Create the repository in the target organization.      |
-| `administration`              | write | `PATCH /repos/{owner}/{repo}`, environments, rulesets, repository deletion | Configure the repository and clean up failed creation. |
-| `contents`                    | write | Git push and repository contents API                                       | Add generated bootstrap files.                         |
-| `issues`                      | write | Labels API                                                                 | Apply default repository labels.                       |
-| `pull-requests`               | write | Weekly tooling PR creation, updates, and auto-merge                        | Run the App-authenticated weekly tooling automation.   |
+| App permission                | Level | Endpoint or operation                                                      | Why it is required                                                                                     |
+| ----------------------------- | ----- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| `organization-administration` | write | `POST /orgs/{org}/repos`                                                   | Create the repository in the target organization.                                                      |
+| `administration`              | write | `PATCH /repos/{owner}/{repo}`, environments, rulesets, repository deletion | Configure the repository; deletion capability is operationally restricted to the documented lifecycle. |
+| `contents`                    | write | Git push and repository contents API                                       | Add generated bootstrap files.                                                                         |
+| `issues`                      | write | Labels API                                                                 | Apply default repository labels.                                                                       |
+| `pull-requests`               | write | Weekly tooling PR creation, updates, and auto-merge                        | Run the App-authenticated weekly tooling automation.                                                   |
 
 `metadata: read` is automatically available for repository access. Members, actions,
 security-events, and unrelated-owner permissions are not granted by this resolver. Pull-request

--- a/docs/github-app-trust-boundaries.md
+++ b/docs/github-app-trust-boundaries.md
@@ -1,0 +1,65 @@
+# GitHub App trust boundaries
+
+This repository uses separate GitHub Apps for separate trust boundaries. The
+JSON files in [`github-app-manifests/`](github-app-manifests/) are reusable
+starting payloads for GitHub's App Manifest flow. Before installation, the
+consumer must review the target owner, selected repositories, and permissions.
+GitHub's automatic `metadata: read` permission is declared explicitly in each
+payload for auditability.
+
+## App roles
+
+| App                                  | Scope and authority                                                                                                                                                                                             | Credentials                                                                                                                | Explicitly excluded                                                                                                               |
+| ------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+| **Bootstrap E2E Admin**              | Test-only administration of repositories created by the generated-repository E2E system, including creation and archive lifecycle operations. Install only in the disposable E2E owner.                         | E2E-only App private key, held in the E2E environment.                                                                     | Production repositories, production maintenance credentials, repository contents, pull requests, workflow approval, and deletion. |
+| **Repository Bootstrap Provisioner** | Consumer-owned setup of an existing or newly created target repository: settings, generated contents, labels, and repository configuration. Install only on the consumer-selected repositories or organization. | Consumer-owned provisioner App private key, held by the consumer's protected workflow secret.                              | E2E administration, maintenance PR review/merge, workflow approval, and ruleset bypass.                                           |
+| **Repository Maintenance Writer**    | Creates verified maintenance commits and opens or updates maintenance pull requests in explicitly selected repositories.                                                                                        | Production Writer App private key, held in the production maintenance environment.                                         | E2E administration, workflow approval, review, auto-merge, and ruleset bypass.                                                    |
+| **Repository Maintenance Reviewer**  | Approves eligible workflow runs, completes the automation review/merge orchestration, and enables auto-merge after all policy gates pass. Install only on explicitly selected maintenance repositories.         | Production Reviewer App private key, held in the production maintenance environment and kept separate from the Writer key. | E2E administration, commit creation, arbitrary repository administration, and ruleset bypass.                                     |
+
+The E2E Admin is never used by production maintenance workflows. The Writer
+and Reviewer are separate Apps even when they are installed on the same target
+repository. No App is a ruleset bypass actor: rulesets remain authoritative
+for signatures, approvals, required checks, linear history, and merge method.
+
+## Permission contract
+
+The payloads intentionally have no webhook events and are private Apps. Their
+default permissions are the complete requested contract:
+
+| App                              | Permissions                                                                     |
+| -------------------------------- | ------------------------------------------------------------------------------- |
+| Bootstrap E2E Admin              | `organization_administration: write`, `administration: write`, `metadata: read` |
+| Repository Bootstrap Provisioner | `administration: write`, `contents: write`, `issues: write`, `metadata: read`   |
+| Repository Maintenance Writer    | `contents: write`, `pull_requests: write`, `metadata: read`                     |
+| Repository Maintenance Reviewer  | `actions: write`, `pull_requests: write`, `metadata: read`                      |
+
+Permissions are not shared between roles for convenience. GitHub's
+`administration: write` permission includes repository deletion capability;
+the E2E Admin and Provisioner need that permission for their documented
+administration operations, but their workflows must never delete arbitrary or
+production repositories. No manifest requests a separate deletion permission,
+`workflows`, `members`, `security-events`, or unrelated-owner access. Later
+workflow issues must use the narrowest role and repository selection that
+satisfies their operation; they must not expand a manifest here to bypass a
+ruleset or combine the E2E and production trust boundaries.
+
+## Installation and secret handling
+
+Organization consumers install the appropriate App on the organization and
+select only the repositories needed by that role. Personal-account consumers
+must use the supported App user-token flow for personal targets; an
+installation token does not become a personal-user credential. The configured
+owner and authenticated identity must match before any operation.
+
+Store each App's GitHub-generated private key as a protected
+`BOOTSTRAP_APP_PRIVATE_KEY` secret in the environment that owns that role.
+Do not commit keys, include them in workflow inputs, print them, or reuse an
+E2E key in production. The production Reviewer key is a distinct secret from
+the Writer key and the E2E key. Client IDs may be non-secret configuration, but
+private keys and App user access tokens remain protected credentials.
+
+E2E repositories and credentials are scoped to the E2E owner and the exact
+system-generated names/markers. E2E lifecycle work must archive generated
+public repositories before cleanup and must never delete arbitrary or
+production repositories. Detailed archive and cleanup behavior belongs to
+issues #118 and #119, not this manifest contract.

--- a/scripts/github-setup/test-app-manifest-contract.sh
+++ b/scripts/github-setup/test-app-manifest-contract.sh
@@ -3,6 +3,8 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 helper="$script_dir/github-app-manifest.sh"
+manifest_dir="$(cd "$script_dir/../../docs/github-app-manifests" 2> /dev/null && pwd)"
+trust_boundary_doc="$manifest_dir/../github-app-trust-boundaries.md"
 
 [ -x "$helper" ] || {
     echo "manifest helper is not executable" >&2
@@ -44,5 +46,75 @@ if grep -Eq 'echo.*(pem|client_secret|private_key)' "$helper"; then
     echo "manifest helper must not print credentials" >&2
     exit 1
 fi
+
+MANIFEST_DIR="$manifest_dir" python3 - << 'PY'
+import json
+import os
+from pathlib import Path
+
+manifest_dir = Path(os.environ["MANIFEST_DIR"])
+expected = {
+    "bootstrap-e2e-admin.json": {
+        "name": "Bootstrap E2E Admin",
+        "default_permissions": {
+            "administration": "write",
+            "metadata": "read",
+            "organization_administration": "write",
+        },
+    },
+    "repository-bootstrap-provisioner.json": {
+        "name": "Repository Bootstrap Provisioner",
+        "default_permissions": {
+            "administration": "write",
+            "contents": "write",
+            "issues": "write",
+            "metadata": "read",
+        },
+    },
+    "repository-maintenance-writer.json": {
+        "name": "Repository Maintenance Writer",
+        "default_permissions": {
+            "contents": "write",
+            "metadata": "read",
+            "pull_requests": "write",
+        },
+    },
+    "repository-maintenance-reviewer.json": {
+        "name": "Repository Maintenance Reviewer",
+        "default_permissions": {
+            "actions": "write",
+            "metadata": "read",
+            "pull_requests": "write",
+        },
+    },
+}
+
+assert set(path.name for path in manifest_dir.glob("*.json")) == set(expected)
+for filename, contract in expected.items():
+    payload = json.loads((manifest_dir / filename).read_text())
+    assert payload["name"] == contract["name"]
+    assert payload["default_permissions"] == contract["default_permissions"]
+    assert payload["default_events"] == []
+    assert payload["public"] is False
+    assert "bypass_actors" not in payload
+    assert "deletion" not in payload["default_permissions"]
+    assert "workflows" not in payload["default_permissions"]
+PY
+
+for required_text in \
+    "Bootstrap E2E Admin" \
+    "Repository Bootstrap Provisioner" \
+    "Repository Maintenance Writer" \
+    "Repository Maintenance Reviewer" \
+    "No App is a ruleset bypass actor" \
+    "\`administration: write\` permission includes repository deletion capability" \
+    "must never delete arbitrary or" \
+    "BOOTSTRAP_APP_PRIVATE_KEY" \
+    "E2E"; do
+    grep -Fq "$required_text" "$trust_boundary_doc" || {
+        echo "expected '$required_text' in $trust_boundary_doc" >&2
+        exit 1
+    }
+done
 
 echo "GitHub App Manifest contract checks passed."


### PR DESCRIPTION
Closes #113

## Summary
- define four reusable least-privilege GitHub App manifests
- document trust boundaries, installation scope, credential isolation, and ruleset invariants
- add manifest permission and documentation contract tests

## Verification
- `bash scripts/github-setup/test-app-manifest-contract.sh`
- `make quality`

No workflow behavior from later parent issues is included.