### PR TITLE
fix: skip the Copilot review gate for bot-authored maintenance PRs

### DIFF
--- a/scripts/github-setup/test-copilot-review-contract.sh
+++ b/scripts/github-setup/test-copilot-review-contract.sh
@@ -24,6 +24,13 @@ cat > "$tmp_dir/no-request.json" << 'EOF'
 EOF
 "$validator" "$tmp_dir/no-request.json" "$tmp_dir/reviews.json" "$tmp_dir/threads.json" ""
 
+# Copilot does not review bot-authored PRs; the gate must skip them rather than
+# block forever on a review that will never arrive.
+cat > "$tmp_dir/bot-pr.json" << 'EOF'
+{"number":9,"head":{"sha":"current-sha"},"user":{"login":"repository-maintenance-writer[bot]"},"requested_reviewers":[{"login":"copilot-pull-request-reviewer[bot]"}]}
+EOF
+"$validator" "$tmp_dir/bot-pr.json" "$tmp_dir/empty-reviews.json" "$tmp_dir/threads.json" "copilot-pull-request-reviewer[bot]"
+
 if "$validator" "$tmp_dir/no-request.json" "$tmp_dir/empty-reviews.json" "$tmp_dir/threads.json" "copilot-pull-request-reviewer[bot]"; then
     echo "configured Copilot review gate was bypassed" >&2
     exit 1

--- a/scripts/github-setup/validate-copilot-review.sh
+++ b/scripts/github-setup/validate-copilot-review.sh
@@ -11,6 +11,19 @@ if ! [ -s "$pr_file" ] || ! [ -s "$reviews_file" ] || ! [ -s "$threads_file" ]; 
     exit 1
 fi
 
+# GitHub Copilot code review does not review pull requests opened by a GitHub
+# App or bot, so a Copilot review can never appear on a trusted-automation
+# maintenance PR (Dependabot, or release-please running under the Writer App).
+# Skip the gate for those; the required checks, the breaking-change E2E gate,
+# and the separate Reviewer App approval still apply.
+pr_author="$(jq -r '.user.login // ""' "$pr_file")"
+case "$pr_author" in
+    *"[bot]")
+        echo "pull request author $pr_author is a bot; Copilot review is not applicable"
+        exit 0
+        ;;
+esac
+
 requested_login="$(jq -r '
     [.requested_reviewers[]?.login // empty | select(test("copilot"; "i"))] | first // empty
     ' "$pr_file")"


### PR DESCRIPTION
## Problem

`Maintenance safety` fails on every release-please PR (#96, #175, #179) with:

```
Copilot review is missing for the current pull request head
```

**GitHub Copilot code review does not review pull requests opened by a GitHub
App or bot.** #178 (a human PR) got a Copilot review; #96 / #175 / #179 (bot
PRs) have **zero** reviews ever. So `validate-copilot-review.sh`'s requirement —
a `COMMENTED` Copilot review whose `commit_id` matches the head — can never be
satisfied for a release-please PR (now authored by `repository-maintenance-writer[bot]`
after #174) or a Dependabot PR. The auto-merge chain stalls there.

## Fix

`validate-copilot-review.sh` skips the Copilot requirement when the PR author
ends in `[bot]`. Everything else still gates the merge:

- required status checks (`quality`, commit policy, providers, CodeQL)
- the `automation: breaking` -> generated-repo E2E gate for major releases
- the separate Reviewer App approval (`merge-maintenance-pr.yml`)

Verified against live PR #179 JSON: the validator now exits 0.

## Validation

- [x] `bash scripts/github-setup/test-copilot-review-contract.sh` (new bot-author fixture)
- [x] `bash scripts/run-contract-tests.sh`
- [x] `shellcheck`, `shfmt`

`Refs #112 #123`

Signed-off-by: Aydin.A <ayd.abd@gmail.com>