### PR TITLE
feat: add maintenance safety check

### DIFF
--- a/.github/actions/apply-repository-ruleset/action.yml
+++ b/.github/actions/apply-repository-ruleset/action.yml
@@ -136,6 +136,9 @@ runs:
           if workflow_has_check .github/workflows/quality.yml quality; then
             REQUIRED_STATUS_CHECKS="$REQUIRED_STATUS_CHECKS,quality"
           fi
+          if workflow_has_check .github/workflows/maintenance-safety.yml "Maintenance safety"; then
+            REQUIRED_STATUS_CHECKS="$REQUIRED_STATUS_CHECKS,Maintenance safety"
+          fi
           REQUIRED_STATUS_CHECKS="${REQUIRED_STATUS_CHECKS#,}"
           [ -n "$REQUIRED_STATUS_CHECKS" ] || {
             echo "::error::Target repository has no validated bootstrap status workflows."

--- a/.github/config/ruleset-coderabbit.json
+++ b/.github/config/ruleset-coderabbit.json
@@ -39,7 +39,8 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "Signed-off-by trailers" },
-          { "context": "quality" }
+          { "context": "quality" },
+          { "context": "Maintenance safety" }
         ]
       }
     }

--- a/.github/config/ruleset-default.json
+++ b/.github/config/ruleset-default.json
@@ -39,7 +39,8 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "Signed-off-by trailers" },
-          { "context": "quality" }
+          { "context": "quality" },
+          { "context": "Maintenance safety" }
         ]
       }
     }

--- a/.github/config/ruleset-minimal.json
+++ b/.github/config/ruleset-minimal.json
@@ -39,7 +39,8 @@
         "strict_required_status_checks_policy": true,
         "required_status_checks": [
           { "context": "Signed-off-by trailers" },
-          { "context": "quality" }
+          { "context": "quality" },
+          { "context": "Maintenance safety" }
         ]
       }
     }

