### PR TITLE
fix: classify Writer-App release PRs and wait for checks before merge

### DIFF
--- a/.github/workflows/classify-maintenance-pr.yml
+++ b/.github/workflows/classify-maintenance-pr.yml
@@ -73,6 +73,7 @@ jobs:
           GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           FULL_REPOSITORY: ${{ github.repository }}
+          WRITER_APP_SLUG: ${{ vars.BOOTSTRAP_MAINTENANCE_WRITER_APP_SLUG }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/merge-maintenance-pr.yml
+++ b/.github/workflows/merge-maintenance-pr.yml
@@ -95,7 +95,32 @@ jobs:
               "$WRITER_APP_SLUG" "$REVIEWER_APP_SLUG" "$require_reviewer_approval"
           }
 
-          validate_state
+          # Maintenance safety completes almost immediately on PR open, well
+          # before the required checks finish, so this run is often triggered
+          # while `quality` is still pending. Wait for the required checks to
+          # settle before deciding; a later trigger handles anything still
+          # unresolved after the window.
+          wait_for_required_checks() {
+            local attempt pending
+            for attempt in $(seq 1 45); do
+              gh pr checks "$PR_NUMBER" --required --json state \
+                > "$tmp_dir/checks.json" 2>/dev/null || true
+              pending="$(jq -r '[.[] | select(.state == "PENDING" or .state == "QUEUED" or .state == "IN_PROGRESS")] | length' \
+                "$tmp_dir/checks.json" 2>/dev/null || echo 1)"
+              [ "${pending:-1}" = "0" ] && return 0
+              sleep 20
+            done
+            return 1
+          }
+
+          wait_for_required_checks || {
+            echo "required checks did not settle within the wait window; deferring to the next trigger" >&2
+            exit 0
+          }
+          if ! validate_state; then
+            echo "maintenance merge preconditions are not met; not enabling auto-merge" >&2
+            exit 0
+          fi
           reviewer_login="${REVIEWER_APP_SLUG}[bot]"
           if ! jq -e --arg reviewer_login "$reviewer_login" \
               'any(.[]?; .user.login == $reviewer_login and .state == "APPROVED")' \

--- a/scripts/github-setup/test-maintenance-pr-contract.sh
+++ b/scripts/github-setup/test-maintenance-pr-contract.sh
@@ -12,6 +12,9 @@ EOF
 cat > "$tmp_dir/release-please.json" << 'EOF'
 {"state":"open","draft":false,"user":{"login":"release-please[bot]"},"head":{"repo":{"full_name":"acme/project"}},"base":{"ref":"main","repo":{"full_name":"acme/project"}},"labels":[{"name":"autorelease: pending"}]}
 EOF
+cat > "$tmp_dir/writer-release.json" << 'EOF'
+{"state":"open","draft":false,"user":{"login":"acme-maintenance-writer[bot]"},"head":{"repo":{"full_name":"acme/project"}},"base":{"ref":"main","repo":{"full_name":"acme/project"}},"labels":[{"name":"autorelease: pending"}]}
+EOF
 
 expected_dependabot="dependabot"
 actual_dependabot="$(FULL_REPOSITORY=acme/project "$validator" "$tmp_dir/dependabot.json")"
@@ -20,6 +23,18 @@ actual_dependabot="$(FULL_REPOSITORY=acme/project "$validator" "$tmp_dir/dependa
 expected_release="release-please"
 actual_release="$(FULL_REPOSITORY=acme/project "$validator" "$tmp_dir/release-please.json")"
 [ "$actual_release" = "$expected_release" ]
