### PR TITLE
fix: create weekly tooling refs through the API

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -164,14 +164,16 @@ jobs:
           done < <(git diff --cached --name-only)
 
           if [ -z "$expected_branch_sha" ]; then
-            git_auth_header="$(printf 'x-access-token:%s' "$GH_TOKEN" | base64 | tr -d '\r\n')"
-            printf '::add-mask::%s\n' "$git_auth_header"
-            git_host="${GITHUB_SERVER_URL#https://}"
-            GIT_CONFIG_COUNT=1 \
-            GIT_CONFIG_KEY_0=http.extraheader \
-            GIT_CONFIG_VALUE_0="AUTHORIZATION: basic $git_auth_header" \
-              git push "https://${git_host}/${GITHUB_REPOSITORY}.git" \
-              "$parent_sha:refs/heads/$branch"
+            ref_payload="$payload_dir/ref.json"
+            ref_response="$payload_dir/ref-response.json"
+            jq -n --arg ref "refs/heads/$branch" --arg sha "$parent_sha" \
+              '{ref: $ref, sha: $sha}' >"$ref_payload"
+            if ! gh api --method POST "/repos/$GITHUB_REPOSITORY/git/refs" \
+              --input "$ref_payload" >"$ref_response"; then
+              jq -r '.message // "weekly tooling branch creation failed"' \
+                "$ref_response" >&2
+              exit 1
+            fi
           fi
 
           wait_for_branch() {

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -33,17 +33,13 @@ for required_text in \
     "expectedHeadOid" \
     "fileChanges" \
     "repositoryNameWithOwner" \
+    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/refs\"" \
+    "ref_payload=\"\$payload_dir/ref.json\"" \
+    "ref_response=\"\$payload_dir/ref-response.json\"" \
+    "'{ref: \$ref, sha: \$sha}'" \
     "gh api graphql --input \"\$create_commit_payload\"" \
     "commit_sha=\"\$(jq -er" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \
-    "git_auth_header=\"\$(printf 'x-access-token:%s' \"\$GH_TOKEN\" | base64 | tr -d '\\r\\n')\"" \
-    "printf '::add-mask::%s\\n' \"\$git_auth_header\"" \
-    "git_host=\"\${GITHUB_SERVER_URL#https://}\"" \
-    "GIT_CONFIG_COUNT=1" \
-    "GIT_CONFIG_KEY_0=http.extraheader" \
-    "GIT_CONFIG_VALUE_0=\"AUTHORIZATION: basic \$git_auth_header\"" \
-    "push \"https://\${git_host}/\${GITHUB_REPOSITORY}.git\"" \
-    "\$parent_sha:refs/heads/\$branch" \
     "wait_for_branch()" \
     "weekly tooling branch did not become visible" \
     "visible_branch_sha=\"\$(wait_for_branch)\"" \
@@ -73,7 +69,8 @@ fi
 for forbidden_text in \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/blobs\"" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/trees\"" \
-    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\""; do
+    "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/git/commits\"" \
+    "git push"; do
     if grep -Fq -- "$forbidden_text" "$workflow"; then
         echo "weekly tooling workflow must use the atomic GraphQL commit path" >&2
         exit 1


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Create the missing weekly tooling branch through GitHub’s Git Database ref API at the existing `main` commit before invoking the signed GraphQL commit mutation. This removes the unreliable Git transport bootstrap while retaining branch visibility and parent checks.

## Related Issue

Follow-up to #112

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

Commands: `bash scripts/github-setup/test-commit-verification-contract.sh`; `LINT_MODE=check make quality`

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer