### PR TITLE
fix: harden tooling metadata gates

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -7,6 +7,12 @@ on:
   schedule:
     - cron: "0 4 * * 1"
   workflow_dispatch:
+    inputs:
+      explicit_breaking:
+        description: "Treat this maintenance update as explicitly breaking"
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: weekly-tooling-updates
@@ -69,6 +75,7 @@ jobs:
       - name: Update repository and template tooling
         env:
           TOOLING_UPDATE_METADATA_FILE: ${{ runner.temp }}/tooling-update-metadata.json
+          TOOLING_UPDATE_EXPLICIT_BREAKING: ${{ inputs.explicit_breaking || false }}
         shell: bash
         run: |
           ENV_MANAGER=micromamba make tooling-update-repo
@@ -111,32 +118,19 @@ jobs:
           after all required checks, CodeRabbit review requirements, and approval rules are satisfied.
           EOF
 
+          if git diff --quiet --exit-code && [ -z "$(git ls-files --others --exclude-standard)" ]; then
+            echo "No tooling updates detected; skipping PR creation."
+            exit 0
+          fi
+
           metadata_file="$TOOLING_UPDATE_METADATA_FILE"
           [ -s "$metadata_file" ] || {
             echo "tooling update metadata is missing" >&2
             exit 1
           }
-          jq -e '
-            .schema_version == 1 and (.updates | type == "array") and
-            all(.updates[];
-              (.package | type == "string" and length > 0) and
-              (.old_version | type == "string" and length > 0) and
-              (.new_version | type == "string" and length > 0) and
-              (.update_type | type == "string" and (IN("patch", "minor", "major", "breaking", "unknown"))) and
-              (.risk | type == "string" and (IN("low", "medium", "high", "unknown"))) and
-              (.files | type == "array" and all(.[]; type == "string" and length > 0))
-            )
-          ' "$metadata_file" >/dev/null || {
-            echo "tooling update metadata is invalid" >&2
-            exit 1
-          }
+          bash ./scripts/github-setup/validate-tooling-metadata.sh "$metadata_file"
           jq -r '.updates[] | "- `\(.package)`: \(.old_version) -> \(.new_version) (\(.update_type), \(.risk))"' "$metadata_file" >> /tmp/weekly-tooling-pr-body.md
           printf '\nMachine-readable metadata is generated in the workflow runner and is not committed.\n' >> /tmp/weekly-tooling-pr-body.md
-
-          if git diff --quiet --exit-code && [ -z "$(git ls-files --others --exclude-standard)" ]; then
-            echo "No tooling updates detected; skipping PR creation."
-            exit 0
-          fi
 
           git checkout -B "$branch"
           git add -A

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -102,6 +102,14 @@ assert_contains "inputs.permission_profile == 'weekly-tooling' || inputs.permiss
 assert_contains "uses: ./.github/actions/resolve-gh-token" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "permission_profile: weekly-tooling" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains 'TOOLING_UPDATE_METADATA_FILE' "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains 'validate-tooling-metadata.sh' "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_contains 'TOOLING_UPDATE_EXPLICIT_BREAKING' "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+no_update_line="$(grep -n 'No tooling updates detected; skipping PR creation.' "$repo_root/.github/workflows/weekly-tooling-updates.yml" | cut -d: -f1)"
+validator_line="$(grep -n 'validate-tooling-metadata.sh' "$repo_root/.github/workflows/weekly-tooling-updates.yml" | cut -d: -f1)"
+[ "$no_update_line" -lt "$validator_line" ] || {
+    echo "no-update path must precede strict metadata validation" >&2
+    exit 1
+}
 assert_contains 'automation: maintenance' "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains 'automation: validating' "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains 'automation: breaking' "$repo_root/.github/workflows/weekly-tooling-updates.yml"

--- a/scripts/github-setup/test-tooling-metadata-contract.sh
+++ b/scripts/github-setup/test-tooling-metadata-contract.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="$script_dir/validate-tooling-metadata.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+valid="$tmp_dir/valid.json"
+cat > "$valid" << 'EOF'
+{"schema_version":1,"updates":[{"package":"tool","old_version":"1.2.3","new_version":"1.2.4","update_type":"patch","risk":"low","files":["mise.toml"]}]}
+EOF
+
+"$validator" "$valid"
+
+for payload in \
+    '{"schema_version":1,"updates":[]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"patch","risk":"low","files":[]}]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"patch","risk":"low"}]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"patch","risk":"high","files":["mise.toml"]}]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"major","risk":"low","files":["mise.toml"]}]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"breaking","risk":"medium","files":["mise.toml"]}]}' \
+    '{"schema_version":1,"updates":[{"package":"tool","old_version":"1","new_version":"2","update_type":"unknown","risk":"high","files":["mise.toml"]}]}'; do
+    candidate="$tmp_dir/candidate.json"
+    printf '%s\n' "$payload" > "$candidate"
+    if "$validator" "$candidate"; then
+        echo "validator accepted invalid metadata: $payload" >&2
+        exit 1
+    fi
+done
+
+for payload in '' 'not-json' '{"schema_version":2,"updates":[]}' '{"schema_version":1}'; do
+    candidate="$tmp_dir/candidate.json"
+    printf '%s\n' "$payload" > "$candidate"
+    if "$validator" "$candidate"; then
+        echo "validator accepted invalid metadata: $payload" >&2
+        exit 1
+    fi
+done
+
+if "$validator" "$tmp_dir/missing.json"; then
+    echo "validator accepted missing metadata" >&2
+    exit 1
+fi
+
+echo "Tooling metadata contract passed."

--- a/scripts/github-setup/validate-tooling-metadata.sh
+++ b/scripts/github-setup/validate-tooling-metadata.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+metadata_file="${1:-}"
+[ -n "$metadata_file" ] || {
+    echo "tooling metadata file is required" >&2
+    exit 1
+}
+[ -s "$metadata_file" ] || {
+    echo "tooling update metadata is missing or empty" >&2
+    exit 1
+}
+
+jq -e '.schema_version == 1 and (.updates | type == "array" and length > 0) and all(.updates[]; (.package | type == "string" and length > 0) and (.old_version | type == "string" and length > 0) and (.new_version | type == "string" and length > 0) and (.files | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and ((.update_type == "patch" and .risk == "low") or (.update_type == "minor" and .risk == "medium") or (.update_type == "major" and .risk == "high") or (.update_type == "breaking" and .risk == "high") or (.update_type == "unknown" and .risk == "unknown")))' "$metadata_file" > /dev/null || {
+    echo "tooling update metadata is invalid" >&2
+    exit 1
+}

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -14,6 +14,7 @@ contract_tests=(
     "$script_dir/github-setup/test-app-manifest-contract.sh"
     "$script_dir/github-setup/test-app-user-token-contract.sh"
     "$script_dir/github-setup/test-commit-verification-contract.sh"
+    "$script_dir/github-setup/test-tooling-metadata-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"
     "$script_dir/github-setup/test-personal-app-e2e-contract.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

- reject empty or missing tooling metadata before any auto-merge decision
- enforce semantically consistent update type and risk pairs
- wire explicit-breaking classification through the normal workflow dispatch path
- add deterministic contract coverage for metadata rejection and no-op ordering

## Related Issue

Closes #128

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable
- [x] `ENV_MANAGER=micromamba LINT_MODE=check make quality`
- [x] Independent code review completed; no Critical, Important, or Minor findings

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
