### PR TITLE
fix: initialize validation checkouts on main

### DIFF
--- a/.github/workflows/approve-automation-workflows.yml
+++ b/.github/workflows/approve-automation-workflows.yml
@@ -26,6 +26,10 @@ jobs:
     steps:
       - name: Checkout validation helpers
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
         with:
           persist-credentials: false
           sparse-checkout: |

--- a/.github/workflows/classify-maintenance-pr.yml
+++ b/.github/workflows/classify-maintenance-pr.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Check out validation helper
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
         with:
           persist-credentials: false
           ref: main

--- a/.github/workflows/maintenance-safety.yml
+++ b/.github/workflows/maintenance-safety.yml
@@ -36,6 +36,10 @@ jobs:
     steps:
       - name: Checkout validation helpers
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
         with:
           persist-credentials: false
           ref: main

--- a/.github/workflows/merge-maintenance-pr.yml
+++ b/.github/workflows/merge-maintenance-pr.yml
@@ -24,6 +24,10 @@ jobs:
     steps:
       - name: Checkout validation helpers
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
         with:
           persist-credentials: false
           ref: main

--- a/templates/.github/workflows/classify-maintenance-pr.yml
+++ b/templates/.github/workflows/classify-maintenance-pr.yml
@@ -22,6 +22,10 @@ jobs:
     steps:
       - name: Check out validation helper
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
         with:
           persist-credentials: false
           sparse-checkout: .github/scripts/validate-maintenance-pr.sh


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Configure Git init for validation-helper checkouts so GitHub Actions initializes new repositories with `main` and does not emit the deprecated `master` default-branch warning.

## Related Issue

Not associated with a numbered issue.

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Local validation: `LINT_MODE=check make quality`

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer