### PR TITLE
feat: run release-please as the Writer App and flag major releases

### DIFF
--- a/.github/actions/resolve-gh-token/action.yml
+++ b/.github/actions/resolve-gh-token/action.yml
@@ -55,7 +55,7 @@ runs:
       run: |
         set -euo pipefail
         case "$PERMISSION_PROFILE" in
-          repository-creation|repository-setup|repository-cleanup|weekly-tooling|maintenance-labeling|workflow-approval|maintenance-review|e2e-lifecycle) ;;
+          repository-creation|repository-setup|repository-cleanup|weekly-tooling|maintenance-labeling|workflow-approval|maintenance-review|release-please|e2e-lifecycle) ;;
           *) echo "::error::Unsupported GitHub App permission profile '$PERMISSION_PROFILE'." >&2; exit 1 ;;
         esac
         if [ "$PERMISSION_PROFILE" != "repository-creation" ] && [ "$PERMISSION_PROFILE" != "e2e-lifecycle" ] && [ -z "$REPOSITORIES" ]; then
@@ -130,10 +130,10 @@ runs:
         repositories: ${{ inputs.repositories }}
         permission-administration: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'repository-cleanup' || inputs.permission_profile == 'e2e-lifecycle') && 'write' || '' }}
         permission-actions: ${{ inputs.permission_profile == 'workflow-approval' && 'write' || '' }}
