### PR TITLE
fix: run weekly tooling on schedule only

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -1,9 +1,7 @@
 name: Weekly Tooling Updates
 
 on:
-  # Reconcile the single tooling PR after every change to main, including merges.
-  push:
-    branches: [main]
+  # Create or reconcile the single tooling PR on the weekly cadence.
   schedule:
     - cron: "0 4 * * 1"
   workflow_dispatch:

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -63,6 +63,17 @@ if grep -Fq 'create_label_args' "$workflow"; then
     exit 1
 fi
 
+if grep -Fq '  push:' "$workflow"; then
+    echo "weekly tooling workflow must not run after every main push" >&2
+    exit 1
+fi
+for required_trigger in '  schedule:' '  workflow_dispatch:'; do
+    grep -Fq "$required_trigger" "$workflow" || {
+        echo "weekly tooling workflow must retain $required_trigger trigger" >&2
+        exit 1
+    }
+done
+
 if grep -Fq 'BOOTSTRAP_APP_SIGNING_KEY' "$workflow" ||
     grep -Fq 'git commit ' "$workflow" ||
     grep -Fq 'git -c http.extraheader=' "$workflow" ||


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Run Weekly Tooling Updates only on its weekly schedule or explicit manual dispatch. Remove the post-merge `push: main` trigger so merges do not start a workflow that has no weekly tooling PR to reconcile.

The scheduled/manual workflow still creates the first weekly branch and PR when none exists, and reconciles the existing PR on later runs.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
