### PR TITLE
fix: create weekly tooling pull requests through REST

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -212,7 +212,6 @@ jobs:
             }
           done
 
-          create_label_args=(--label dependencies --label "automation: maintenance" --label "automation: validating")
           edit_label_args=(--add-label dependencies --add-label "automation: maintenance" --add-label "automation: validating" --remove-label "automation: breaking" --remove-label "automation: blocked")
           breaking_count="$(jq '[.updates[] | select(.risk == "high" or .update_type == "major" or .update_type == "breaking")] | length' "$metadata_file")"
           unknown_count="$(jq '[.updates[] | select(.risk == "unknown" or .update_type == "unknown")] | length' "$metadata_file")"
@@ -228,11 +227,14 @@ jobs:
           pr_number="$(gh pr list --head "$branch" --state open --json number --jq '.[0].number // empty')"
 
           if [ -z "$pr_number" ]; then
-            pr_url="$(gh pr create --base main --head "$branch" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md "${create_label_args[@]}")"
-            pr_number="$(gh pr view "$pr_url" --json number --jq '.number')"
-          else
-            gh pr edit "$pr_number" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md "${edit_label_args[@]}"
+            pr_number="$(gh api --method POST "/repos/$GITHUB_REPOSITORY/pulls" \
+              -f title="$title" \
+              -f head="$branch" \
+              -f base=main \
+              -f body="$(< /tmp/weekly-tooling-pr-body.md)" \
+              --jq '.number')"
           fi
+          gh pr edit "$pr_number" --title "$title" --body-file /tmp/weekly-tooling-pr-body.md "${edit_label_args[@]}"
 
           if [ "$unknown_count" -gt 0 ]; then
             echo "Unknown update risk detected; leaving PR blocked without enabling auto-merge." >&2

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -33,6 +33,7 @@ for required_text in \
     "parent_tree_sha=\"\$(gh api" \
     "jq -n --arg base_tree \"\$parent_tree_sha\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
+    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
     "-f \"parents[]=\$parent_sha\"" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \
     "expected_branch_sha=\"\$(gh api" \
@@ -48,6 +49,11 @@ for required_text in \
         exit 1
     }
 done
+
+if grep -Fq 'gh pr create' "$workflow"; then
+    echo "weekly tooling PR creation must use the REST API" >&2
+    exit 1
+fi
 
 if grep -Fq 'BOOTSTRAP_APP_SIGNING_KEY' "$workflow" ||
     grep -Fq 'git commit ' "$workflow" ||


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Create the weekly tooling pull request through GitHub's REST API after the automation creates and verifies its Git reference. This avoids the `gh pr create` GraphQL path that failed with `Reference does not exist (HTTP 422)`.

Existing labels and maintenance safety handling remain unchanged.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
