### PR TITLE
fix: align template maintenance app credentials

### DIFF
--- a/templates/.github/workflows/classify-maintenance-pr.yml
+++ b/templates/.github/workflows/classify-maintenance-pr.yml
@@ -34,8 +34,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ vars.BOOTSTRAP_APP_CLIENT_ID }}
-          private-key: ${{ secrets.BOOTSTRAP_APP_PRIVATE_KEY }}
+          client-id: ${{ vars.BOOTSTRAP_MAINTENANCE_WRITER_APP_CLIENT_ID }}
+          private-key: ${{ secrets.BOOTSTRAP_MAINTENANCE_WRITER_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.repository.name }}
           permission-issues: write


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Align the shipped `classify-maintenance-pr.yml` template with the role-specific
Maintenance Writer App credentials used by the current repository workflow.
This prevents generated repositories from receiving the removed legacy App
credential names.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-app-auth-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`
- [x] Template parity and workflow asset checks pass

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
