### PR TITLE
fix: guard weekly tooling run against mid-run main changes

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -185,16 +185,14 @@ jobs:
             mv "$file_changes.tmp" "$file_changes"
           done < <(git diff --cached --name-only)
 
-          # Resolve the repository node id, the current main tip, and any
-          # existing automation branch through one GraphQL read. Creating and
-          # updating the ref on the same GraphQL endpoint that runs
-          # createCommitOnBranch avoids the REST-to-GraphQL propagation gap
-          # that made the mutation fail with "Branch not found".
+          # Resolve the repository node id and any existing automation branch
+          # through GraphQL. Creating and updating the ref on the same GraphQL
+          # endpoint that runs createCommitOnBranch avoids the REST-to-GraphQL
+          # propagation gap that made the mutation fail with "Branch not found".
           gh api graphql \
             -f query='query($owner: String!, $name: String!, $branchRef: String!) {
               repository(owner: $owner, name: $name) {
                 id
-                mainRef: ref(qualifiedName: "refs/heads/main") { target { oid } }
                 branchRef: ref(qualifiedName: $branchRef) {
                   id
                   target {
@@ -210,17 +208,43 @@ jobs:
             >"$repo_state"
 
           repository_id="$(jq -r '.data.repository.id // empty' "$repo_state")"
-          base_oid="$(jq -r '.data.repository.mainRef.target.oid // empty' "$repo_state")"
           branch_ref_id="$(jq -r '.data.repository.branchRef.id // empty' "$repo_state")"
           branch_commit_message="$(jq -r '.data.repository.branchRef.target.message // empty' "$repo_state")"
           [ -n "$repository_id" ] || {
             echo "weekly tooling workflow could not resolve the repository node id" >&2
             exit 1
           }
+
+          # Resolve the tip of main now, immediately before the branch is reset
+          # and the commit is created, so createRef / updateRef /
+          # createCommitOnBranch all pin the same current commit rather than a
+          # value that aged while the updater ran.
+          base_oid="$(gh api graphql \
+            -f query='query($owner: String!, $name: String!) {
+              repository(owner: $owner, name: $name) {
+                ref(qualifiedName: "refs/heads/main") { target { oid } }
+              }
+            }' \
+            -f owner="$owner" \
+            -f name="$name" \
+            --jq '.data.repository.ref.target.oid')"
           [ -n "$base_oid" ] || {
             echo "weekly tooling workflow could not resolve the refs/heads/main tip" >&2
             exit 1
           }
+
+          # Idempotency guard. The updater ran against the checked-out tree and
+          # the commit below replaces whole files, so on the scheduled/main path
+          # the checkout must still be the tip of main. If something merged
+          # mid-run, abort and let the next run reconcile from a fresh checkout
+          # rather than silently reverting that change.
+          if [ "$GITHUB_REF_NAME" = "main" ]; then
+            checkout_sha="$(git rev-parse HEAD)"
+            [ "$checkout_sha" = "$base_oid" ] || {
+              echo "main advanced during the run (updater base $checkout_sha, current tip $base_oid); aborting for a clean reconcile on the next run" >&2
+              exit 1
+            }
+          fi
 
           if [ -z "$branch_ref_id" ]; then
             gh api graphql \

--- a/scripts/github-setup/test-commit-verification-contract.sh
+++ b/scripts/github-setup/test-commit-verification-contract.sh
@@ -37,8 +37,12 @@ for required_text in \
     "updateRef(input:" \
     "force: true" \
     "ref(qualifiedName: \"refs/heads/main\")" \
-    "base_oid=\"\$(jq -r '.data.repository.mainRef.target.oid" \
+    "base_oid=\"\$(gh api graphql" \
     "branch_ref_id=\"\$(jq -r '.data.repository.branchRef.id" \
+    "if [ \"\$GITHUB_REF_NAME\" = \"main\" ]; then" \
+    "checkout_sha=\"\$(git rev-parse HEAD)\"" \
+    "[ \"\$checkout_sha\" = \"\$base_oid\" ] ||" \
+    "main advanced during the run" \
     "gh api graphql --input \"\$create_commit_payload\"" \
     "commit_sha=\"\$(jq -er" \
     "gh api --method POST \"/repos/\$GITHUB_REPOSITORY/pulls\"" \


### PR DESCRIPTION
## Context

Follow-up to #163. The weekly run is already conflict-proof by construction —
each run resets `chore/weekly-tooling-updates` to the current `main` tip
(`createRef`, or `updateRef --force` for an existing automation branch) and puts
**one** `createCommitOnBranch` commit on top carrying **whole-file snapshots**
(not patches). No rebase, no merge, so a merge conflict cannot happen, and an
existing PR (e.g. #164) is reconciled in place.

## The one gap this closes

`actions/checkout` grabs `main` at trigger time; `make tooling-update-*` and the
GraphQL `base_oid` read happen a minute or two later. If a PR merges in that
window **and** touches a file the updater also rewrites (`environment.yml`,
`mise.toml`, `scripts/provider-assets.txt`, `templates/**/providers/**`), the
whole-file snapshot would silently revert it.

Guard: on the scheduled / `main`-dispatch path, require the checked-out commit
to still equal the resolved `main` tip; otherwise abort so the next run
reconciles from a fresh checkout (fail-closed, per #112). Branch-scoped manual
dispatch (used for testing) is unaffected.

## Validation

- [x] `bash scripts/run-contract-tests.sh`
- [x] `actionlint` + `yamllint` (repo configs)
- [x] `shellcheck` on the contract test
- [x] contract now asserts the guard

Signed-off-by: Aydin.A <ayd.abd@gmail.com>