-        permission-contents: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'weekly-tooling') && 'write' || '' }}
+        permission-contents: ${{ (inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup' || inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'release-please') && 'write' || '' }}
         permission-issues: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-labeling' || inputs.permission_profile == 'repository-creation' || inputs.permission_profile == 'repository-setup') && 'write' || '' }}
         permission-organization-administration: ${{ inputs.permission_profile == 'repository-creation' && 'write' || '' }}
-        permission-pull-requests: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-review' || inputs.permission_profile == 'maintenance-labeling') && 'write' || inputs.permission_profile == 'workflow-approval' && 'read' || '' }}
+        permission-pull-requests: ${{ (inputs.permission_profile == 'weekly-tooling' || inputs.permission_profile == 'maintenance-review' || inputs.permission_profile == 'maintenance-labeling' || inputs.permission_profile == 'release-please') && 'write' || inputs.permission_profile == 'workflow-approval' && 'read' || '' }}
         permission-workflows: ${{ inputs.permission_profile == 'weekly-tooling' && 'write' || '' }}
 
     - name: Finalize token output

--- a/.github/workflows/classify-maintenance-pr.yml
+++ b/.github/workflows/classify-maintenance-pr.yml
@@ -34,6 +34,7 @@ jobs:
             .github/actions/resolve-gh-token/action.yml
             scripts/github-setup/gh-common.sh
             scripts/github-setup/validate-app-auth.sh
+            .release-please-manifest.json
 
       - name: Resolve Writer App token
         id: resolve-token
@@ -85,6 +86,22 @@ jobs:
           labels=("automation: maintenance" "automation: validating")
           if [ "$classification" = "dependabot" ]; then
             labels+=(dependencies)
+          fi
+
+          # A major release-please bump must clear generated-repository E2E before
+          # it can merge; validate-maintenance-safety.sh enforces that whenever the
+          # "automation: breaking" label is present.
+          if [ "$classification" = "release-please" ]; then
+            pr_title="$(jq -r '.title' "$pr_file")"
+            new_major="$(printf '%s\n' "$pr_title" | sed -n 's/.*release \([0-9][0-9]*\)\.[0-9][0-9]*\.[0-9][0-9]*.*/\1/p')"
+            # The root package is keyed "." in release-please-config.json; read it
+            # explicitly rather than relying on manifest entry order.
+            current_version="$(jq -r '."." // "0.0.0"' .release-please-manifest.json)"
+            current_major="${current_version%%.*}"
+            if [ -n "$new_major" ] && [ "$new_major" -gt "${current_major:-0}" ]; then
+              labels+=("automation: breaking")
+              echo "Release $pr_title raises the major version from $current_version; marking as breaking."
+            fi
           fi
 
           label_args=()

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,6 +2,12 @@
 # Breaking changes use a `feat!` commit and `BREAKING CHANGE:` footer.
 # Uses Google's release-please to create release PRs based on conventional commits
 # See: https://github.com/googleapis/release-please
+#
+# release-please runs with a Maintenance Writer App installation token, not the
+# default GITHUB_TOKEN. GitHub does not trigger workflows from GITHUB_TOKEN
+# events, so a release PR opened with it never fires the classify / maintenance
+# safety / reviewer chain and cannot auto-merge. The App identity restores those
+# triggers.
 name: Release Please
 
 on:
@@ -10,17 +16,57 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
+  pull-requests: read
 
 jobs:
   release-please:
     name: Release Please
     runs-on: ubuntu-latest
-
+    environment: production-maintenance
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
+      - name: Check out token resolver
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
+        with:
+          persist-credentials: false
+          ref: main
+          sparse-checkout: |
+            .github/actions/resolve-gh-token/action.yml
+            scripts/github-setup/gh-common.sh
+            scripts/github-setup/validate-app-auth.sh
+
+      - name: Resolve Writer App token
+        id: resolve-token
+        uses: ./.github/actions/resolve-gh-token
+        with:
+          client_id: ${{ vars.BOOTSTRAP_MAINTENANCE_WRITER_APP_CLIENT_ID }}
+          app_private_key: ${{ secrets.BOOTSTRAP_MAINTENANCE_WRITER_APP_PRIVATE_KEY }}
+          app_owner: ${{ github.repository_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: release-please
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Verify resolved App identity
+        env:
+          APP_SLUG: ${{ steps.resolve-token.outputs.app_slug }}
+          EXPECTED_APP_SLUG: ${{ vars.BOOTSTRAP_MAINTENANCE_WRITER_APP_SLUG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "$APP_SLUG" ] || { echo "Writer App slug was not resolved" >&2; exit 1; }
+          [ -n "$EXPECTED_APP_SLUG" ] || { echo "Expected Writer App slug is not configured" >&2; exit 1; }
+          [ "$APP_SLUG" = "$EXPECTED_APP_SLUG" ] || { echo "Resolved App is not the configured Writer" >&2; exit 1; }
+
       - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
+          token: ${{ steps.resolve-token.outputs.token }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json

--- a/scripts/github-setup/test-app-auth-contract.sh
+++ b/scripts/github-setup/test-app-auth-contract.sh
@@ -65,6 +65,18 @@ assert_contains "github.event.workflow_run.pull_requests[0].number" "$merge_work
 assert_contains "pull_request_target:" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "permission_profile: maintenance-labeling" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
 assert_contains "Verify Writer App installation" "$repo_root/.github/workflows/classify-maintenance-pr.yml"
+assert_contains 'automation: breaking' "$repo_root/.github/workflows/classify-maintenance-pr.yml"
+
+# release-please must run under the Writer App identity, otherwise its release
+# PRs are opened with GITHUB_TOKEN and never trigger the maintenance automation.
+release_workflow="$repo_root/.github/workflows/release-please.yml"
+assert_contains "release-please" "$resolver"
+assert_contains "permission_profile == 'release-please'" "$resolver"
+assert_contains "permission_profile: release-please" "$release_workflow"
+assert_contains "uses: ./.github/actions/resolve-gh-token" "$release_workflow"
+assert_contains "token: \${{ steps.resolve-token.outputs.token }}" "$release_workflow"
+assert_contains "environment: production-maintenance" "$release_workflow"
+assert_not_contains "\${{ secrets.GITHUB_TOKEN }}" "$release_workflow"
 assert_contains "Verify Maintenance Writer installation access" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "/installation/repositories" "$repo_root/.github/workflows/weekly-tooling-updates.yml"
 assert_contains "gh api --paginate --slurp /installation/repositories" "$repo_root/.github/workflows/weekly-tooling-updates.yml"


### PR DESCRIPTION
## Problem

`googleapis/release-please-action` runs with the default `GITHUB_TOKEN`. GitHub
does not trigger workflows from `GITHUB_TOKEN` events, so the release PR it opens
(e.g. #96) never fired `Classify` / `Maintenance safety` / the Reviewer App, its
`pull_request` checks sat at `action_required`, and it could not auto-merge.

## Changes

### 1. release-please runs as the Maintenance Writer App
- New `release-please` permission profile in `resolve-gh-token`
  (`contents: write` + `pull-requests: write`, added to the profile `case`).
- `release-please.yml` now runs under `environment: production-maintenance`,
  resolves a Writer App installation token, verifies the App slug, and passes
  `token:` to `release-please-action`.
- Result: release PRs carry the App identity → CI + the classify → safety →
  reviewer → squash-auto-merge chain all trigger normally.

### 2. Major releases are gated on E2E
- `classify-maintenance-pr.yml` adds **`automation: breaking`** when a
  release-please PR raises the major version (compares the `release X.Y.Z` title
  against `.release-please-manifest.json`).
- `validate-maintenance-safety.sh` **already** requires a passing
  `test-generated-repository-e2e` run for the exact head SHA whenever
  `automation: breaking` is present — so a major release cannot auto-merge until
  E2E is green. Minor/patch releases auto-merge with the standard gates.

## Follow-up

Nothing auto-dispatches `test-generated-repository-e2e.yml` yet (it is
`workflow_dispatch`-only). Until that lands (tracked under #117), a major
release will block on "E2E missing" until the E2E run is kicked off manually
with the E2E App credentials. This PR makes major releases **fail-safe** (no
auto-merge without E2E), not fully hands-off.

## Validation

- [x] `bash scripts/run-contract-tests.sh` (incl. `test-app-auth-contract.sh`)
- [x] `actionlint` + `yamllint` (repo configs)
- [x] `go test ./tools/internal/workflowcontract/...`

Signed-off-by: Aydin.A <ayd.abd@gmail.com>

## Issue references

- Part of the still-open umbrella **#112** (verified maintenance PR automation with fail-closed review gates).
- **Closes #123** (*Migrate weekly tooling, Dependabot, and release-please automation*) — its release-please acceptance criteria (lifecycle labels preserved/extended, `action_required` runs approved only when eligible, Copilot + E2E gates honored, auto-merge only after Reviewer App approval) were never actually met for release PRs; this PR delivers that leg.
- Partially addresses **#117** (*E2E against the exact PR head*): adds the `automation: breaking` trigger that feeds the existing head-SHA E2E gate, but does **not** auto-dispatch the E2E run — that remains open work.
- Extends **#115** (*structured risk classification / release-style labels*) to major release PRs.

`Refs #112`
`Closes #123`


