### PR TITLE
fix: bootstrap weekly tooling refs from main

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -197,28 +197,13 @@ jobs:
               -F force=false >/dev/null
           else
             ref_payload="$payload_dir/ref.json"
-            ref_error="$payload_dir/ref-error"
-            jq -n --arg ref "refs/heads/$branch" --arg sha "$commit_sha" \
+            jq -n --arg ref "refs/heads/$branch" --arg sha "$parent_sha" \
               '{ref: $ref, sha: $sha}' >"$ref_payload"
-            ref_created=false
-            ref_attempt=1
-            while [ "$ref_attempt" -le 5 ]; do
-              if gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
-                --input "$ref_payload" > /dev/null 2>"$ref_error"; then
-                ref_created=true
-                break
-              fi
-              if ! grep -Fq 'Reference does not exist' "$ref_error"; then
-                cat "$ref_error" >&2
-                exit 1
-              fi
-              sleep 2
-              ref_attempt=$((ref_attempt + 1))
-            done
-            if [ "$ref_created" != true ]; then
-              cat "$ref_error" >&2
-              exit 1
-            fi
+            gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
+              --input "$ref_payload" >/dev/null
+            gh api --method PATCH "/repos/$GITHUB_REPOSITORY/git/refs/heads/$branch" \
+              -f sha="$commit_sha" \
+              -F force=false >/dev/null
           fi
           branch_sha="$(gh api "/repos/$GITHUB_REPOSITORY/git/ref/heads/$branch" --jq '.object.sha')"
           [ "$branch_sha" = "$commit_sha" ] || {

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -35,11 +35,11 @@ for required_text in \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
     "ref_payload=\"\$payload_dir/ref.json\"" \
-    "jq -n --arg ref \"refs/heads/\$branch\" --arg sha \"\$commit_sha\"" \
-    "ref_attempt=1" \
-    "Reference does not exist" \
+    "jq -n --arg ref \"refs/heads/\$branch\" --arg sha \"\$parent_sha\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/refs\"" \
     "--input \"\$ref_payload\"" \
+    "--arg sha \"\$parent_sha\"" \
+    "gh api --method PATCH \"/repos/\$GITHUB_REPOSITORY/git/refs/heads/\$branch\"" \
     "branch_sha=\"\$(gh api" \
     "-f \"parents[]=\$parent_sha\"" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix App-token weekly tooling branch creation. A missing branch is first created
at the existing `main` commit, then advanced with the existing non-force update
to the verified Git Database commit.

This avoids the 422 returned when the App token creates a ref directly at a
newly generated commit.

## Related Issue

Related to #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `LINT_MODE=check make quality`
- [x] No secrets or mutable action references were added
- [x] Commit includes a Signed-off-by trailer

## Review Checklist

- [x] Scope is limited to weekly tooling branch creation
- [x] No force push or local unsigned commit path was added
- [x] Exact created commit SHA is still verified after ref creation