+
+# release-please runs as the Maintenance Writer App: its PR is authored by
+# "<writer-app-slug>[bot]" and must classify as release-please when the slug is
+# supplied, but not otherwise.
+actual_writer="$(FULL_REPOSITORY=acme/project WRITER_APP_SLUG=acme-maintenance-writer \
+    "$validator" "$tmp_dir/writer-release.json")"
+[ "$actual_writer" = "release-please" ]
+
+if FULL_REPOSITORY=acme/project "$validator" "$tmp_dir/writer-release.json"; then
+    echo "validator accepted a writer-app release PR without WRITER_APP_SLUG" >&2
+    exit 1
+fi
 
 for mutation in fork closed draft author release-label base; do
     case "$mutation" in

--- a/scripts/github-setup/validate-maintenance-pr.sh
+++ b/scripts/github-setup/validate-maintenance-pr.sh
@@ -3,19 +3,28 @@ set -euo pipefail
 
 pr_file="${1:-}"
 full_repository="${FULL_REPOSITORY:-}"
+# release-please runs under the Maintenance Writer App (see release-please.yml),
+# so its release PR is authored by "<writer-app-slug>[bot]" rather than
+# "release-please[bot]". Accept that identity too when it carries the
+# "autorelease: pending" label.
+writer_app_slug="${WRITER_APP_SLUG:-}"
 
 if [ -z "$pr_file" ] || [ ! -s "$pr_file" ] || [ -z "$full_repository" ]; then
     echo "maintenance PR validation inputs are incomplete" >&2
     exit 1
 fi
 
-classification="$(jq -r --arg full_repository "$full_repository" '
+classification="$(jq -r \
+    --arg full_repository "$full_repository" \
+    --arg writer_bot "${writer_app_slug:+${writer_app_slug}[bot]}" '
     if .state != "open" then ""
     elif .draft == true then ""
     elif .base.ref != "main" then ""
     elif .base.repo.full_name != $full_repository or .head.repo.full_name != $full_repository then ""
     elif .user.login == "dependabot[bot]" then "dependabot"
-    elif (.user.login == "release-please[bot]" or .user.login == "github-actions[bot]") and
+    elif (.user.login == "release-please[bot]"
+            or .user.login == "github-actions[bot]"
+            or ($writer_bot != "" and .user.login == $writer_bot)) and
         any(.labels[]?; .name == "autorelease: pending") then "release-please"
     else ""
     end


### PR DESCRIPTION
## Problem (PR #175 doesn't auto-merge)

After #174, release-please runs under the **Maintenance Writer App**, so its
release PR (#175) is authored by `repository-maintenance-writer[bot]`, not
`release-please[bot]`.

1. **`validate-maintenance-pr.sh` doesn't recognize that identity** → `Classify`
   ran but applied no labels → `#175` never got `automation: maintenance` /
   `automation: validating` → `validate-maintenance-merge.sh` rejects it → the
   Reviewer App never approves or enables auto-merge.
2. **`merge-maintenance-pr` fires too early.** `Maintenance safety` completes on
   PR open, before `quality` finishes, so the merge job ran while checks were
   `PENDING` and failed with *"required checks are pending, failed, stale, or
   missing"*. Correctly-timed re-runs of `Maintenance safety` often carry no PR
   context, so it never retried successfully.

## Fix

- `validate-maintenance-pr.sh` accepts `<WRITER_APP_SLUG>[bot]` as a
  release-please author when `autorelease: pending` is present;
  `classify-maintenance-pr.yml` passes `WRITER_APP_SLUG`.
  Verified against real PR #175 JSON: `release-please` with the slug, rejected
  without it.
- `merge-maintenance-pr.yml` waits (~15 min, 20s poll) for the required checks
  to settle before validating, and **defers** (clean exit) instead of failing
  when they haven't — a later trigger picks it up.

## Validation

- [x] `bash scripts/github-setup/test-maintenance-pr-contract.sh` (new
      Writer-App fixtures: classifies with the slug, rejected without it)
- [x] `bash scripts/run-contract-tests.sh`
- [x] `shellcheck`, `actionlint`, `yamllint` (repo configs)
- [x] dry-run against live PR #175 JSON

`Refs #112 #123`

Signed-off-by: Aydin.A <ayd.abd@gmail.com>