### PR TITLE
feat: validate generated E2E head SHA

### DIFF
--- a/.github/workflows/test-generated-repository-e2e.yml
+++ b/.github/workflows/test-generated-repository-e2e.yml
@@ -1,4 +1,5 @@
 name: Test Generated Repository E2E
+run-name: Generated Repository E2E / ${{ inputs.head_sha || inputs.target_ref || 'main' }}
 
 on:
   workflow_dispatch:
@@ -7,6 +8,10 @@ on:
         description: Branch or tag containing the creation workflow to test.
         required: false
         default: main
+        type: string
+      head_sha:
+        description: Exact 40-character PR head commit SHA to test instead of target_ref.
+        required: false
         type: string
       client_id:
         description: GitHub App client ID for the credentialed E2E run.
@@ -53,7 +58,7 @@ permissions:
 
 jobs:
   generated-repository:
-    name: ${{ matrix.creation_workflow }} / ${{ matrix.delivery }} / ${{ matrix.provider }}
+    name: ${{ matrix.creation_workflow }} / ${{ matrix.delivery }} / ${{ matrix.provider }} @ ${{ inputs.head_sha || inputs.target_ref || 'main' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -142,7 +147,8 @@ jobs:
         env:
           GH_TOKEN: ${{ steps.token.outputs.token }}
           OWNER: ${{ github.repository_owner }}
-          TARGET_REF: ${{ inputs.target_ref || 'main' }}
+          TARGET_REF: ${{ inputs.head_sha || inputs.target_ref || 'main' }}
+          REQUESTED_HEAD_SHA: ${{ inputs.head_sha }}
           PROVIDER: ${{ matrix.provider }}
           DELIVERY: ${{ matrix.delivery }}
           CENTRAL_REPOSITORY: ${{ inputs.central_repository }}
@@ -168,7 +174,12 @@ jobs:
 
           REPO_NAME="e2e-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${PROVIDER}-${DELIVERY}-${CREATION_WORKFLOW%.yml}"
 
+          DISPATCH_REF="$TARGET_REF"
+          TEMP_REF_CREATED=false
           cleanup() {
+            if [ "$TEMP_REF_CREATED" = true ]; then
+              gh api --method DELETE "/repos/$GITHUB_REPOSITORY/git/refs/heads/$DISPATCH_REF" >/dev/null 2>&1 || true
+            fi
             if [ "$CLEANUP" = true ] && gh repo view "$OWNER/$REPO_NAME" >/dev/null 2>&1; then
               gh repo delete "$OWNER/$REPO_NAME" --yes >/dev/null
               echo "Deleted $OWNER/$REPO_NAME"
@@ -176,7 +187,18 @@ jobs:
           }
           trap cleanup EXIT
 
-          gh workflow run "$CREATION_WORKFLOW" --repo "$GITHUB_REPOSITORY" --ref "$TARGET_REF" \
+          if [ -n "$REQUESTED_HEAD_SHA" ] && ! [[ "$REQUESTED_HEAD_SHA" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "head_sha must be a 40-character commit SHA" >&2
+            exit 1
+          fi
+          if [ -n "$REQUESTED_HEAD_SHA" ]; then
+            DISPATCH_REF="e2e-head-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${PROVIDER}-${DELIVERY}-${CREATION_WORKFLOW%.yml}"
+            gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
+              -f "ref=refs/heads/$DISPATCH_REF" -f "sha=$REQUESTED_HEAD_SHA" >/dev/null
+            TEMP_REF_CREATED=true
+          fi
+
+          gh workflow run "$CREATION_WORKFLOW" --repo "$GITHUB_REPOSITORY" --ref "$DISPATCH_REF" \
             --field repo_name="$REPO_NAME" \
             --field repo_description="Generated repository E2E scenario" \
             --field visibility=private --field team_name="* @$OWNER" --field license_holder="$OWNER" \
@@ -185,6 +207,8 @@ jobs:
             --field workflows=quality --field delivery_mode="$DELIVERY" \
             --field central_repository="$CENTRAL_SOURCE" \
             --field cleanup_on_failure=true
+
+          echo "requested_head_sha=$TARGET_REF" >> "$GITHUB_STEP_SUMMARY"
 
           CREATION_RUN=""
           for _ in $(seq 1 60); do
@@ -197,6 +221,15 @@ jobs:
             sleep 10
           done
           [ -n "$CREATION_RUN" ] || { echo "creation run not found" >&2; exit 1; }
+
+          CREATION_RUN_JSON="$RUNNER_TEMP/creation-run-$REPO_NAME.json"
+          gh run view "$CREATION_RUN" --repo "$GITHUB_REPOSITORY" --json headSha,status,conclusion > "$CREATION_RUN_JSON"
+          if [ -n "$REQUESTED_HEAD_SHA" ]; then
+            "$GITHUB_WORKSPACE/scripts/github-setup/validate-generated-e2e-head.sh" \
+              "$REQUESTED_HEAD_SHA" "$CREATION_RUN_JSON"
+          fi
+          CREATION_HEAD_SHA=$(jq -r '.headSha // empty' "$CREATION_RUN_JSON")
+          echo "creation_head_sha=$CREATION_HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
 
           for _ in $(seq 1 90); do
             STATUS=$(gh run view "$CREATION_RUN" --repo "$GITHUB_REPOSITORY" --json status,conclusion --jq '[.status,.conclusion] | @tsv')

--- a/scripts/github-setup/test-generated-e2e-head-contract.sh
+++ b/scripts/github-setup/test-generated-e2e-head-contract.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="$script_dir/validate-generated-e2e-head.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+requested_sha="0123456789abcdef0123456789abcdef01234567"
+cat > "$tmp_dir/matching-run.json" << EOF
+{"headSha":"$requested_sha"}
+EOF
+"$validator" "$requested_sha" "$tmp_dir/matching-run.json"
+
+cat > "$tmp_dir/stale-run.json" << 'EOF'
+{"head_sha":"fedcba9876543210fedcba9876543210fedcba98"}
+EOF
+if "$validator" "$requested_sha" "$tmp_dir/stale-run.json"; then
+    echo "stale E2E run SHA was accepted" >&2
+    exit 1
+fi
+
+if "$validator" "" "$tmp_dir/matching-run.json"; then
+    echo "empty requested E2E SHA was accepted" >&2
+    exit 1
+fi
+
+if "$validator" "not-a-sha" "$tmp_dir/matching-run.json"; then
+    echo "malformed requested E2E SHA was accepted" >&2
+    exit 1
+fi
+
+echo "Generated repository E2E head contract passed."

--- a/scripts/github-setup/test-profile.sh
+++ b/scripts/github-setup/test-profile.sh
@@ -93,6 +93,14 @@ if grep -Eq '^    if: .*matrix\.' "$repo_root/.github/workflows/test-generated-r
     exit 1
 fi
 grep -q '^      - name: Select requested creation workflow$' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q '^      head_sha:' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q '^    name: .*matrix.creation_workflow.*matrix.delivery.*matrix.provider' \
+    "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q '@ .*inputs.head_sha' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q 'validate-generated-e2e-head.sh' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q 'git/refs' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q 'DISPATCH_REF' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
+grep -q 'requested_head_sha=' "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
 for runtime_input in python_version node_version go_version java_version; do
     runtime_env="$(printf '%s' "$runtime_input" | tr '[:lower:]' '[:upper:]')"
     grep -q -- "--field ${runtime_input}=\"\$${runtime_env}\"" \

--- a/scripts/github-setup/validate-generated-e2e-head.sh
+++ b/scripts/github-setup/validate-generated-e2e-head.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+requested_sha="${1:-}"
+run_file="${2:-}"
+
+if ! [[ "$requested_sha" =~ ^[0-9a-fA-F]{40}$ ]] || [ ! -s "$run_file" ]; then
+    echo "generated E2E head validation inputs are incomplete" >&2
+    exit 1
+fi
+
+jq -e --arg requested_sha "$requested_sha" '(.head_sha // .headSha) == $requested_sha' "$run_file" > /dev/null || {
+    echo "generated E2E run head SHA does not match requested SHA" >&2
+    exit 1
+}

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -15,6 +15,7 @@ contract_tests=(
     "$script_dir/github-setup/test-app-user-token-contract.sh"
     "$script_dir/github-setup/test-commit-verification-contract.sh"
     "$script_dir/github-setup/test-tooling-metadata-contract.sh"
+    "$script_dir/github-setup/test-generated-e2e-head-contract.sh"
     "$script_dir/github-setup/test-workflow-approval-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Extend generated-repository E2E runs to accept an exact PR head SHA, dispatch creation workflows at that immutable ref, validate the resulting run head SHA, and expose the requested/observed SHA in the run and check names.

## Related Issue

Closes #117

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Exact validation: `bash scripts/github-setup/test-generated-e2e-head-contract.sh`; `ENV_MANAGER=micromamba LINT_MODE=check make quality` (all contracts, Go tests, ShellCheck, workflow assets, formatting, vet, and pre-commit checks passed).

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer