### PR TITLE
fix: use App token for weekly refs

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -25,7 +25,6 @@ jobs:
       contents: write
       issues: read
       pull-requests: write
-      workflows: write
 
     steps:
       - name: Checkout code
@@ -88,7 +87,6 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
-          BOOTSTRAP_TOKEN: ${{ github.token }}
           APP_SLUG: ${{ steps.resolve-token.outputs.app_slug }}
           TOOLING_UPDATE_METADATA_FILE: ${{ runner.temp }}/tooling-update-metadata.json
         run: |
@@ -170,7 +168,7 @@ jobs:
             ref_response="$payload_dir/ref-response.json"
             jq -n --arg ref "refs/heads/$branch" --arg sha "$parent_sha" \
               '{ref: $ref, sha: $sha}' >"$ref_payload"
-            if ! GH_TOKEN="$BOOTSTRAP_TOKEN" gh api --method POST \
+            if ! gh api --method POST \
               "/repos/$GITHUB_REPOSITORY/git/refs" \
               --input "$ref_payload" >"$ref_response"; then
               jq -r '.message // "weekly tooling branch creation failed"' \

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -121,7 +121,7 @@ assert_contains "repositories: \${{ inputs.repo_name }}" "$repo_root/.github/wor
 assert_contains "repositories: \${{ github.event.repository.name }}" "$repo_root/.github/workflows/test-generated-repository-e2e.yml"
 assert_contains "repositories: \${{ needs.create-test-repo.outputs.test_repo_name }}" "$repo_root/.github/workflows/test-repository-creation.yml"
 assert_contains "contents: write" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
-assert_contains "workflows: write" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
+assert_not_contains "      workflows: write" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "pull-requests: write" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "issues: read" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "inputs.permission_profile == 'weekly-tooling'" "$resolver"

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -15,7 +15,6 @@ for required_text in \
     "uses: ./.github/actions/resolve-gh-token" \
     "environment: production-maintenance" \
     "permission_profile: weekly-tooling" \
-    "workflows: write" \
     "BOOTSTRAP_MAINTENANCE_WRITER_APP_PRIVATE_KEY" \
     "BOOTSTRAP_MAINTENANCE_WRITER_APP_CLIENT_ID" \
     "BOOTSTRAP_MAINTENANCE_WRITER_APP_SLUG" \
@@ -37,8 +36,7 @@ for required_text in \
     "ref_payload=\"\$payload_dir/ref.json\"" \
     "ref_response=\"\$payload_dir/ref-response.json\"" \
     "'{ref: \$ref, sha: \$sha}'" \
-    "BOOTSTRAP_TOKEN: \${{ github.token }}" \
-    "GH_TOKEN=\"\$BOOTSTRAP_TOKEN\" gh api --method POST" \
+    "gh api --method POST" \
     "/repos/\$GITHUB_REPOSITORY/git/refs" \
     "weekly tooling branch creation returned an unexpected ref" \
     "gh api graphql --input \"\$create_commit_payload\"" \
@@ -54,6 +52,11 @@ for required_text in \
         exit 1
     }
 done
+
+if grep -Fq 'BOOTSTRAP_TOKEN' "$workflow"; then
+    echo "weekly tooling ref creation must use the resolved Maintenance Writer App token" >&2
+    exit 1
+fi
 
 if grep -Fq 'gh pr create' "$workflow"; then
     echo "weekly tooling PR creation must use the REST API" >&2


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Remove the invalid GitHub Actions `workflows` permission and use the scoped Maintenance Writer App token for initial weekly branch creation. Add a contract preventing the Actions-token path from returning.

## Related Issue

Follow-up to #112.

## Validation

- [x] Tests pass
- [x] Lint and security checks pass
- [x] Generated-file or template parity is verified when applicable

`LINT_MODE=check make quality`

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer