### PR TITLE
fix: label maintenance pull requests through REST

### DIFF
--- a/.github/workflows/classify-maintenance-pr.yml
+++ b/.github/workflows/classify-maintenance-pr.yml
@@ -61,9 +61,14 @@ jobs:
             exit 0
           fi
 
-          gh pr edit "$PR_NUMBER" \
-            --add-label "automation: maintenance" \
-            --add-label "automation: validating"
+          labels=("automation: maintenance" "automation: validating")
           if [ "$classification" = "dependabot" ]; then
-            gh pr edit "$PR_NUMBER" --add-label dependencies
+            labels+=(dependencies)
           fi
+
+          label_args=()
+          for label in "${labels[@]}"; do
+            label_args+=(-f "labels[]=$label")
+          done
+          gh api --method POST "/repos/$FULL_REPOSITORY/issues/$PR_NUMBER/labels" \
+            "${label_args[@]}" > /dev/null

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -67,10 +67,14 @@ assert_contains "permission_profile: maintenance-labeling" "$repo_root/.github/w
 assert_contains "validate-maintenance-pr.sh" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains 'automation: maintenance' "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains 'automation: validating' "$repo_root/.github/workflows/classify-maintenance-pr.yml"
+assert_contains "issues/\$PR_NUMBER/labels" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
+assert_not_contains "gh pr edit \"\$PR_NUMBER\"" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "if ! classification=\"\$(bash scripts/github-setup/validate-maintenance-pr.sh \"\$pr_file\")\"; then" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 template_classifier="$repo_root/templates/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "actions/create-github-app-token" "$template_classifier"
 assert_contains ".github/scripts/validate-maintenance-pr.sh" "$template_classifier"
+assert_contains "issues/\$PR_NUMBER/labels" "$template_classifier"
+assert_not_contains "gh pr edit \"\$PR_NUMBER\"" "$template_classifier"
 [ -x "$repo_root/templates/.github/scripts/validate-maintenance-pr.sh" ]
 
 for workflow in create-repository.yml terraform-create-repository.yml; do

--- a/templates/.github/workflows/classify-maintenance-pr.yml
+++ b/templates/.github/workflows/classify-maintenance-pr.yml
@@ -53,9 +53,14 @@ jobs:
           gh api "/repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER" > "$pr_file"
           classification="$(bash .github/scripts/validate-maintenance-pr.sh "$pr_file")"
 
-          gh pr edit "$PR_NUMBER" \
-            --add-label "automation: maintenance" \
-            --add-label "automation: validating"
+          labels=("automation: maintenance" "automation: validating")
           if [ "$classification" = "dependabot" ]; then
-            gh pr edit "$PR_NUMBER" --add-label dependencies
+            labels+=(dependencies)
           fi
+
+          label_args=()
+          for label in "${labels[@]}"; do
+            label_args+=(-f "labels[]=$label")
+          done
+          gh api --method POST "/repos/$FULL_REPOSITORY/issues/$PR_NUMBER/labels" \
+            "${label_args[@]}" > /dev/null


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Label eligible maintenance pull requests through the REST issue-label endpoint, which is covered by the Writer App's Issues permission and avoids the GraphQL mutation used by `gh pr edit`.

The root workflow and shipped template are kept in sync.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-app-auth-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
