### PR TITLE
fix: skip conda pre-release versions in tooling updater

### DIFF
--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 	"time"
 )
@@ -183,17 +184,78 @@ func fetchSHA256(rawURL string) (string, error) {
 	return "", fmt.Errorf("failed to fetch binary for checksum after retries: %s: %w", rawURL, lastErr)
 }
 
+// stableVersionPattern matches plain numeric dotted releases such as "3.14.7".
+// It deliberately rejects pre-releases like "3.15.0rc1", "3.15.0a7" or
+// "3.15.0b4": conda-forge only serves those under separate labels, so pinning
+// one breaks `micromamba create` against the default channel.
+var stableVersionPattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)*$`)
+
 func latestCondaVersion(pkg string) (string, error) {
 	encoded := url.PathEscape(pkg)
 	data, err := httpGetJSON("https://api.anaconda.org/package/conda-forge/" + encoded)
 	if err != nil {
 		return "", err
 	}
+	if rawVersions, ok := data["versions"].([]any); ok {
+		candidates := make([]string, 0, len(rawVersions))
+		for _, item := range rawVersions {
+			if version, ok := item.(string); ok {
+				candidates = append(candidates, version)
+			}
+		}
+		if stable := latestStableVersion(candidates); stable != "" {
+			return stable, nil
+		}
+	}
 	version, ok := data["latest_version"].(string)
+	version = strings.TrimSpace(version)
 	if !ok || version == "" {
 		return "", fmt.Errorf("unable to resolve conda-forge latest version for %s", pkg)
 	}
+	if !stableVersionPattern.MatchString(version) {
+		return "", fmt.Errorf("conda-forge has no stable release for %s (latest is %q)", pkg, version)
+	}
 	return version, nil
+}
+
+// latestStableVersion returns the greatest plain-numeric release from versions,
+// ignoring any pre-release identifiers. It returns "" when versions holds no
+// stable release.
+func latestStableVersion(versions []string) string {
+	best := ""
+	for _, candidate := range versions {
+		candidate = strings.TrimSpace(candidate)
+		if !stableVersionPattern.MatchString(candidate) {
+			continue
+		}
+		if best == "" || compareNumericVersions(candidate, best) > 0 {
+			best = candidate
+		}
+	}
+	return best
+}
+
+// compareNumericVersions compares two dotted numeric versions component by
+// component, treating missing trailing components as zero. It returns a
+// negative, zero, or positive value when a sorts before, equal to, or after b.
+func compareNumericVersions(a, b string) int {
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	limit := max(len(aParts), len(bParts))
+	for index := range limit {
+		aNumber := 0
+		if index < len(aParts) {
+			aNumber = parseVersionPart(aParts[index])
+		}
+		bNumber := 0
+		if index < len(bParts) {
+			bNumber = parseVersionPart(bParts[index])
+		}
+		if aNumber != bNumber {
+			return aNumber - bNumber
+		}
+	}
+	return 0
 }
 
 func latestPyPIVersion(pkg string) (string, error) {

--- a/tools/pkg/toolinglib/version_fetch_test.go
+++ b/tools/pkg/toolinglib/version_fetch_test.go
@@ -1,0 +1,89 @@
+package toolinglib
+
+import "testing"
+
+func TestLatestStableVersion(t *testing.T) {
+	tests := []struct {
+		name     string
+		versions []string
+		want     string
+	}{
+		{
+			name:     "ignores pre-releases and picks the newest stable",
+			versions: []string{"3.14.6", "3.15.0a7", "3.15.0b4", "3.15.0rc1", "3.14.7", "3.13.15"},
+			want:     "3.14.7",
+		},
+		{
+			name:     "compares components numerically not lexically",
+			versions: []string{"1.2.9", "1.2.10", "1.10.0"},
+			want:     "1.10.0",
+		},
+		{
+			name:     "handles differing component counts",
+			versions: []string{"1.15", "1.15.9", "1.9.9"},
+			want:     "1.15.9",
+		},
+		{
+			name:     "returns empty when every version is a pre-release",
+			versions: []string{"3.15.0a1", "3.15.0rc2"},
+			want:     "",
+		},
+		{
+			name:     "returns empty for no versions",
+			versions: nil,
+			want:     "",
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := latestStableVersion(testCase.versions)
+			if got != testCase.want {
+				t.Fatalf("latestStableVersion(%v) = %q, want %q", testCase.versions, got, testCase.want)
+			}
+		})
+	}
+}
+
+func TestCompareNumericVersions(t *testing.T) {
+	tests := []struct {
+		a    string
+		b    string
+		sign int
+	}{
+		{a: "3.14.7", b: "3.14.6", sign: 1},
+		{a: "3.14.6", b: "3.14.7", sign: -1},
+		{a: "3.14.6", b: "3.14.6", sign: 0},
+		{a: "1.2.10", b: "1.2.9", sign: 1},
+		{a: "1.15", b: "1.15.0", sign: 0},
+		{a: "2.0", b: "1.99.99", sign: 1},
+	}
+
+	for _, testCase := range tests {
+		result := compareNumericVersions(testCase.a, testCase.b)
+		switch {
+		case testCase.sign == 0 && result != 0:
+			t.Fatalf("compareNumericVersions(%q, %q) = %d, want 0", testCase.a, testCase.b, result)
+		case testCase.sign < 0 && result >= 0:
+			t.Fatalf("compareNumericVersions(%q, %q) = %d, want < 0", testCase.a, testCase.b, result)
+		case testCase.sign > 0 && result <= 0:
+			t.Fatalf("compareNumericVersions(%q, %q) = %d, want > 0", testCase.a, testCase.b, result)
+		}
+	}
+}
+
+func TestStableVersionPatternRejectsPreReleases(t *testing.T) {
+	stable := []string{"3", "3.14", "3.14.7", "1.15.9", "0.11.0"}
+	for _, version := range stable {
+		if !stableVersionPattern.MatchString(version) {
+			t.Errorf("expected %q to be treated as stable", version)
+		}
+	}
+
+	preRelease := []string{"3.15.0rc1", "3.15.0a7", "3.15.0b4", "1.2.3-dev", "v1.2.3", "1.2.3+meta"}
+	for _, version := range preRelease {
+		if stableVersionPattern.MatchString(version) {
+			t.Errorf("expected %q to be treated as a pre-release", version)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The weekly tooling run (#164) failed because the updater pinned
`python=3.15.0rc1`.

`latestCondaVersion` returned anaconda.org's `latest_version` field, which
includes pre-releases. conda-forge only serves rc/alpha/beta builds under a
separate label, so `micromamba create` against the default channel could not
solve `environment.yml` and the required **quality** check failed. The `rc1`
string also fails `ClassifyUpdate` (not plain-numeric) → `automation: blocked`
label → **Maintenance safety** fails by design.

## Fix

- Read the full `versions` array from the anaconda API and pick the greatest
  plain-numeric release, ignoring rc/alpha/beta identifiers
  (`latestStableVersion` + `compareNumericVersions`).
- Fall back to `latest_version` only when it is itself stable; otherwise fail
  loudly rather than emit a broken pin (fail-closed, per #112).
- Verified against live data: `python` now resolves to `3.14.7` (was `3.15.0rc1`).

Only conda version selection was affected — PyPI/npm/Go-proxy/GitHub-release
lookups already exclude pre-releases.

## Validation

- [x] `go build ./... && go vet ./... && go test ./...` (tools module)
- [x] `gofmt` clean
- [x] `bash scripts/run-contract-tests.sh`
- [x] new unit tests: `TestLatestStableVersion`, `TestCompareNumericVersions`, `TestStableVersionPatternRejectsPreReleases`

## Follow-up

After merge, re-run **Weekly Tooling Updates**; it will `updateRef --force` the
`chore/weekly-tooling-updates` branch onto `main` and recommit #164 with the
stable pins.

Signed-off-by: Aydin.A <ayd.abd@gmail.com>