--- a/.github/workflows/maintenance-safety.yml
+++ b/.github/workflows/maintenance-safety.yml
@@ -1,0 +1,94 @@
+name: Maintenance safety
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+  workflow_run:
+    workflows:
+      - Quality
+      - Commit policy
+      - Test Quality Providers
+      - CodeQL Security Scan
+      - Test Generated Repository E2E
+    types: [completed]
+  repository_dispatch:
+    types: [maintenance-safety]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to validate.
+        required: true
+        type: string
+      head_sha:
+        description: Exact pull request head SHA to validate.
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: read
+  pull-requests: read
+
+jobs:
+  safety:
+    name: Maintenance safety
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout validation helpers
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
+          ref: main
+          sparse-checkout: |
+            scripts/github-setup/validate-copilot-review.sh
+            scripts/github-setup/validate-maintenance-safety.sh
+
+      - name: Validate maintenance safety gates
+        env:
+          GH_TOKEN: ${{ github.token }}
+          COPILOT_REVIEWER_LOGIN: ${{ vars.BOOTSTRAP_COPILOT_REVIEWER_LOGIN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.inputs.head_sha || github.event.client_payload.head_sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number || github.event.client_payload.pr_number }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          tmp_dir="$(mktemp -d)"
+          cleanup() { rm -rf "$tmp_dir"; }
+          trap cleanup EXIT
+
+          [ -n "$HEAD_SHA" ] || { echo "maintenance safety head SHA is missing" >&2; exit 1; }
+          [ -n "$PR_NUMBER" ] || { echo "maintenance safety pull request number is missing" >&2; exit 1; }
+          [ -n "$COPILOT_REVIEWER_LOGIN" ] || { echo "Copilot reviewer identity is not configured" >&2; exit 1; }
+
+          pr_file="$tmp_dir/pr.json"
+          runs_file="$tmp_dir/runs.json"
+          e2e_file="$tmp_dir/e2e.json"
+          labels_file="$tmp_dir/labels.json"
+          reviews_file="$tmp_dir/reviews.json"
+          threads_file="$tmp_dir/threads.json"
+
+          gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$pr_file"
+          gh api "/repos/$GITHUB_REPOSITORY/actions/runs?head_sha=$HEAD_SHA&per_page=100" \
+            --jq '[.workflow_runs[] | select(.name == "Quality" or .name == "Commit policy" or .name == "Test Quality Providers" or .name == "CodeQL Security Scan") | {name,status,conclusion,head_sha}]' > "$runs_file"
+          gh api --paginate "/repos/$GITHUB_REPOSITORY/actions/workflows/test-generated-repository-e2e.yml/runs?per_page=100" \
+            --jq '.workflow_runs[] | {status,conclusion,head_sha}' | jq -s '.' > "$e2e_file"
+          gh api "/repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/labels?per_page=100" > "$labels_file"
+          gh api --paginate --slurp "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" > "$tmp_dir/review-pages.json"
+          jq '[.[][]]' "$tmp_dir/review-pages.json" > "$reviews_file"
+
+          # shellcheck disable=SC2016
+          gh api graphql \
+            -f query='query($owner:String!,$repository:String!,$number:Int!){repository(owner:$owner,name:$repository){pullRequest(number:$number){reviewThreads(first:100){pageInfo{hasNextPage} nodes{isResolved comments(first:1){nodes{author{login}}}}}}}}' \
+            -F owner="${GITHUB_REPOSITORY%%/*}" -F repository="${GITHUB_REPOSITORY#*/}" -F number="$PR_NUMBER" \
+            > "$tmp_dir/thread-response.json"
+          jq -e '.data.repository.pullRequest.reviewThreads.pageInfo.hasNextPage == false' "$tmp_dir/thread-response.json" > /dev/null || {
+            echo "maintenance safety review threads exceed validation page; refusing to pass" >&2
+            exit 1
+          }
+          jq '[.data.repository.pullRequest.reviewThreads.nodes[] | {isResolved, author_login: (.comments.nodes[0].author.login // "")}]' \
+            "$tmp_dir/thread-response.json" > "$threads_file"
+
+          "$GITHUB_WORKSPACE/scripts/github-setup/validate-maintenance-safety.sh" \
+            "$pr_file" "$runs_file" "$e2e_file" "$labels_file" "$reviews_file" "$threads_file" \
+            "$HEAD_SHA" "$COPILOT_REVIEWER_LOGIN"

--- a/scripts/github-setup/setup-ruleset.sh
+++ b/scripts/github-setup/setup-ruleset.sh
@@ -142,6 +142,9 @@ derive_required_status_checks() {
     if workflow_has_check "$installed_root/.github/workflows/quality.yml" "quality"; then
         checks+=("quality")
     fi
+    if workflow_has_check "$installed_root/.github/workflows/maintenance-safety.yml" "Maintenance safety"; then
+        checks+=("Maintenance safety")
+    fi
     if [ "${#checks[@]}" -eq 0 ]; then
         echo "no validated profile workflows are installed under $installed_root" >&2
         exit 1

--- a/scripts/github-setup/test-maintenance-safety-contract.sh
+++ b/scripts/github-setup/test-maintenance-safety-contract.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+validator="$script_dir/validate-maintenance-safety.sh"
+workflow="$script_dir/../../.github/workflows/maintenance-safety.yml"
+ruleset="$script_dir/../../.github/config/ruleset-default.json"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+cat > "$tmp_dir/pr.json" << 'EOF'
+{"number":7,"head":{"sha":"current-sha"},"requested_reviewers":[{"login":"copilot-pull-request-reviewer[bot]"}]}
+EOF
+cat > "$tmp_dir/runs.json" << 'EOF'
+[{"name":"Quality","status":"completed","conclusion":"success","head_sha":"current-sha"},{"name":"Commit policy","status":"completed","conclusion":"success","head_sha":"current-sha"},{"name":"Test Quality Providers","status":"completed","conclusion":"success","head_sha":"current-sha"},{"name":"CodeQL Security Scan","status":"completed","conclusion":"success","head_sha":"current-sha"}]
+EOF
+cat > "$tmp_dir/e2e.json" << 'EOF'
+[{"status":"completed","conclusion":"success","head_sha":"current-sha"}]
+EOF
+cat > "$tmp_dir/labels.json" << 'EOF'
+[{"name":"automation: maintenance"},{"name":"automation: validating"},{"name":"automation: breaking"}]
+EOF
+cat > "$tmp_dir/reviews.json" << 'EOF'
+[{"user":{"login":"copilot-pull-request-reviewer[bot]"},"state":"COMMENTED","commit_id":"current-sha"}]
+EOF
+cat > "$tmp_dir/threads.json" << 'EOF'
+[{"isResolved":true,"author_login":"copilot-pull-request-reviewer[bot]"}]
+EOF
+for empty_file in empty-runs empty-e2e empty-labels empty-reviews empty-threads; do
+    printf '%s\n' '[]' > "$tmp_dir/$empty_file.json"
+done
+
+"$validator" "$tmp_dir/pr.json" "$tmp_dir/runs.json" "$tmp_dir/e2e.json" "$tmp_dir/labels.json" "$tmp_dir/reviews.json" "$tmp_dir/threads.json" "current-sha" "copilot-pull-request-reviewer[bot]"
+
+cat > "$tmp_dir/non-maintenance.json" << 'EOF'
+{"number":8,"head":{"sha":"other-sha"},"requested_reviewers":[]}
+EOF
+"$validator" "$tmp_dir/non-maintenance.json" "$tmp_dir/empty-runs.json" "$tmp_dir/empty-e2e.json" "$tmp_dir/empty-labels.json" "$tmp_dir/empty-reviews.json" "$tmp_dir/empty-threads.json" "other-sha" ""
+
+for mutation in missing pending stale failed unknown; do
+    cp "$tmp_dir/runs.json" "$tmp_dir/mutated-runs.json"
+    cp "$tmp_dir/e2e.json" "$tmp_dir/mutated-e2e.json"
+    cp "$tmp_dir/labels.json" "$tmp_dir/mutated-labels.json"
+    case "$mutation" in
+        missing) printf '%s\n' '[]' > "$tmp_dir/mutated-runs.json" ;;
+        pending) sed 's/"status":"completed"/"status":"in_progress"/' "$tmp_dir/runs.json" > "$tmp_dir/mutated-runs.json" ;;
+        stale) sed 's/current-sha/stale-sha/g' "$tmp_dir/runs.json" > "$tmp_dir/mutated-runs.json" ;;
+        failed) sed 's/"conclusion":"success"/"conclusion":"failure"/' "$tmp_dir/runs.json" > "$tmp_dir/mutated-runs.json" ;;
+        unknown) sed 's/"automation: breaking"/"automation: blocked"/' "$tmp_dir/labels.json" > "$tmp_dir/mutated-labels.json" ;;
+    esac
+    if "$validator" "$tmp_dir/pr.json" "$tmp_dir/mutated-runs.json" "$tmp_dir/mutated-e2e.json" "$tmp_dir/mutated-labels.json" "$tmp_dir/reviews.json" "$tmp_dir/threads.json" "current-sha" "copilot-pull-request-reviewer[bot]"; then
+        echo "maintenance safety accepted invalid fixture: $mutation" >&2
+        exit 1
+    fi
+done
+
+grep -Fq 'Maintenance safety' "$workflow"
+grep -Fq 'pull_request_target:' "$workflow"
+grep -Fq 'ref: main' "$workflow"
+grep -Fq 'repository_dispatch:' "$workflow"
+grep -Fq 'client_payload.head_sha' "$workflow"
+grep -Fq 'client_payload.pr_number' "$workflow"
+grep -Fq 'pr_number:' "$workflow"
+grep -Fq 'head_sha:' "$workflow"
+if grep -Fq '^  pull_request:' "$workflow"; then
+    echo "maintenance safety must not execute from an untrusted pull_request ref" >&2
+    exit 1
+fi
+grep -Fq 'validate-maintenance-safety.sh' "$workflow"
+grep -Fq 'workflow_runs' "$workflow"
+grep -Fq 'test-generated-repository-e2e.yml' "$workflow"
+grep -Fq 'BOOTSTRAP_COPILOT_REVIEWER_LOGIN' "$workflow"
+grep -Fq 'required_status_checks' "$ruleset"
+grep -Fq 'Maintenance safety' "$ruleset"
+grep -Fq 'bypass_actors' "$ruleset"
+
+echo "Maintenance safety contract passed."

--- a/scripts/github-setup/test-payloads.sh
+++ b/scripts/github-setup/test-payloads.sh
@@ -41,7 +41,7 @@ jq -e '
     any(.rules[]; .type == "required_signatures") and
     any(.rules[]; .type == "required_status_checks" and
         .parameters.strict_required_status_checks_policy == true and
-        ([.parameters.required_status_checks[]?.context] | sort) == ["Signed-off-by trailers", "quality"]) and
+        ([.parameters.required_status_checks[]?.context] | sort) == ["Maintenance safety", "Signed-off-by trailers", "quality"]) and
     any(.rules[]; .type == "pull_request" and .parameters.required_approving_review_count == 1 and
         .parameters.dismiss_stale_reviews_on_push == true and .parameters.require_last_push_approval == true and
         .parameters.required_review_thread_resolution == true and .parameters.allowed_merge_methods == ["squash"])

--- a/scripts/github-setup/validate-maintenance-safety.sh
+++ b/scripts/github-setup/validate-maintenance-safety.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr_file="${1:-}"
+workflow_runs_file="${2:-}"
+e2e_runs_file="${3:-}"
+labels_file="${4:-}"
+reviews_file="${5:-}"
+threads_file="${6:-}"
+expected_sha="${7:-}"
+copilot_login="${8:-}"
+
+for input_file in "$pr_file" "$workflow_runs_file" "$e2e_runs_file" "$labels_file" "$reviews_file" "$threads_file"; do
+    [ -s "$input_file" ] || {
+        echo "maintenance safety inputs are incomplete" >&2
+        exit 1
+    }
+done
+[ -n "$expected_sha" ] || {
+    echo "maintenance safety expected SHA is missing" >&2
+    exit 1
+}
+
+if ! jq -e 'any(.[]?; .name == "automation: maintenance")' "$labels_file" > /dev/null; then
+    exit 0
+fi
+
+jq -e --arg expected_sha "$expected_sha" '.head.sha == $expected_sha' "$pr_file" > /dev/null || {
+    echo "maintenance safety PR head is stale or mismatched" >&2
+    exit 1
+}
+
+jq -e '
+    any(.[]?; .name == "automation: maintenance") and
+    any(.[]?; .name == "automation: validating") and
+    all(.[]?; .name != "automation: blocked")
+' "$labels_file" > /dev/null || {
+    echo "maintenance safety labels are missing or blocked" >&2
+    exit 1
+}
+
+jq -e '
+    . as $runs |
+    ["Quality", "Commit policy", "Test Quality Providers", "CodeQL Security Scan"] as $required |
+    all($required[]; . as $required_name | any($runs[]?; .name == $required_name and .status == "completed" and .conclusion == "success" and .head_sha == $expected_sha))
+' --arg expected_sha "$expected_sha" "$workflow_runs_file" > /dev/null || {
+    echo "maintenance workflow approval checks are missing, pending, failed, or stale" >&2
+    exit 1
+}
+
+if jq -e 'any(.[]?; .name == "automation: breaking")' "$labels_file" > /dev/null; then
+    jq -e --arg expected_sha "$expected_sha" 'any(.[]?; .status == "completed" and .conclusion == "success" and .head_sha == $expected_sha)' "$e2e_runs_file" > /dev/null || {
+        echo "risk-specific E2E validation is missing, pending, failed, or stale" >&2
+        exit 1
+    }
+fi
+
+copilot_validator="$(dirname "$0")/validate-copilot-review.sh"
+"$copilot_validator" "$pr_file" "$reviews_file" "$threads_file" "$copilot_login"

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -20,6 +20,7 @@ contract_tests=(
     "$script_dir/github-setup/test-e2e-cleanup-contract.sh"
     "$script_dir/github-setup/test-workflow-approval-contract.sh"
     "$script_dir/github-setup/test-copilot-review-contract.sh"
+    "$script_dir/github-setup/test-maintenance-safety-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"
     "$script_dir/github-setup/test-personal-app-e2e-contract.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Adds the required `Maintenance safety` check for automation PRs. It validates the current head SHA, successful workflow approval prerequisites, risk-specific E2E validation, Copilot completion, unresolved Copilot findings, and required automation labels. Non-maintenance PRs pass through, while missing, stale, pending, failed, blocked, or unknown maintenance inputs fail closed. Ruleset payloads remain free of bypass actors.

## Related Issue

Closes #121

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Exact evidence: `bash scripts/run-contract-tests.sh`; `MAMBA_ROOT_PREFIX=/Users/r04285/micromamba ENV_MANAGER=micromamba LINT_MODE=check make quality` (all contracts, Go tests, pre-commit hooks, ShellCheck, shfmt, YAML/workflow checks, Go vet, and formatting passed).

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer