### PR TITLE
fix: create missing repository labels

### DIFF
--- a/scripts/github-setup/setup-labels.sh
+++ b/scripts/github-setup/setup-labels.sh
@@ -92,7 +92,10 @@ validate_label_file() {
 
 find_existing_label() {
     local name="$1"
-    gh_api_json "$(label_endpoint "$name")" 2> /dev/null || true
+    local existing_label
+    if existing_label="$(gh_api_json "$(label_endpoint "$name")" 2> /dev/null)"; then
+        printf '%s\n' "$existing_label"
+    fi
 }
 
 write_label_payload() {

--- a/scripts/github-setup/test-label-creation-contract.sh
+++ b/scripts/github-setup/test-label-creation-contract.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+setup_script="$script_dir/setup-labels.sh"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+mkdir -p "$tmp_dir/bin"
+cat > "$tmp_dir/bin/gh" << 'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+method=GET
+endpoint=""
+for ((index = 1; index <= $#; index++)); do
+    argument="${!index}"
+    case "$argument" in
+        --method)
+            next=$((index + 1))
+            method="${!next}"
+            ;;
+        /repos/*)
+            endpoint="$argument"
+            ;;
+    esac
+done
+
+case "$method $endpoint" in
+    "GET /repos/aydabd/github-bootstrap/labels/"*)
+        printf '%s\n' '{"message":"Not Found"}'
+        exit 1
+        ;;
+    "POST /repos/aydabd/github-bootstrap/labels")
+        printf '%s\n' POST >> "$GH_LABEL_CALLS"
+        printf '%s\n' '{}'
+        ;;
+    *)
+        echo "unexpected gh call: $method $endpoint" >&2
+        exit 1
+        ;;
+esac
+EOF
+chmod 700 "$tmp_dir/bin/gh"
+
+cat > "$tmp_dir/labels.json" << 'EOF'
+{"labels":[{"name":"automation: maintenance","color":"0366d6","description":"Automated maintenance update"}]}
+EOF
+: > "$tmp_dir/calls"
+
+if PATH="$tmp_dir/bin:$PATH" GH_LABEL_CALLS="$tmp_dir/calls" \
+    bash "$setup_script" --owner aydabd --repo github-bootstrap \
+    --label-file "$tmp_dir/labels.json" > /dev/null; then
+    actual_calls="$(cat "$tmp_dir/calls")"
+    [ "$actual_calls" = POST ] || {
+        echo "expected a POST when a label lookup returns 404" >&2
+        exit 1
+    }
+else
+    echo "setup-labels.sh failed to create a missing label" >&2
+    exit 1
+fi
+
+echo "Missing label creation contract passed."

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -24,6 +24,7 @@ contract_tests=(
     "$script_dir/github-setup/test-maintenance-merge-contract.sh"
     "$script_dir/github-setup/test-maintenance-pr-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"
+    "$script_dir/github-setup/test-label-creation-contract.sh"
     "$script_dir/github-setup/test-payloads.sh"
     "$script_dir/github-setup/test-personal-app-e2e-contract.sh"
     "$script_dir/github-setup/test-profile.sh"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix label setup when a repository label lookup returns 404. The setup script
now treats that response as a missing label and creates it with POST instead of
mistaking the error payload for an existing label and attempting PATCH.

Add a deterministic contract test covering the missing-label path.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-label-creation-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
