### PR TITLE
feat: clean up archived E2E repositories

### DIFF
--- a/.github/workflows/cleanup-archived-e2e.yml
+++ b/.github/workflows/cleanup-archived-e2e.yml
@@ -1,0 +1,140 @@
+name: Cleanup Archived E2E Repositories
+
+on:
+  schedule:
+    - cron: "17 3 * * 0"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  cleanup:
+    name: Remove eligible archived E2E repositories
+    runs-on: ubuntu-24.04
+    environment: e2e-cleanup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+
+      - name: Resolve isolated E2E lifecycle token
+        id: e2e-token
+        uses: ./.github/actions/resolve-gh-token
+        with:
+          client_id: ${{ vars.BOOTSTRAP_E2E_APP_CLIENT_ID }}
+          app_private_key: ${{ secrets.BOOTSTRAP_E2E_APP_PRIVATE_KEY }}
+          app_owner: ${{ vars.BOOTSTRAP_E2E_APP_OWNER }}
+          target_owner: ${{ vars.BOOTSTRAP_E2E_APP_OWNER }}
+          permission_profile: e2e-lifecycle
+
+      - name: Delete eligible archived E2E repositories
+        env:
+          E2E_GH_TOKEN: ${{ steps.e2e-token.outputs.token }}
+          ALLOWED_OWNERS: ${{ vars.BOOTSTRAP_E2E_ALLOWED_OWNERS }}
+          APP_OWNER: ${{ vars.BOOTSTRAP_E2E_APP_OWNER }}
+          CENTRAL_REPOSITORY: ${{ vars.BOOTSTRAP_E2E_CENTRAL_REPOSITORY }}
+          BOOTSTRAP_REPOSITORY: ${{ github.repository }}
+          VALIDATOR: ${{ github.workspace }}/scripts/github-setup/validate-e2e-cleanup-candidate.sh
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          cleanup() { rm -rf "$tmp_dir"; }
+          trap cleanup EXIT
+
+          [[ "$APP_OWNER" =~ ^[A-Za-z0-9_.-]+$ ]] || {
+            echo "E2E App owner is missing or invalid" >&2
+            exit 1
+          }
+          [ -n "$ALLOWED_OWNERS" ] || {
+            echo "E2E cleanup allowlist is empty; refusing to continue" >&2
+            exit 1
+          }
+          owner_is_allowed=false
+          IFS=',' read -ra allowed_owner_values <<< "$ALLOWED_OWNERS"
+          for allowed_owner in "${allowed_owner_values[@]}"; do
+            allowed_owner="${allowed_owner//[[:space:]]/}"
+            if [ "$allowed_owner" = "$APP_OWNER" ]; then
+              owner_is_allowed=true
+            fi
+          done
+          [ "$owner_is_allowed" = true ] || {
+            echo "E2E App owner is not present in the cleanup allowlist" >&2
+            exit 1
+          }
+          [[ "$CENTRAL_REPOSITORY" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+            echo "central workflow repository exclusion is missing or invalid" >&2
+            exit 1
+          }
+
+          exclusions="$BOOTSTRAP_REPOSITORY,$CENTRAL_REPOSITORY"
+          now_epoch="$(date -u '+%s')"
+          repositories_file="$tmp_dir/repositories.json"
+          if ! GH_TOKEN="$E2E_GH_TOKEN" gh api --paginate --slurp \
+            "/orgs/$APP_OWNER/repos?type=all&per_page=100" > "$repositories_file"; then
+            echo "failed to enumerate E2E repositories" >&2
+            exit 1
+          fi
+
+          scanned=0
+          eligible=0
+          deleted=0
+          already_gone=0
+          failures=0
+          deleted_names=""
+
+          while IFS= read -r repository; do
+            [ -n "$repository" ] || continue
+            scanned=$((scanned + 1))
+            owner="$(jq -r '.owner.login // empty' <<< "$repository")"
+            name="$(jq -r '.name // empty' <<< "$repository")"
+            full_name="$owner/$name"
+            candidate_file="$tmp_dir/candidate.json"
+            probe_file="$tmp_dir/probe-response"
+            if GH_TOKEN="$E2E_GH_TOKEN" gh api --include \
+              "/repos/$full_name" > "$probe_file" 2>&1; then
+              sed -n '/^{/,$p' "$probe_file" > "$candidate_file"
+            elif grep -Eq '^HTTP/[0-9.]+ 404' "$probe_file"; then
+              continue
+            else
+              echo "failed to re-fetch E2E repository $full_name before validation" >&2
+              exit 1
+            fi
+
+            if ! "$VALIDATOR" "$ALLOWED_OWNERS" "$candidate_file" "$exclusions" "$now_epoch"; then
+              continue
+            fi
+
+            eligible=$((eligible + 1))
+            response_file="$tmp_dir/delete-response"
+            if GH_TOKEN="$E2E_GH_TOKEN" gh api --include --method DELETE \
+              "/repos/$full_name" > "$response_file" 2>&1; then
+              deleted=$((deleted + 1))
+              deleted_names="$deleted_names $full_name"
+              continue
+            fi
+            if grep -Eq '^HTTP/[0-9.]+ 404' "$response_file"; then
+              already_gone=$((already_gone + 1))
+              continue
+            fi
+            echo "failed to delete validated E2E repository $full_name" >&2
+            failures=$((failures + 1))
+          done < <(jq -c '.[][]' "$repositories_file")
+
+          {
+            echo "## Archived E2E repository cleanup"
+            echo "- Scanned: $scanned"
+            echo "- Eligible: $eligible"
+            echo "- Deleted: $deleted"
+            echo "- Already absent: $already_gone"
+            echo "- Skipped: $((scanned - eligible))"
+            echo "- Failures: $failures"
+            [ -n "$deleted_names" ] && echo "- Deleted repositories:$deleted_names"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "$failures" -ne 0 ]; then
+            exit 1
+          fi

--- a/scripts/github-setup/test-e2e-cleanup-contract.sh
+++ b/scripts/github-setup/test-e2e-cleanup-contract.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="$script_dir/validate-e2e-cleanup-candidate.sh"
+workflow="$script_dir/../../.github/workflows/cleanup-archived-e2e.yml"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+if now_epoch="$(date -u -d '2026-08-28T00:00:00Z' '+%s' 2> /dev/null)"; then
+    :
+else
+    now_epoch="$(date -j -f '%Y-%m-%dT%H:%M:%SZ' '2026-08-28T00:00:00Z' '+%s')"
+fi
+cat > "$tmp_dir/eligible.json" << 'EOF'
+{"owner":{"login":"e2e-owner"},"name":"bootstrap-e2e-123-1-system-embedded-create-repository","visibility":"public","archived":true,"topics":["bootstrap-e2e"],"updated_at":"2026-05-01T00:00:00Z"}
+EOF
+"$validator" "e2e-owner" "$tmp_dir/eligible.json" "e2e-owner/github-bootstrap,e2e-owner/central-workflows" "$now_epoch"
+
+for fixture in wrong-owner wrong-name unarchived unmarked recent excluded; do
+    excluded_names="e2e-owner/github-bootstrap,e2e-owner/central-workflows"
+    case "$fixture" in
+        wrong-owner) sed 's/e2e-owner/other-owner/' "$tmp_dir/eligible.json" > "$tmp_dir/$fixture.json" ;;
+        wrong-name) sed 's/bootstrap-e2e-/e2e-/' "$tmp_dir/eligible.json" > "$tmp_dir/$fixture.json" ;;
+        unarchived) sed 's/"archived":true/"archived":false/' "$tmp_dir/eligible.json" > "$tmp_dir/$fixture.json" ;;
+        unmarked) sed 's/"bootstrap-e2e"/"unrelated"/' "$tmp_dir/eligible.json" > "$tmp_dir/$fixture.json" ;;
+        recent) sed 's/2026-05-01/2026-08-01/' "$tmp_dir/eligible.json" > "$tmp_dir/$fixture.json" ;;
+        excluded)
+            excluded_names="e2e-owner/bootstrap-e2e-123-1-system-embedded-create-repository"
+            cp "$tmp_dir/eligible.json" "$tmp_dir/$fixture.json"
+            ;;
+    esac
+    if "$validator" "e2e-owner" "$tmp_dir/$fixture.json" "$excluded_names" "$now_epoch"; then
+        echo "$fixture cleanup candidate was accepted" >&2
+        exit 1
+    fi
+done
+
+if "$validator" "e2e-owner" "$tmp_dir/eligible.json" "E2E-OWNER/bootstrap-e2e-123-1-system-embedded-create-repository" "$now_epoch"; then
+    echo "case-variant exclusion was ignored" >&2
+    exit 1
+fi
+
+grep -q 'visibility' "$validator"
+grep -q 'bootstrap-e2e' "$validator"
+grep -q 'trap cleanup EXIT' "$workflow"
+grep -q 'archived' "$workflow"
+grep -q 'validate-e2e-cleanup-candidate.sh' "$workflow"
+grep -q 'permission_profile: e2e-lifecycle' "$workflow"
+grep -q 'BOOTSTRAP_E2E_APP_PRIVATE_KEY' "$workflow"
+grep -q 'E2E_GH_TOKEN' "$workflow"
+grep -Fq 'HTTP/[0-9.]+ 404' "$workflow"
+grep -Fq 'BOOTSTRAP_E2E_ALLOWED_OWNERS' "$workflow"
+grep -Fq 'BOOTSTRAP_E2E_CENTRAL_REPOSITORY' "$workflow"
+grep -Fq 'gh api --include --method DELETE' "$workflow"
+grep -Fq "gh api --include \\" "$workflow"
+grep -Fq 're-fetch E2E repository' "$workflow"
+grep -Fq 'GITHUB_STEP_SUMMARY' "$workflow"
+
+echo "E2E cleanup contract passed."

