### PR TITLE
fix: create weekly tooling branch refs through API

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -196,14 +196,29 @@ jobs:
               -f sha="$commit_sha" \
               -F force=false >/dev/null
           else
-            GIT_AUTH_HEADER="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
-            printf '::add-mask::%s\n' "$GIT_AUTH_HEADER"
-            git_host="${GITHUB_SERVER_URL#https://}"
-            GIT_CONFIG_COUNT=1 \
-            GIT_CONFIG_KEY_0=http.extraheader \
-            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $GIT_AUTH_HEADER" \
-              git push "https://${git_host}/${GITHUB_REPOSITORY}.git" \
-              "$commit_sha:refs/heads/$branch"
+            ref_payload="$payload_dir/ref.json"
+            ref_error="$payload_dir/ref-error"
+            jq -n --arg ref "refs/heads/$branch" --arg sha "$commit_sha" \
+              '{ref: $ref, sha: $sha}' >"$ref_payload"
+            ref_created=false
+            ref_attempt=1
+            while [ "$ref_attempt" -le 5 ]; do
+              if gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
+                --input "$ref_payload" > /dev/null 2>"$ref_error"; then
+                ref_created=true
+                break
+              fi
+              if ! grep -Fq 'Reference does not exist' "$ref_error"; then
+                cat "$ref_error" >&2
+                exit 1
+              fi
+              sleep 2
+              ref_attempt=$((ref_attempt + 1))
+            done
+            if [ "$ref_created" != true ]; then
+              cat "$ref_error" >&2
+              exit 1
+            fi
           fi
           branch_sha="$(gh api "/repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" --jq '.object.sha')"
           [ "$branch_sha" = "$commit_sha" ] || {

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -34,14 +34,12 @@ for required_text in \
     "jq -n --arg base_tree \"\$parent_tree_sha\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
-    "GIT_AUTH_HEADER=\"\$(printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64 | tr -d '\\r\\n')\"" \
-    "printf '::add-mask::%s\\n' \"\$GIT_AUTH_HEADER\"" \
-    "git_host=\"\${GITHUB_SERVER_URL#https://}\"" \
-    "GIT_CONFIG_COUNT=1" \
-    "GIT_CONFIG_KEY_0=http.extraheader" \
-    "GIT_CONFIG_VALUE_0=\"AUTHORIZATION: basic \$GIT_AUTH_HEADER\"" \
-    "push \"https://\${git_host}/\${GITHUB_REPOSITORY}.git\"" \
-    "\$commit_sha:refs/heads/\$branch" \
+    "ref_payload=\"\$payload_dir/ref.json\"" \
+    "jq -n --arg ref \"refs/heads/\$branch\" --arg sha \"\$commit_sha\"" \
+    "ref_attempt=1" \
+    "Reference does not exist" \
+    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/refs\"" \
+    "--input \"\$ref_payload\"" \
     "branch_sha=\"\$(gh api" \
     "-f \"parents[]=\$parent_sha\"" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix weekly tooling branch creation after the Git Database API creates the
verified commit. The workflow now creates a missing branch through the GitHub
ref API instead of asking the runner's local Git client to push a remote-only
commit object.

Transient `Reference does not exist` responses are retried briefly for
GitHub's commit propagation window. Other API failures remain fail-closed.

## Related Issue

Related to #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `LINT_MODE=check make quality`
- [x] No secrets or mutable action references were added
- [x] Commit includes a Signed-off-by trailer

## Review Checklist

- [x] Scope is limited to weekly tooling branch creation
- [x] No force push or local unsigned commit path was added
- [x] Exact created commit SHA is still verified after ref creation
