### PR TITLE
fix: skip maintenance merge runs without pull requests

### DIFF
--- a/.github/workflows/merge-maintenance-pr.yml
+++ b/.github/workflows/merge-maintenance-pr.yml
@@ -13,7 +13,9 @@ permissions:
 
 jobs:
   merge:
-    if: github.event.workflow_run.conclusion == 'success'
+    if: |
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.pull_requests[0].number
     name: Approve and enable squash auto-merge
     runs-on: ubuntu-24.04
     environment: production-maintenance

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -5,6 +5,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repo_root="$(cd "$script_dir/../.." && pwd)"
 resolver="$repo_root/.github/actions/resolve-gh-token/action.yml"
 app_validator="$script_dir/validate-app-auth.sh"
+merge_workflow="$repo_root/.github/workflows/merge-maintenance-pr.yml"
 
 assert_contains() {
     local needle="$1"
@@ -59,6 +60,8 @@ assert_contains "Unsupported GitHub App permission profile '\$PERMISSION_PROFILE
 assert_contains "required except for repository-creation" "$resolver"
 assert_not_contains "gh_pat_secret" "$resolver"
 assert_not_contains "gh_token" "$resolver"
+assert_contains "github.event.workflow_run.conclusion == 'success' &&" "$merge_workflow"
+assert_contains "github.event.workflow_run.pull_requests[0].number" "$merge_workflow"
 assert_contains "pull_request_target:" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "permission_profile: maintenance-labeling" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "validate-maintenance-pr.sh" "$repo_root/.github/workflows/classify-maintenance-pr.yml"


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Prevent the maintenance merge workflow from running for successful Maintenance safety runs that have no pull request, such as push-triggered runs on `main`.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-app-auth-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