--- a/scripts/github-setup/validate-e2e-cleanup-candidate.sh
+++ b/scripts/github-setup/validate-e2e-cleanup-candidate.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+allowed_owners="${1:-}"
+repository_file="${2:-}"
+excluded_names="${3:-}"
+now_epoch="${4:-}"
+
+if [ -z "$allowed_owners" ] || [ ! -s "$repository_file" ] || ! [[ "$now_epoch" =~ ^[0-9]+$ ]]; then
+    echo "E2E cleanup candidate inputs are incomplete" >&2
+    exit 1
+fi
+
+cutoff_epoch=$((now_epoch - 90 * 24 * 60 * 60))
+jq -e \
+    --arg allowed_owners "$allowed_owners" \
+    --arg excluded_names "$excluded_names" \
+    --argjson cutoff_epoch "$cutoff_epoch" '
+    (.owner.login | ascii_downcase) as $owner |
+    .name as $name |
+    ($allowed_owners | split(",") | map(gsub("^\\s+|\\s+$"; "") | ascii_downcase)) as $owners |
+    ($excluded_names | split(",") | map(gsub("^\\s+|\\s+$"; "") | ascii_downcase)) as $excluded |
+    ($name | test("^bootstrap-e2e-[0-9]+-[0-9]+-(micromamba|mise|system)-(embedded|centralized)-(create-repository|terraform-create-repository)$")) and
+    ($owners | index($owner) != null) and
+    ($excluded | index("\($owner)/\($name)" | ascii_downcase) == null) and
+    (.visibility == "public") and
+    (.archived == true) and
+    (.topics | type == "array" and index("bootstrap-e2e") != null) and
+    ((.updated_at | fromdateiso8601) <= $cutoff_epoch)
+    ' "$repository_file" > /dev/null || {
+    echo "E2E repository is not eligible for cleanup" >&2
+    exit 1
+}

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -17,6 +17,7 @@ contract_tests=(
     "$script_dir/github-setup/test-tooling-metadata-contract.sh"
     "$script_dir/github-setup/test-generated-e2e-head-contract.sh"
     "$script_dir/github-setup/test-e2e-archive-contract.sh"
+    "$script_dir/github-setup/test-e2e-cleanup-contract.sh"
     "$script_dir/github-setup/test-workflow-approval-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a scheduled and manually dispatchable cleanup workflow for public, archived generated E2E repositories that are at least 90 days old. Cleanup is fail-closed, allowlist-scoped, excludes the bootstrap and central workflow repositories, and uses the isolated E2E lifecycle App profile.

## Related Issue

Closes #119

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Exact evidence: `bash scripts/run-contract-tests.sh`; `MAMBA_ROOT_PREFIX=/Users/r04285/micromamba ENV_MANAGER=micromamba LINT_MODE=check make quality` (all contracts, Go tests, pre-commit hooks, ShellCheck, YAML/workflow checks, Go vet, and formatting passed).

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer