### PR TITLE
feat: add a 14-day release cooldown to the tooling updater

### DIFF
--- a/tools/cmd/tooling-updater/main.go
+++ b/tools/cmd/tooling-updater/main.go
@@ -5,11 +5,28 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
 
 	"github-bootstrap/tools/internal/toolingupdater/runner"
 	"github-bootstrap/tools/pkg/toolinglib"
 )
+
+const defaultCooldownDays = 14
+
+// envIntDefault reads a non-negative integer from name, falling back to
+// fallback when the variable is unset, empty, or malformed.
+func envIntDefault(name string, fallback int) int {
+	raw := strings.TrimSpace(os.Getenv(name))
+	if raw == "" {
+		return fallback
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < 0 {
+		return fallback
+	}
+	return value
+}
 
 func parseLogLevel() slog.Level {
 	switch strings.ToLower(strings.TrimSpace(os.Getenv(toolinglib.EnvLogLevel))) {
@@ -34,9 +51,10 @@ func main() {
 	verifyOnly := flag.Bool("verify-only", false, "verify workspace layout and exit")
 	metadataFile := flag.String("metadata-file", os.Getenv("TOOLING_UPDATE_METADATA_FILE"), "write structured update metadata to this file")
 	explicitBreaking := flag.Bool("explicit-breaking", os.Getenv("TOOLING_UPDATE_EXPLICIT_BREAKING") == "true", "classify all emitted updates as explicitly breaking")
+	cooldownDays := flag.Int("cooldown-days", envIntDefault("TOOLING_UPDATE_COOLDOWN_DAYS", defaultCooldownDays), "skip upstream releases published within this many days (0 disables)")
 	flag.Parse()
 
-	logger.Info("tooling updater started", "scope", *scope, "updaters", *updatersRaw, "dry_run", *dryRun, "verify_only", *verifyOnly)
+	logger.Info("tooling updater started", "scope", *scope, "updaters", *updatersRaw, "dry_run", *dryRun, "verify_only", *verifyOnly, "cooldown_days", *cooldownDays)
 
 	if *scope != "repo" && *scope != "templates" && *scope != "all" {
 		fmt.Fprintln(os.Stderr, "invalid scope, expected repo|templates|all")
@@ -56,6 +74,7 @@ func main() {
 		DryRun:       *dryRun,
 		VerifyLayout: *verifyLayout,
 		VerifyOnly:   *verifyOnly,
+		CooldownDays: *cooldownDays,
 	})
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "tooling update failed: %v\n", err)

--- a/tools/internal/toolingupdater/runner/runner.go
+++ b/tools/internal/toolingupdater/runner/runner.go
@@ -17,6 +17,7 @@ type Config struct {
 	DryRun       bool
 	VerifyLayout bool
 	VerifyOnly   bool
+	CooldownDays int
 }
 
 type updaterEntry struct {
@@ -112,7 +113,7 @@ func Run(cfg Config) ([]string, error) {
 
 	var versions *toolinglib.Versions
 	if needsVersions {
-		resolved, err := toolinglib.CollectVersions(selected)
+		resolved, err := toolinglib.CollectVersions(selected, cfg.CooldownDays)
 		if err != nil {
 			return nil, err
 		}

--- a/tools/pkg/toolinglib/version_fetch.go
+++ b/tools/pkg/toolinglib/version_fetch.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"os"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 )
@@ -190,49 +191,112 @@ func fetchSHA256(rawURL string) (string, error) {
 // one breaks `micromamba create` against the default channel.
 var stableVersionPattern = regexp.MustCompile(`^[0-9]+(?:\.[0-9]+)*$`)
 
-func latestCondaVersion(pkg string) (string, error) {
+// releaseCandidate pairs a version string with the earliest time it was
+// published upstream. A zero released time means the publish time is unknown.
+type releaseCandidate struct {
+	version  string
+	released time.Time
+}
+
+// cooldownCutoff converts a cooldown window in days into an absolute cutoff
+// time. A non-positive value disables the cooldown and yields the zero time.
+func cooldownCutoff(days int) time.Time {
+	if days <= 0 {
+		return time.Time{}
+	}
+	return time.Now().UTC().AddDate(0, 0, -days)
+}
+
+// parsePublishTime parses the timestamp formats the upstream version APIs
+// return. It yields the zero time for an empty or unrecognised value.
+func parsePublishTime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	for _, layout := range []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999-07:00", // anaconda.org files[].upload_time
+		"2006-01-02 15:04:05-07:00",
+	} {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+// newestEligibleVersion returns the greatest plain-numeric release whose publish
+// time is at or before cutoff, ignoring pre-releases. A zero cutoff disables the
+// age filter. It returns "" when no candidate qualifies.
+func newestEligibleVersion(candidates []releaseCandidate, cutoff time.Time) string {
+	best := ""
+	for _, candidate := range candidates {
+		version := strings.TrimSpace(candidate.version)
+		if !stableVersionPattern.MatchString(version) {
+			continue
+		}
+		if !cutoff.IsZero() && (candidate.released.IsZero() || candidate.released.After(cutoff)) {
+			continue
+		}
+		if best == "" || compareNumericVersions(version, best) > 0 {
+			best = version
+		}
+	}
+	return best
+}
+
+func noEligibleReleaseError(source, pkg string, cutoff time.Time) error {
+	if cutoff.IsZero() {
+		return fmt.Errorf("%s has no stable release for %s", source, pkg)
+	}
+	return fmt.Errorf("%s has no stable release for %s older than the cooldown window (cutoff %s)",
+		source, pkg, cutoff.Format(time.RFC3339))
+}
+
+func latestCondaVersion(pkg string, cutoff time.Time) (string, error) {
 	encoded := url.PathEscape(pkg)
 	data, err := httpGetJSON("https://api.anaconda.org/package/conda-forge/" + encoded)
 	if err != nil {
 		return "", err
 	}
-	if rawVersions, ok := data["versions"].([]any); ok {
-		candidates := make([]string, 0, len(rawVersions))
-		for _, item := range rawVersions {
-			if version, ok := item.(string); ok {
-				candidates = append(candidates, version)
+	earliest := map[string]time.Time{}
+	if files, ok := data["files"].([]any); ok {
+		for _, raw := range files {
+			file, ok := raw.(map[string]any)
+			if !ok {
+				continue
+			}
+			version := strings.TrimSpace(asString(file["version"]))
+			uploaded := parsePublishTime(asString(file["upload_time"]))
+			if version == "" || uploaded.IsZero() {
+				continue
+			}
+			if existing, seen := earliest[version]; !seen || uploaded.Before(existing) {
+				earliest[version] = uploaded
 			}
 		}
-		if stable := latestStableVersion(candidates); stable != "" {
-			return stable, nil
+	}
+	var candidates []releaseCandidate
+	if rawVersions, ok := data["versions"].([]any); ok {
+		for _, item := range rawVersions {
+			version := strings.TrimSpace(asString(item))
+			if version == "" {
+				continue
+			}
+			candidates = append(candidates, releaseCandidate{version: version, released: earliest[version]})
 		}
 	}
-	version, ok := data["latest_version"].(string)
-	version = strings.TrimSpace(version)
-	if !ok || version == "" {
-		return "", fmt.Errorf("unable to resolve conda-forge latest version for %s", pkg)
+	if picked := newestEligibleVersion(candidates, cutoff); picked != "" {
+		return picked, nil
 	}
-	if !stableVersionPattern.MatchString(version) {
-		return "", fmt.Errorf("conda-forge has no stable release for %s (latest is %q)", pkg, version)
-	}
-	return version, nil
+	return "", noEligibleReleaseError("conda-forge", pkg, cutoff)
 }
 
-// latestStableVersion returns the greatest plain-numeric release from versions,
-// ignoring any pre-release identifiers. It returns "" when versions holds no
-// stable release.
-func latestStableVersion(versions []string) string {
-	best := ""
-	for _, candidate := range versions {
-		candidate = strings.TrimSpace(candidate)
-		if !stableVersionPattern.MatchString(candidate) {
-			continue
-		}
-		if best == "" || compareNumericVersions(candidate, best) > 0 {
-			best = candidate
-		}
-	}
-	return best
+func asString(value any) string {
+	text, _ := value.(string)
+	return text
 }
 
 // compareNumericVersions compares two dotted numeric versions component by
@@ -258,63 +322,179 @@ func compareNumericVersions(a, b string) int {
 	return 0
 }
 
-func latestPyPIVersion(pkg string) (string, error) {
+func latestPyPIVersion(pkg string, cutoff time.Time) (string, error) {
 	encoded := url.PathEscape(pkg)
 	data, err := httpGetJSON("https://pypi.org/pypi/" + encoded + "/json")
 	if err != nil {
 		return "", err
 	}
-	info, ok := data["info"].(map[string]any)
+	releases, ok := data["releases"].(map[string]any)
 	if !ok {
 		return "", fmt.Errorf("unable to parse PyPI response for %s", pkg)
 	}
-	version, ok := info["version"].(string)
-	if !ok || version == "" {
-		return "", fmt.Errorf("unable to resolve PyPI latest version for %s", pkg)
+	var candidates []releaseCandidate
+	for version, raw := range releases {
+		files, ok := raw.([]any)
+		if !ok || len(files) == 0 {
+			continue // removed or artifact-less release
+		}
+		var earliest time.Time
+		hasUsableFile := false
+		for _, entry := range files {
+			file, ok := entry.(map[string]any)
+			if !ok {
+				continue
+			}
+			if isYanked, _ := file["yanked"].(bool); isYanked {
+				continue
+			}
+			hasUsableFile = true
+			uploaded := parsePublishTime(asString(file["upload_time_iso_8601"]))
+			if uploaded.IsZero() {
+				continue
+			}
+			if earliest.IsZero() || uploaded.Before(earliest) {
+				earliest = uploaded
+			}
+		}
+		if !hasUsableFile {
+			continue // every file yanked
+		}
+		candidates = append(candidates, releaseCandidate{version: version, released: earliest})
 	}
-	return version, nil
+	if picked := newestEligibleVersion(candidates, cutoff); picked != "" {
+		return picked, nil
+	}
+	return "", noEligibleReleaseError("PyPI", pkg, cutoff)
 }
 
-func latestNPMVersion(pkg string) (string, error) {
-	// Use the /latest endpoint to avoid fetching the full package document.
+func latestNPMVersion(pkg string, cutoff time.Time) (string, error) {
 	encoded := strings.ReplaceAll(url.PathEscape(pkg), "%2F", "/")
-	data, err := httpGetJSON("https://registry.npmjs.org/" + encoded + "/latest")
+	data, err := httpGetJSON("https://registry.npmjs.org/" + encoded)
 	if err != nil {
 		return "", err
 	}
-	version, ok := data["version"].(string)
-	if !ok || version == "" {
-		return "", fmt.Errorf("unable to resolve npm latest version for %s", pkg)
+	versions, ok := data["versions"].(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("unable to parse npm response for %s", pkg)
 	}
-	return version, nil
+	published, _ := data["time"].(map[string]any)
+	var candidates []releaseCandidate
+	for version := range versions {
+		candidates = append(candidates, releaseCandidate{
+			version:  version,
+			released: parsePublishTime(asString(published[version])),
+		})
+	}
+	if picked := newestEligibleVersion(candidates, cutoff); picked != "" {
+		return picked, nil
+	}
+	return "", noEligibleReleaseError("npm", pkg, cutoff)
 }
 
-func latestGoModuleVersion(module string) (string, error) {
+func latestGoModuleVersion(module string, cutoff time.Time) (string, error) {
 	encoded := strings.ReplaceAll(url.PathEscape(module), "%2F", "/")
-	data, err := httpGetJSON("https://proxy.golang.org/" + encoded + "/@latest")
+	latest, err := httpGetJSON("https://proxy.golang.org/" + encoded + "/@latest")
 	if err != nil {
 		return "", err
 	}
-	version, ok := data["Version"].(string)
-	if !ok || version == "" {
+	latestVersion := asString(latest["Version"])
+	latestTime := parsePublishTime(asString(latest["Time"]))
+	if latestVersion == "" {
 		return "", fmt.Errorf("unable to resolve Go module latest version for %s", module)
 	}
-	return version, nil
-}
-
-func latestGitHubReleaseTag(repo string) (string, error) {
-	data, err := httpGetJSON("https://api.github.com/repos/" + repo + "/releases/latest")
+	if cutoff.IsZero() || (!latestTime.IsZero() && !latestTime.After(cutoff)) {
+		return latestVersion, nil
+	}
+	// The newest tag is inside the cooldown window; walk the tag list newest
+	// first and return the first release old enough.
+	body, err := readURLBytes("https://proxy.golang.org/"+encoded+"/@v/list", httpTimeoutSeconds)
 	if err != nil {
 		return "", err
 	}
-	tag, ok := data["tag_name"].(string)
-	if !ok || tag == "" {
-		return "", fmt.Errorf("unable to resolve latest GitHub release tag for %s", repo)
+	tags := strings.Fields(string(body))
+	sort.Slice(tags, func(i, j int) bool {
+		return compareNumericVersions(
+			strings.TrimPrefix(tags[i], "v"),
+			strings.TrimPrefix(tags[j], "v"),
+		) > 0
+	})
+	for _, tag := range tags {
+		if strings.Contains(tag, "-") { // skip pseudo-versions / pre-releases
+			continue
+		}
+		info, infoErr := httpGetJSON("https://proxy.golang.org/" + encoded + "/@v/" + url.PathEscape(tag) + ".info")
+		if infoErr != nil {
+			continue
+		}
+		released := parsePublishTime(asString(info["Time"]))
+		if !released.IsZero() && !released.After(cutoff) {
+			return tag, nil
+		}
 	}
-	return tag, nil
+	return "", noEligibleReleaseError("Go proxy", module, cutoff)
 }
 
-func CollectVersions(selectedUpdaters []string) (Versions, error) {
+func latestGitHubReleaseTag(repo string, cutoff time.Time) (string, error) {
+	if cutoff.IsZero() {
+		data, err := httpGetJSON("https://api.github.com/repos/" + repo + "/releases/latest")
+		if err != nil {
+			return "", err
+		}
+		tag := asString(data["tag_name"])
+		if tag == "" {
+			return "", fmt.Errorf("unable to resolve latest GitHub release tag for %s", repo)
+		}
+		return tag, nil
+	}
+	// Releases come back newest first. Fast-moving projects (e.g. jdx/mise ships
+	// several times a week) can have more than one page of releases inside the
+	// cooldown window, so walk pages until an eligible release is found or the
+	// history is exhausted.
+	const perPage, maxPages = 100, 20
+	for page := 1; page <= maxPages; page++ {
+		body, err := readURLBytes(fmt.Sprintf(
+			"https://api.github.com/repos/%s/releases?per_page=%d&page=%d", repo, perPage, page),
+			httpTimeoutSeconds)
+		if err != nil {
+			return "", err
+		}
+		var releases []struct {
+			TagName     string `json:"tag_name"`
+			Draft       bool   `json:"draft"`
+			Prerelease  bool   `json:"prerelease"`
+			PublishedAt string `json:"published_at"`
+		}
+		if err := json.Unmarshal(body, &releases); err != nil {
+			return "", fmt.Errorf("unable to parse GitHub releases for %s: %w", repo, err)
+		}
+		if len(releases) == 0 {
+			break
+		}
+		for _, release := range releases {
+			if release.Draft || release.Prerelease || release.TagName == "" {
+				continue
+			}
+			published := parsePublishTime(release.PublishedAt)
+			if !published.IsZero() && !published.After(cutoff) {
+				return release.TagName, nil
+			}
+		}
+		if len(releases) < perPage {
+			break
+		}
+	}
+	return "", fmt.Errorf("GitHub repository %s has no published release older than the cooldown window (cutoff %s)",
+		repo, cutoff.Format(time.RFC3339))
+}
+
+// CollectVersions resolves the newest eligible upstream version for every
+// managed tool. cooldownDays skips releases published within that many days so a
+// freshly cut (and potentially broken or yanked) release is not pinned
+// immediately; pass 0 to disable the cooldown.
+func CollectVersions(selectedUpdaters []string, cooldownDays int) (Versions, error) {
+	cutoff := cooldownCutoff(cooldownDays)
+
 	needsMicromamba := false
 	needsMise := false
 	for _, updater := range selectedUpdaters {
@@ -332,7 +512,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 
 	conda := make(map[string]string)
 	for _, pkg := range allCondaPackages() {
-		v, err := latestCondaVersion(pkg)
+		v, err := latestCondaVersion(pkg, cutoff)
 		if err != nil {
 			return Versions{}, err
 		}
@@ -349,7 +529,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 		}
 
 		for _, pkg := range []string{"pre-commit", "editorconfig-checker", "yamllint"} {
-			v, err := latestPyPIVersion(pkg)
+			v, err := latestPyPIVersion(pkg, cutoff)
 			if err != nil {
 				return Versions{}, err
 			}
@@ -357,7 +537,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 		}
 
 		for _, pkg := range []string{"prettier", "markdownlint-cli"} {
-			v, err := latestNPMVersion(pkg)
+			v, err := latestNPMVersion(pkg, cutoff)
 			if err != nil {
 				return Versions{}, err
 			}
@@ -365,7 +545,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 		}
 
 		for replacementModule, lookupModule := range goModuleLookup {
-			v, err := latestGoModuleVersion(lookupModule)
+			v, err := latestGoModuleVersion(lookupModule, cutoff)
 			if err != nil {
 				return Versions{}, err
 			}
@@ -375,7 +555,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 
 	providerURLs := map[string]string{}
 	if needsMise {
-		miseTag, err := latestGitHubReleaseTag("jdx/mise")
+		miseTag, err := latestGitHubReleaseTag("jdx/mise", cutoff)
 		if err != nil {
 			return Versions{}, err
 		}
@@ -385,7 +565,7 @@ func CollectVersions(selectedUpdaters []string) (Versions, error) {
 		providerURLs["mise:macos:arm64"] = "https://github.com/jdx/mise/releases/download/" + miseTag + "/mise-" + miseTag + "-macos-arm64"
 	}
 	if needsMicromamba {
-		micromambaTag, err := latestGitHubReleaseTag("mamba-org/micromamba-releases")
+		micromambaTag, err := latestGitHubReleaseTag("mamba-org/micromamba-releases", cutoff)
 		if err != nil {
 			return Versions{}, err
 		}

--- a/tools/pkg/toolinglib/version_fetch_test.go
+++ b/tools/pkg/toolinglib/version_fetch_test.go
@@ -1,47 +1,88 @@
 package toolinglib
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestLatestStableVersion(t *testing.T) {
+func rc(version string, released time.Time) releaseCandidate {
+	return releaseCandidate{version: version, released: released}
+}
+
+func TestNewestEligibleVersion_NoCutoff(t *testing.T) {
 	tests := []struct {
-		name     string
-		versions []string
-		want     string
+		name       string
+		candidates []releaseCandidate
+		want       string
 	}{
 		{
-			name:     "ignores pre-releases and picks the newest stable",
-			versions: []string{"3.14.6", "3.15.0a7", "3.15.0b4", "3.15.0rc1", "3.14.7", "3.13.15"},
-			want:     "3.14.7",
+			name:       "ignores pre-releases and picks the newest stable",
+			candidates: []releaseCandidate{rc("3.14.6", time.Time{}), rc("3.15.0a7", time.Time{}), rc("3.15.0b4", time.Time{}), rc("3.15.0rc1", time.Time{}), rc("3.14.7", time.Time{}), rc("3.13.15", time.Time{})},
+			want:       "3.14.7",
 		},
 		{
-			name:     "compares components numerically not lexically",
-			versions: []string{"1.2.9", "1.2.10", "1.10.0"},
-			want:     "1.10.0",
+			name:       "compares components numerically not lexically",
+			candidates: []releaseCandidate{rc("1.2.9", time.Time{}), rc("1.2.10", time.Time{}), rc("1.10.0", time.Time{})},
+			want:       "1.10.0",
 		},
 		{
-			name:     "handles differing component counts",
-			versions: []string{"1.15", "1.15.9", "1.9.9"},
-			want:     "1.15.9",
+			name:       "handles differing component counts",
+			candidates: []releaseCandidate{rc("1.15", time.Time{}), rc("1.15.9", time.Time{}), rc("1.9.9", time.Time{})},
+			want:       "1.15.9",
 		},
 		{
-			name:     "returns empty when every version is a pre-release",
-			versions: []string{"3.15.0a1", "3.15.0rc2"},
-			want:     "",
+			name:       "returns empty when every candidate is a pre-release",
+			candidates: []releaseCandidate{rc("3.15.0a1", time.Time{}), rc("3.15.0rc2", time.Time{})},
+			want:       "",
 		},
 		{
-			name:     "returns empty for no versions",
-			versions: nil,
-			want:     "",
+			name:       "returns empty for no candidates",
+			candidates: nil,
+			want:       "",
 		},
 	}
 
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			got := latestStableVersion(testCase.versions)
-			if got != testCase.want {
-				t.Fatalf("latestStableVersion(%v) = %q, want %q", testCase.versions, got, testCase.want)
+			if got := newestEligibleVersion(testCase.candidates, time.Time{}); got != testCase.want {
+				t.Fatalf("newestEligibleVersion(...) = %q, want %q", got, testCase.want)
 			}
 		})
+	}
+}
+
+func TestNewestEligibleVersion_Cooldown(t *testing.T) {
+	now := time.Now().UTC()
+	cutoff := now.AddDate(0, 0, -14)
+	old := now.AddDate(0, 0, -40)
+	recent := now.AddDate(0, 0, -3)
+
+	candidates := []releaseCandidate{
+		rc("1.2.0", old),
+		rc("1.3.0", old),
+		rc("1.4.0", recent), // inside the cooldown window
+		rc("1.5.0rc1", old), // pre-release, always skipped
+	}
+
+	if got := newestEligibleVersion(candidates, cutoff); got != "1.3.0" {
+		t.Fatalf("cooldown filter = %q, want 1.3.0 (1.4.0 too recent)", got)
+	}
+
+	// Exactly on the cutoff still counts as eligible.
+	onCutoff := []releaseCandidate{rc("2.0.0", cutoff)}
+	if got := newestEligibleVersion(onCutoff, cutoff); got != "2.0.0" {
+		t.Fatalf("release exactly on cutoff = %q, want 2.0.0", got)
+	}
+
+	// A stable candidate with an unknown publish time is skipped under cooldown.
+	unknown := []releaseCandidate{rc("3.0.0", time.Time{}), rc("2.9.0", old)}
+	if got := newestEligibleVersion(unknown, cutoff); got != "2.9.0" {
+		t.Fatalf("unknown publish time under cooldown = %q, want 2.9.0", got)
+	}
+
+	// Without a cooldown, publish times are irrelevant.
+	if got := newestEligibleVersion(candidates, time.Time{}); got != "1.4.0" {
+		t.Fatalf("no cooldown = %q, want 1.4.0", got)
 	}
 }
 
@@ -85,5 +126,42 @@ func TestStableVersionPatternRejectsPreReleases(t *testing.T) {
 		if stableVersionPattern.MatchString(version) {
 			t.Errorf("expected %q to be treated as a pre-release", version)
 		}
+	}
+}
+
+func TestParsePublishTime(t *testing.T) {
+	cases := map[string]bool{
+		"2026-08-10T22:07:16.942290Z":      true,  // PyPI upload_time_iso_8601
+		"2026-07-14T22:02:03.567Z":         true,  // npm time
+		"2026-08-28 20:31:20.099000+00:00": true,  // anaconda files[].upload_time
+		"2026-02-28T08:10:00Z":             true,  // Go proxy Time
+		"":                                 false, // empty
+		"not-a-timestamp":                  false, // garbage
+	}
+	for value, wantParsed := range cases {
+		got := parsePublishTime(value)
+		if wantParsed && got.IsZero() {
+			t.Errorf("parsePublishTime(%q) returned zero, expected a time", value)
+		}
+		if !wantParsed && !got.IsZero() {
+			t.Errorf("parsePublishTime(%q) = %v, expected zero", value, got)
+		}
+	}
+}
+
+func TestCooldownCutoff(t *testing.T) {
+	if !cooldownCutoff(0).IsZero() {
+		t.Error("cooldownCutoff(0) should be the zero time (disabled)")
+	}
+	if !cooldownCutoff(-5).IsZero() {
+		t.Error("cooldownCutoff(-5) should be the zero time (disabled)")
+	}
+	got := cooldownCutoff(14)
+	if got.IsZero() {
+		t.Fatal("cooldownCutoff(14) should be a real time")
+	}
+	age := time.Since(got)
+	if age < 13*24*time.Hour || age > 15*24*time.Hour {
+		t.Errorf("cooldownCutoff(14) is %v ago, expected ~14 days", age)
 	}
 }


### PR DESCRIPTION
## Why

The weekly tooling updater pins whatever is newest **right now** — no age
filter. It picked `python=3.15.0rc1` (fixed by #165's pre-release filter), and
would have pinned `python=3.14.7` the day it hit conda-forge. Fresh releases are
the ones most likely to be yanked or broken.

Dependabot in this repo already runs `cooldown: default-days: 14` for
`github-actions` / `gomod` / `terraform`. This brings the same protection to the
complementary set the weekly updater owns: conda runtimes + lint tools, PyPI
tools, npm tools, Go modules, and the `mise` / `micromamba` release binaries.

## What

`CollectVersions(selected, cooldownDays)` — default **14**, overridable with
`--cooldown-days` or `TOOLING_UPDATE_COOLDOWN_DAYS`, `0` disables. Each source
resolves the newest stable version whose publish time is ≥ the window:

| Source | Timestamp used |
|---|---|
| conda-forge | `files[].upload_time` (earliest per version) |
| PyPI | `releases[].upload_time_iso_8601` — also skips `yanked` |
| npm | packument `time{}` map (full doc instead of `/latest`) |
| Go proxy | `@latest` `Time`, then walk `@v/list` when it's too new |
| GitHub releases | `published_at`, walking back past drafts / pre-releases |

Fails closed (error, no pin) when nothing is old enough.

## Verified live

```
conda/python      14d -> 3.14.6   (0 -> 3.14.7, held 9 more days)
conda/go-shfmt    14d -> 3.13.1   (3.14.0 is ~4 days old)
pypi/pre-commit   14d -> 4.6.2
npm/markdownlint  14d -> 0.49.1
go/gci            14d -> v0.14.0
gh/jdx-mise       14d -> v2026.8.8 (v2026.8.16 was ~1 day old)
```

## Validation

- [x] `go build/vet/test ./...`, `gofmt` clean
- [x] `bash scripts/run-contract-tests.sh`
- [x] new unit tests: cooldown selection, on-cutoff boundary, unknown publish
      time, `parsePublishTime` formats, `cooldownCutoff`
- [x] live smoke test across all five sources

## Notes

- No workflow change needed — the default is 14 and env passes through `make`.
- Separate from the SHA/lockfile discussion (see the follow-up plan in the thread).

Signed-off-by: Aydin.A <ayd.abd@gmail.com>