### PR TITLE
fix: verify weekly tooling branch creation

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -192,6 +192,9 @@ jobs:
             -f "parents[]=$parent_sha" \
             --jq '.sha')"
           bash ./scripts/github-setup/verify-commit-verification.sh "$GITHUB_REPOSITORY" "$commit_sha"
+          ref_payload="$payload_dir/ref.json"
+          jq -n --arg ref "refs/heads/$branch" --arg sha "$commit_sha" \
+            '{ref: $ref, sha: $sha}' >"$ref_payload"
 
           if [ -n "$expected_branch_sha" ]; then
             gh api --method PATCH "/repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" \
@@ -199,9 +202,13 @@ jobs:
               -F force=false >/dev/null
           else
             gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
-              -f ref="refs/heads/$branch" \
-              -f sha="$commit_sha" >/dev/null
+              --input "$ref_payload" >/dev/null
           fi
+          branch_sha="$(gh api "/repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" --jq '.object.sha')"
+          [ "$branch_sha" = "$commit_sha" ] || {
+            echo "weekly tooling branch does not point to the created commit" >&2
+            exit 1
+          }
 
           label_names="$(gh label list --limit 200 --json name --jq '.[].name')"
           required_labels=("dependencies" "automation: maintenance" "automation: validating" "automation: breaking" "automation: blocked")
@@ -216,11 +223,9 @@ jobs:
           breaking_count="$(jq '[.updates[] | select(.risk == "high" or .update_type == "major" or .update_type == "breaking")] | length' "$metadata_file")"
           unknown_count="$(jq '[.updates[] | select(.risk == "unknown" or .update_type == "unknown")] | length' "$metadata_file")"
           if [ "$breaking_count" -gt 0 ]; then
-            create_label_args+=(--label "automation: breaking")
             edit_label_args+=(--add-label "automation: breaking")
           fi
           if [ "$unknown_count" -gt 0 ]; then
-            create_label_args+=(--label "automation: blocked")
             edit_label_args+=(--add-label "automation: blocked")
           fi
 

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -34,6 +34,9 @@ for required_text in \
     "jq -n --arg base_tree \"\$parent_tree_sha\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
+    "ref_payload=\"\$payload_dir/ref.json\"" \
+    "--input \"\$ref_payload\"" \
+    "branch_sha=\"\$(gh api" \
     "-f \"parents[]=\$parent_sha\"" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \
     "expected_branch_sha=\"\$(gh api" \
@@ -52,6 +55,11 @@ done
 
 if grep -Fq 'gh pr create' "$workflow"; then
     echo "weekly tooling PR creation must use the REST API" >&2
+    exit 1
+fi
+
+if grep -Fq 'create_label_args' "$workflow"; then
+    echo "weekly tooling workflow must not retain unused create-label arguments" >&2
     exit 1
 fi
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix the weekly tooling branch creation path by sending the Git reference as an explicit JSON payload and verifying that the created branch points to the generated signed commit before creating or updating the pull request.

Also remove stale label arguments left behind after the REST pull-request creation change.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `bash scripts/run-contract-tests.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
