### PR TITLE
fix: bootstrap tooling branch with App Git transport

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -164,11 +164,14 @@ jobs:
           done < <(git diff --cached --name-only)
 
           if [ -z "$expected_branch_sha" ]; then
-            ref_payload="$payload_dir/ref.json"
-            jq -n --arg ref "refs/heads/$branch" --arg sha "$parent_sha" \
-              '{ref: $ref, sha: $sha}' >"$ref_payload"
-            gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
-              --input "$ref_payload" >/dev/null
+            git_auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
+            printf '::add-mask::%s\n' "$git_auth_header"
+            git_host="${GITHUB_SERVER_URL#https://}"
+            GIT_CONFIG_COUNT=1 \
+            GIT_CONFIG_KEY_0=http.extraheader \
+            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $git_auth_header" \
+              git push "https://${git_host}/${GITHUB_REPOSITORY}.git" \
+              "$parent_sha:refs/heads/$branch"
           fi
 
           graphql_query='mutation($input: CreateCommitOnBranchInput!) {

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -36,11 +36,14 @@ for required_text in \
     "gh api graphql --input \"\$create_commit_payload\"" \
     "commit_sha=\"\$(jq -er" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
-    "ref_payload=\"\$payload_dir/ref.json\"" \
-    "jq -n --arg ref \"refs/heads/\$branch\" --arg sha \"\$parent_sha\"" \
-    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/refs\"" \
-    "--input \"\$ref_payload\"" \
-    "--arg sha \"\$parent_sha\"" \
+    "git_auth_header=\"\$(printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64 | tr -d '\\r\\n')\"" \
+    "printf '::add-mask::%s\\n' \"\$git_auth_header\"" \
+    "git_host=\"\${GITHUB_SERVER_URL#https://}\"" \
+    "GIT_CONFIG_COUNT=1" \
+    "GIT_CONFIG_KEY_0=http.extraheader" \
+    "GIT_CONFIG_VALUE_0=\"AUTHORIZATION: basic \$git_auth_header\"" \
+    "push \"https://\${git_host}/\${GITHUB_REPOSITORY}.git\"" \
+    "\$parent_sha:refs/heads/\$branch" \
     "branch_sha=\"\$(gh api" \
     "bash ./scripts/github-setup/verify-commit-verification.sh \"\$GITHUB_REPOSITORY\" \"\$commit_sha\"" \
     "expected_branch_sha=\"\$(gh api" \


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Fix missing weekly tooling branch creation with the installed Writer App.
The App-authenticated Git transport creates only the empty branch from the
existing local `main` commit. GitHub's GraphQL mutation then creates and signs
the maintenance commit atomically.

## Related Issue

Related to #112

## Validation

- [x] `bash scripts/github-setup/test-commit-verification-contract.sh`
- [x] `LINT_MODE=check make quality`
- [x] No secrets or mutable action references were added
- [x] Commit includes a Signed-off-by trailer

## Review Checklist

- [x] Scope is limited to weekly tooling branch bootstrap
- [x] No force push or local unsigned maintenance commit path was added
- [x] GitHub verification and exact final branch SHA remain required
