### PR TITLE
fix: create weekly branch with writer app token

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -190,17 +190,20 @@ jobs:
             -f "parents[]=$parent_sha" \
             --jq '.sha')"
           bash ./scripts/github-setup/verify-commit-verification.sh "$GITHUB_REPOSITORY" "$commit_sha"
-          ref_payload="$payload_dir/ref.json"
-          jq -n --arg ref "refs/heads/$branch" --arg sha "$commit_sha" \
-            '{ref: $ref, sha: $sha}' >"$ref_payload"
 
           if [ -n "$expected_branch_sha" ]; then
             gh api --method PATCH "/repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" \
               -f sha="$commit_sha" \
               -F force=false >/dev/null
           else
-            gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
-              --input "$ref_payload" >/dev/null
+            GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+            printf '::add-mask::%s\n' "$GIT_AUTH_HEADER"
+            git_host="${GITHUB_SERVER_URL#https://}"
+            GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0=http.extraheader \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $GIT_AUTH_HEADER" \
+              git push "https://${git_host}/${GITHUB_REPOSITORY}.git" \
+              "$commit_sha:refs/heads/$branch"
           fi
           branch_sha="$(gh api "/repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" --jq '.object.sha')"
           [ "$branch_sha" = "$commit_sha" ] || {

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -34,8 +34,14 @@ for required_text in \
     "jq -n --arg base_tree \"\$parent_tree_sha\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
-    "ref_payload=\"\$payload_dir/ref.json\"" \
-    "--input \"\$ref_payload\"" \
+    "GIT_AUTH_HEADER=\"\$(printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64 | tr -d '\\r\\n')\"" \
+    "printf '::add-mask::%s\\n' \"\$GIT_AUTH_HEADER\"" \
+    "git_host=\"\${GITHUB_SERVER_URL#https://}\"" \
+    "GIT_CONFIG_COUNT=1" \
+    "GIT_CONFIG_KEY_0=http.extraheader" \
+    "GIT_CONFIG_VALUE_0=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" \
+    "push \"https://\${git_host}/\${GITHUB_REPOSITORY}.git\"" \
+    "\$commit_sha:refs/heads/\$branch" \
     "branch_sha=\"\$(gh api" \
     "-f \"parents[]=\$parent_sha\"" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \
@@ -76,10 +82,14 @@ done
 
 if grep -Fq 'BOOTSTRAP_APP_SIGNING_KEY' "$workflow" ||
     grep -Fq 'git commit ' "$workflow" ||
-    grep -Fq 'git -c http.extraheader=' "$workflow" ||
     grep -Fq 'git write-tree' "$workflow" ||
     grep -Fq 'force=true' "$workflow"; then
-    echo "verified App commits must use the Git database API, not local git signing or push" >&2
+    echo "verified App commits must use the Git database API, not local git signing" >&2
+    exit 1
+fi
+
+if grep -Fq 'git -c http.extraheader=' "$workflow"; then
+    echo "Git push must pass authentication through Git config environment variables" >&2
     exit 1
 fi
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix first-time weekly tooling branch creation with the maintenance Writer App.

The Git Database API continues to create and verify the signed commit. When the branch does not yet exist, the workflow now publishes that exact verified commit with an App-authenticated Git push, because the installation token was rejected by the REST reference-creation endpoint with HTTP 422. Existing branches continue to use the non-force Git reference update API.

## Related Issue

Part of #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `LINT_MODE=check make quality`
- [x] Manifest contract E2E passed with its local callback server
- [x] Personal-token control test created and removed a temporary reference successfully

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
