### PR TITLE
feat: gate automation on Copilot review

### DIFF
--- a/.github/workflows/approve-automation-workflows.yml
+++ b/.github/workflows/approve-automation-workflows.yml
@@ -33,6 +33,7 @@ jobs:
             scripts/github-setup/gh-common.sh
             scripts/github-setup/validate-app-auth.sh
             scripts/github-setup/validate-workflow-approval.sh
+            scripts/github-setup/validate-copilot-review.sh
 
       - name: Resolve Reviewer App token
         id: resolve-token
@@ -64,6 +65,7 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPOSITORY: ${{ github.event.repository.name }}
           WRITER_APP_SLUG: ${{ vars.BOOTSTRAP_MAINTENANCE_WRITER_APP_SLUG }}
+          COPILOT_REVIEWER_LOGIN: ${{ vars.BOOTSTRAP_COPILOT_REVIEWER_LOGIN }}
           RUN_ID: ${{ github.event.workflow_run.id }}
           VALIDATOR: scripts/github-setup/validate-workflow-approval.sh
         shell: bash
@@ -72,12 +74,30 @@ jobs:
           run_file="$RUNNER_TEMP/workflow-run.json"
           pr_file="$RUNNER_TEMP/pull-request.json"
           changed_files="$RUNNER_TEMP/changed-files.txt"
+          reviews_file="$RUNNER_TEMP/copilot-reviews.json"
+          threads_file="$RUNNER_TEMP/copilot-threads.json"
           gh api "/repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" > "$run_file"
           pr_number="$(jq -r '.pull_requests[0].number // empty' "$run_file")"
           [ -n "$pr_number" ] || { echo "workflow run has no pull request" >&2; exit 1; }
           gh api "/repos/$GITHUB_REPOSITORY/pulls/$pr_number" > "$pr_file"
           gh api --paginate "/repos/$GITHUB_REPOSITORY/pulls/$pr_number/files" --jq '.[].filename' > "$changed_files"
           "$VALIDATOR" "$run_file" "$pr_file" "$changed_files"
+          gh api --paginate --slurp "/repos/$GITHUB_REPOSITORY/pulls/$pr_number/reviews" > "$RUNNER_TEMP/reviews-pages.json"
+          jq '[.[][]]' "$RUNNER_TEMP/reviews-pages.json" > "$reviews_file"
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -f query='query($owner:String!,$repository:String!,$number:Int!){repository(owner:$owner,name:$repository){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}' \
+            -F owner="$OWNER" -F repository="$REPOSITORY" -F number="$pr_number" \
+            > "$RUNNER_TEMP/threads-response.json"
+          jq -e '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false' \
+            "$RUNNER_TEMP/threads-response.json" > /dev/null || {
+              echo "Copilot review threads exceed the validation page; refusing to approve" >&2
+              exit 1
+            }
+          jq '[.data.repository.pullRequest.reviewThreads.nodes[] | {isResolved, author_login: (.comments.nodes[0].author.login // "")}]' \
+            "$RUNNER_TEMP/threads-response.json" > "$threads_file"
+          "$GITHUB_WORKSPACE/scripts/github-setup/validate-copilot-review.sh" \
+            "$pr_file" "$reviews_file" "$threads_file" "$COPILOT_REVIEWER_LOGIN"
           printf '%s\n' "$pr_number" > "$RUNNER_TEMP/pull-request-number"
 
       - name: Approve workflow run

--- a/scripts/github-setup/test-copilot-review-contract.sh
+++ b/scripts/github-setup/test-copilot-review-contract.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="$script_dir/validate-copilot-review.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "$tmp_dir/pr.json" << 'EOF'
+{"number":7,"head":{"sha":"current-sha"},"requested_reviewers":[{"login":"copilot-pull-request-reviewer[bot]"}]}
+EOF
+cat > "$tmp_dir/reviews.json" << 'EOF'
+[{"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"COMMENTED","commit_id":"current-sha"}]
+EOF
+cat > "$tmp_dir/threads.json" << 'EOF'
+[{"isResolved":true,"author_login":"copilot-pull-request-reviewer[bot]"}]
+EOF
+printf '%s\n' '[]' > "$tmp_dir/empty-reviews.json"
+
+"$validator" "$tmp_dir/pr.json" "$tmp_dir/reviews.json" "$tmp_dir/threads.json" "copilot-pull-request-reviewer[bot]"
+
+cat > "$tmp_dir/no-request.json" << 'EOF'
+{"number":7,"head":{"sha":"current-sha"},"requested_reviewers":[]}
+EOF
+"$validator" "$tmp_dir/no-request.json" "$tmp_dir/reviews.json" "$tmp_dir/threads.json" ""
+
+if "$validator" "$tmp_dir/no-request.json" "$tmp_dir/empty-reviews.json" "$tmp_dir/threads.json" "copilot-pull-request-reviewer[bot]"; then
+    echo "configured Copilot review gate was bypassed" >&2
+    exit 1
+fi
+
+for mutation in pending stale unresolved; do
+    cp "$tmp_dir/pr.json" "$tmp_dir/mutated-pr.json"
+    cp "$tmp_dir/reviews.json" "$tmp_dir/mutated-reviews.json"
+    cp "$tmp_dir/threads.json" "$tmp_dir/mutated-threads.json"
+    case "$mutation" in
+        pending) printf '%s\n' '[]' > "$tmp_dir/mutated-reviews.json" ;;
+        stale) sed 's/current-sha/old-sha/' "$tmp_dir/reviews.json" > "$tmp_dir/mutated-reviews.json" ;;
+        unresolved) sed 's/"isResolved":true/"isResolved":false/' "$tmp_dir/threads.json" > "$tmp_dir/mutated-threads.json" ;;
+    esac
+    if "$validator" "$tmp_dir/mutated-pr.json" "$tmp_dir/mutated-reviews.json" "$tmp_dir/mutated-threads.json" "copilot-pull-request-reviewer[bot]"; then
+        echo "validator accepted invalid Copilot fixture: $mutation" >&2
+        exit 1
+    fi
+done
+
+workflow="$script_dir/../../.github/workflows/approve-automation-workflows.yml"
+grep -Fq 'validate-copilot-review.sh' "$workflow"
+grep -Fq 'BOOTSTRAP_COPILOT_REVIEWER_LOGIN' "$workflow"
+grep -Fq "pulls/\$pr_number/reviews" "$workflow"
+grep -Fq 'reviewThreads(first:100)' "$workflow"
+grep -Fq 'pageInfo.hasNextPage == false' "$workflow"
+grep -Fq 'isResolved' "$workflow"
+grep -Fq 'COPILOT_REVIEWER_LOGIN' "$workflow"
+
+echo "Copilot review contract passed."

--- a/scripts/github-setup/validate-copilot-review.sh
+++ b/scripts/github-setup/validate-copilot-review.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr_file="${1:-}"
+reviews_file="${2:-}"
+threads_file="${3:-}"
+configured_login="${4:-}"
+
+if ! [ -s "$pr_file" ] || ! [ -s "$reviews_file" ] || ! [ -s "$threads_file" ]; then
+    echo "Copilot review validation inputs are incomplete" >&2
+    exit 1
+fi
+
+requested_login="$(jq -r '
+    [.requested_reviewers[]?.login // empty | select(test("copilot"; "i"))] | first // empty
+    ' "$pr_file")"
+copilot_login="$configured_login"
+if [ -z "$copilot_login" ]; then
+    copilot_login="$requested_login"
+fi
+
+if [ -z "$copilot_login" ]; then
+    exit 0
+fi
+
+head_sha="$(jq -r '.head.sha // empty' "$pr_file")"
+[ -n "$head_sha" ] || {
+    echo "pull request head SHA is missing" >&2
+    exit 1
+}
+
+jq -e \
+    --arg copilot_login "$copilot_login" \
+    --arg head_sha "$head_sha" \
+    'any(.[]; (.user.login // "") == $copilot_login and .state == "COMMENTED" and .commit_id == $head_sha)' \
+    "$reviews_file" > /dev/null || {
+    echo "Copilot review is missing for the current pull request head" >&2
+    exit 1
+}
+
+jq -e \
+    --arg copilot_login "$copilot_login" \
+    'all(.[]; (.author_login // "") != $copilot_login or .isResolved == true)' \
+    "$threads_file" > /dev/null || {
+    echo "Copilot review has unresolved threads" >&2
+    exit 1
+}

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -19,6 +19,7 @@ contract_tests=(
     "$script_dir/github-setup/test-e2e-archive-contract.sh"
     "$script_dir/github-setup/test-e2e-cleanup-contract.sh"
     "$script_dir/github-setup/test-workflow-approval-contract.sh"
+    "$script_dir/github-setup/test-copilot-review-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"
     "$script_dir/github-setup/test-personal-app-e2e-contract.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds a fail-closed Copilot review completion gate to automation workflow approval. Requested or configured Copilot review must be present on the current PR head with COMMENTED state, and all Copilot-authored review threads must be resolved. Copilot COMMENTED remains completion evidence, never repository approval.

## Related Issue

Closes #120

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Exact evidence: `bash scripts/run-contract-tests.sh`; `MAMBA_ROOT_PREFIX=/Users/r04285/micromamba ENV_MANAGER=micromamba LINT_MODE=check make quality` (contracts, Go tests, pre-commit hooks, ShellCheck, shfmt, YAML/workflow checks, Go vet, and formatting passed).

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer