### PR TITLE
fix: grant maintenance-labeling token pull-request write

### DIFF
--- a/.github/actions/resolve-gh-token/action.yml
+++ b/.github/actions/resolve-gh-token/action.yml
@@ -133,7 +133,7 @@ runs:
         permission-contents: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'weekly-tooling') && 'write' || '' }}
         permission-issues: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-labeling' || inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup') && 'write' || '' }}
         permission-organization-administration: ${{ inputs.permission_profile == 'repository-creation' && 'write' || '' }}
-        permission-pull-requests: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-review') && 'write' || (inputs.permission_profile == 'workflow-approval' || inputs.permission_profile == 'maintenance-labeling') && 'read' || '' }}
+        permission-pull-requests: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-review' || inputs.permission_profile == 'maintenance-labeling') && 'write' || inputs.permission_profile == 'workflow-approval' && 'read' || '' }}
         permission-workflows: ${{ inputs.permission_profile == 'weekly-tooling' && 'write' || '' }}
 
     - name: Finalize token output

--- a/docs/github-app-permission-matrix.md
+++ b/docs/github-app-permission-matrix.md
@@ -17,7 +17,7 @@ installation token does not inherit unused permissions from the App installation
 | `repository-cleanup`   | `administration: write`                                                                           | Delete a failed repository.                                            |
 | `e2e-lifecycle`        | `administration: write`                                                                           | Archive generated E2E repositories in the isolated E2E owner.          |
 | `weekly-tooling`       | `contents: write`, `issues: write`, `pull-requests: write`, `workflows: write`                    | Commit tooling updates, action pins, labels, and manage the weekly PR. |
-| `maintenance-labeling` | `issues: write`, `pull-requests: read`                                                            | Classify trusted Dependabot and release-please PRs.                    |
+| `maintenance-labeling` | `issues: write`, `pull-requests: write`                                                           | Classify trusted Dependabot and release-please PRs.                    |
 | `workflow-approval`    | `actions: write`, `pull-requests: read`                                                           | Approve eligible `action_required` workflow runs only.                 |
 | `maintenance-review`   | `pull-requests: write`                                                                            | Approve eligible maintenance PRs and enable squash auto-merge.         |
 
@@ -34,9 +34,12 @@ installation token does not inherit unused permissions from the App installation
 `metadata: read` is automatically available for repository access. Members, security-events,
 and unrelated-owner permissions are not granted by this resolver. The `actions: write`
 permission is granted only by the `workflow-approval` profile. Pull-request
-write permission is granted by the `weekly-tooling` and `maintenance-review` profiles. Issues write permission is
-limited to the weekly profile's and `maintenance-labeling` profile's idempotent pull-request label operations and
-the existing repository creation/setup profiles' repository label configuration.
+write permission is granted by the `weekly-tooling`, `maintenance-review`, and
+`maintenance-labeling` profiles; the labeling profile needs it because adding a
+label to a pull request is gated by `pull-requests` (not `issues`) for a GitHub
+App. Issues write permission is limited to the weekly and `maintenance-labeling`
+profiles' idempotent label operations and the existing repository creation/setup
+profiles' repository label configuration.
 
 The `e2e-lifecycle` profile intentionally omits a repository list because the generated
 repository does not exist when its token is resolved. Use it only with the Bootstrap E2E Admin

--- a/docs/github-app-trust-boundaries.md
+++ b/docs/github-app-trust-boundaries.md
@@ -63,9 +63,10 @@ Environment and set `BOOTSTRAP_MAINTENANCE_WRITER_APP_CLIENT_ID` and
 the `BOOTSTRAP_MAINTENANCE_WRITER_APP_PRIVATE_KEY` Environment secret. These names remain stable;
 the Environment identifies which deployment is authorized to use them.
 The same Writer App may use the narrower `maintenance-labeling` profile for
-the pull-request classifier; that profile grants only `issues: write` and
-`pull_requests: read` to apply lifecycle labels to trusted Dependabot and
-release-please PRs.
+the pull-request classifier; that profile grants `issues: write` and
+`pull_requests: write` to apply lifecycle labels to trusted Dependabot and
+release-please PRs (labelling a pull request is gated by the `pull_requests`
+scope for a GitHub App).
 Do not commit keys, include them in workflow inputs, print them, or reuse an
 E2E key in production. The production Reviewer key is a distinct secret from
 the Writer key and the E2E key. Client IDs may be non-secret configuration, but


### PR DESCRIPTION
## Problem

The **Classify trusted automation PR** check fails on every release-please PR
(e.g. #96):

```
gh: Resource not accessible by integration (HTTP 403)
POST /repos/aydabd/github-bootstrap/issues/96/labels
```

`classify-maintenance-pr.yml` labels the PR with the Maintenance Writer App
token resolved under `permission_profile: maintenance-labeling`, which grants
`issues: write` + `pull-requests: **read**`. Adding a label to a **pull
request** — even via the `/issues/{n}/labels` endpoint — requires the GitHub
App **`pull_requests: write`** permission; `issues: write` only covers real
issues.

Weekly-tooling PRs never hit this: `validate-maintenance-pr.sh` doesn't
classify the Writer-App bot as eligible, so classify short-circuits and the
weekly workflow labels the PR itself with a `pull-requests: write` token.
Release-please PRs are the only ones that run the label-POST path.

Knock-on effect: without the `automation: maintenance` / `automation:
validating` labels, `validate-maintenance-merge.sh` rejects the PR, so the
Reviewer App never approves or enables auto-merge.

## Fix

Move `maintenance-labeling` into the write branch of the `permission-pull-requests`
expression in `.github/actions/resolve-gh-token/action.yml` (`write` implies
`read`). `workflow-approval` stays `read`.

## Validation

- [x] `bash scripts/run-contract-tests.sh` (incl. `test-app-auth-contract.sh`)
- [x] `actionlint` + `yamllint` (repo configs)

Signed-off-by: Aydin.A <ayd.abd@gmail.com>