### PR TITLE
docs: document gh stack PR fallback

### DIFF
--- a/.github/skills/github-stack/SKILL.md
+++ b/.github/skills/github-stack/SKILL.md
@@ -7,6 +7,29 @@ description: Use when creating, synchronizing, rebasing, submitting, or merging 
 
 Use `WORKTREES.md` as the canonical policy for isolation, stack readiness, and
 merge order. Install the extension with `gh extension install github/gh-stack`.
+
+Before GitHub operations, verify the active Muximate identity:
+
+    muximate profile
+    gh auth status
+    gh api user --jq .login
+
+`gh stack` is public-preview software. Its remote GraphQL PR-creation step can
+return an Enterprise Managed User authorization error even when the verified
+profile is personal and ordinary `gh pr create` works. Treat that as a stack
+submission limitation, not proof that Muximate selected the wrong profile.
+
 Use `gh stack init`, `add`, `submit`, `view`, `sync`, `rebase`, `push`, `link`,
 and `checkout` for stack operations. Merge from the bottom upward only after
 required checks, review threads, and verified signatures are clean.
+
+If `gh stack submit` pushes branches but fails at `createPullRequest`, stop
+retrying it. Keep the branches, push them if needed, and create ordinary PRs
+with explicit bases and the repository's `.github/pull_request_template.md`:
+
+    git push origin <branch-name>
+    gh pr create --base main --head <branch-name> --title "..." --body-file <completed-template>
+
+Create the bottom PR first (`main`), then each child PR against the branch
+immediately below it. Run `gh stack link` afterward only if stack metadata is
+required.

--- a/WORKTREES.md
+++ b/WORKTREES.md
@@ -48,6 +48,17 @@ Use `git worktree prune --dry-run` before pruning stale worktree metadata.
 Use the `gh-stack` extension for stacked pull requests. Install it with
 `gh extension install github/gh-stack`.
 
+Before any GitHub operation, verify the intended Muximate profile and account:
+
+    muximate profile
+    gh auth status
+    gh api user --jq .login
+
+The profile must be the one intended for this repository. Do not diagnose an
+account mismatch from a `gh stack` error alone: `gh stack` is public-preview
+software, and its GraphQL PR-creation path can fail for an otherwise valid
+personal account with an Enterprise Managed User authorization error.
+
 Use `gh stack init`, `add`, `submit`, `view`, `sync`, `rebase`, and `push` for
 local stack management. Use `gh stack link` and `gh stack checkout` for PRs
 that already exist on GitHub.
@@ -60,6 +71,21 @@ check or unresolved review unless the repository policy explicitly permits it.
 Stack metadata is public-preview functionality and can become stale after the
 trunk PR merges. Run `gh stack sync`, then `gh stack rebase` and `gh stack push`
 before treating a stack as ready.
+
+If `gh stack submit` pushes the branches but fails while creating the remote
+PR, keep the local branches and create the PRs with ordinary GitHub CLI
+commands. Use the repository pull-request template from
+`.github/pull_request_template.md`, preserve the stack order, and set each PR's
+base explicitly (the bottom PR targets `main`; each later PR targets the PR
+immediately below it). For example:
+
+    git push origin <branch-name>
+    gh pr create --base main --head <branch-name> --title "..." --body-file <completed-template>
+
+This fallback is supported for both personal and enterprise accounts. Do not
+retry `gh stack submit` repeatedly after a `createPullRequest` authorization
+failure; first verify the profile, then use the ordinary PR flow. Optionally
+run `gh stack link` after the PRs exist if remote stack metadata is needed.
 
 ## Cleanup after merge
 

--- a/templates/.github/skills/github-stack/SKILL.md
+++ b/templates/.github/skills/github-stack/SKILL.md
@@ -14,6 +14,19 @@ Install the extension when it is not available:
 gh extension install github/gh-stack
 ```
 
+Before GitHub operations, verify the active Muximate identity:
+
+```bash
+muximate profile
+gh auth status
+gh api user --jq .login
+```
+
+`gh stack` is public-preview software. Its remote GraphQL PR-creation step can
+return an Enterprise Managed User authorization error even when the verified
+profile is personal and ordinary `gh pr create` works. Treat that as a stack
+submission limitation, not proof that Muximate selected the wrong profile.
+
 Use `gh stack init` for a new stack, `gh stack add` to add a dependent branch,
 and `gh stack submit` to publish the stack. Use `gh stack view` to inspect the
 topology, `gh stack sync` after a lower PR merges, and `gh stack rebase` followed
@@ -22,3 +35,17 @@ by `gh stack push` to update descendants. Use `gh stack link` or
 
 Merge from the bottom upward only after each PR has passing required checks,
 no unresolved review threads, and a verified signed commit.
+
+If `gh stack submit` pushes branches but fails at `createPullRequest`, stop
+retrying it. Keep the branches, push them if needed, and create ordinary PRs
+with explicit bases and the generated repository's
+`.github/pull_request_template.md`:
+
+```bash
+git push origin <branch-name>
+gh pr create --base main --head <branch-name> --title "..." --body-file <completed-template>
+```
+
+Create the bottom PR first (`main`), then each child PR against the branch
+immediately below it. Run `gh stack link` afterward only if stack metadata is
+required.


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Document Muximate account preflight and the ordinary GitHub CLI fallback when gh stack pushes branches but cannot create remote PRs. Keep the guidance synchronized in the dogfooding repository and generated templates.

## Related Issue

Follow-up implementation: #123 (this documentation PR does not close it).

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Commands: `bash scripts/run-contract-tests.sh`; `LINT_MODE=check make quality`.

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer