### PR TITLE
fix: skip maintenance safety without pull request

### DIFF
--- a/.github/workflows/maintenance-safety.yml
+++ b/.github/workflows/maintenance-safety.yml
@@ -32,6 +32,9 @@ permissions:
 jobs:
   safety:
     name: Maintenance safety
+    if: |
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.pull_requests[0].number
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout validation helpers

--- a/scripts/github-setup/test-maintenance-safety-contract.sh
+++ b/scripts/github-setup/test-maintenance-safety-contract.sh
@@ -55,6 +55,7 @@ for mutation in missing pending stale failed unknown; do
 done
 
 grep -Fq 'Maintenance safety' "$workflow"
+grep -Fq "github.event_name != 'workflow_run'" "$workflow"
 grep -Fq 'pull_request_target:' "$workflow"
 grep -Fq 'ref: main' "$workflow"
 grep -Fq 'repository_dispatch:' "$workflow"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Skip Maintenance safety workflow-run events that have no associated pull request, such as post-merge runs on main, instead of failing with a missing PR number.

## Related Issue

Follow-up to #138.

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Commands: `bash scripts/github-setup/test-maintenance-safety-contract.sh`; `LINT_MODE=check make quality`.

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer