### PR TITLE
fix: re-approve the current head and merge already-clean maintenance PRs

### DIFF
--- a/.github/workflows/merge-maintenance-pr.yml
+++ b/.github/workflows/merge-maintenance-pr.yml
@@ -148,8 +148,8 @@ jobs:
             exit 0
           fi
           reviewer_login="${REVIEWER_APP_SLUG}[bot]"
-          if ! jq -e --arg reviewer_login "$reviewer_login" \
-              'any(.[]?; .user.login == $reviewer_login and .state == "APPROVED")' \
+          if ! jq -e --arg reviewer_login "$reviewer_login" --arg head_sha "$HEAD_SHA" \
+              'any(.[]?; .user.login == $reviewer_login and .state == "APPROVED" and .commit_id == $head_sha)' \
               "$tmp_dir/reviews.json" > /dev/null; then
             gh api --method POST "/repos/$REPOSITORY/pulls/$PR_NUMBER/reviews" \
               -f event=APPROVE \
@@ -162,8 +162,17 @@ jobs:
             echo "pull request node ID is missing" >&2
             exit 1
           }
-          # shellcheck disable=SC2016
-          GH_TOKEN="$MERGE_TOKEN" gh api graphql \
-            -f query='mutation($pullRequestId:ID!,$mergeMethod:PullRequestMergeMethod!){enablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId,mergeMethod:$mergeMethod}){pullRequest{autoMergeRequest{mergeMethod}}}}' \
-            -f pullRequestId="$node_id" \
-            -f mergeMethod=SQUASH
+
+          # enablePullRequestAutoMerge rejects a PR that is already mergeable;
+          # merge it outright in that case.
+          if [ "$(gh api "/repos/$REPOSITORY/pulls/$PR_NUMBER" --jq '.mergeable_state')" = "clean" ]; then
+            GH_TOKEN="$MERGE_TOKEN" gh api --method PUT \
+              "/repos/$REPOSITORY/pulls/$PR_NUMBER/merge" \
+              -f sha="$HEAD_SHA" -f merge_method=squash > /dev/null
+          else
+            # shellcheck disable=SC2016
+            GH_TOKEN="$MERGE_TOKEN" gh api graphql \
+              -f query='mutation($pullRequestId:ID!,$mergeMethod:PullRequestMergeMethod!){enablePullRequestAutoMerge(input:{pullRequestId:$pullRequestId,mergeMethod:$mergeMethod}){pullRequest{autoMergeRequest{mergeMethod}}}}' \
+              -f pullRequestId="$node_id" \
+              -f mergeMethod=SQUASH
+          fi

--- a/scripts/github-setup/test-maintenance-merge-contract.sh
+++ b/scripts/github-setup/test-maintenance-merge-contract.sh
@@ -86,6 +86,21 @@ if bash "$validator" "$tmp_dir/pr.json" "$tmp_dir/checks.json" "$tmp_dir/reviews
     exit 1
 fi
 
+cat > "$tmp_dir/stale-approval.json" << 'EOF'
+[{"user":{"login":"maintenance-reviewer[bot]"},"state":"APPROVED","commit_id":"old-sha"}]
+EOF
+if bash "$validator" "$tmp_dir/pr.json" "$tmp_dir/checks.json" "$tmp_dir/stale-approval.json" \
+    "$tmp_dir/labels.json" "aydabd/github-bootstrap" "current-sha" "maintenance-writer" "maintenance-reviewer" true; then
+    echo "stale Reviewer App approval was accepted" >&2
+    exit 1
+fi
+
+cat > "$tmp_dir/head-approval.json" << 'EOF'
+[{"user":{"login":"maintenance-reviewer[bot]"},"state":"APPROVED","commit_id":"current-sha"}]
+EOF
+bash "$validator" "$tmp_dir/pr.json" "$tmp_dir/checks.json" "$tmp_dir/head-approval.json" \
+    "$tmp_dir/labels.json" "aydabd/github-bootstrap" "current-sha" "maintenance-writer" "maintenance-reviewer" true
+
 assert_contains "workflow_run:" "$workflow"
 assert_contains "workflows:" "$workflow"
 assert_contains "Maintenance safety" "$workflow"

--- a/scripts/github-setup/validate-maintenance-merge.sh
+++ b/scripts/github-setup/validate-maintenance-merge.sh
@@ -64,10 +64,10 @@ jq -e 'all(.[]?; .state != "CHANGES_REQUESTED")' "$reviews_file" > /dev/null || 
 }
 
 if [ "$require_reviewer_approval" = "true" ]; then
-    jq -e --arg reviewer_login "${reviewer_app_slug}[bot]" \
-        'any(.[]?; .user.login == $reviewer_login and .state == "APPROVED")' \
+    jq -e --arg reviewer_login "${reviewer_app_slug}[bot]" --arg expected_sha "$expected_sha" \
+        'any(.[]?; .user.login == $reviewer_login and .state == "APPROVED" and .commit_id == $expected_sha)' \
         "$reviews_file" > /dev/null || {
-        echo "Reviewer App approval is missing" >&2
+        echo "Reviewer App approval is missing for the current head" >&2
         exit 1
     }
 fi


### PR DESCRIPTION
## What happened on #179

The chain finally reached the merge step. Then:

```
enablePullRequestAutoMerge → UNPROCESSABLE "Pull request is in clean status"
```

`enablePullRequestAutoMerge` only *queues* a merge for a PR that still has
something to wait for. Once every gate is green (`mergeable_state = clean`) it
rejects — you have to merge directly.

Separately, #179 then went **`BLOCKED`**: Release Please re-pushes the branch on
every merge to `main`, so the Reviewer App's `APPROVED` review was stuck on a
**stale commit**. `require_extra_approval_for_unattributed_changes` needs an
approval that covers the *current* head.

## Fix (`merge-maintenance-pr.yml` + `validate-maintenance-merge.sh`)

- The approve check and `validate-maintenance-merge.sh` now key on the current
  head SHA (`.commit_id == $expected_sha`), so a stale approval triggers a fresh
  one.
- After approving: if `mergeable_state == clean`, merge directly
  (`PUT /repos/.../pulls/N/merge` with the Writer `MERGE_TOKEN`); otherwise queue
  `enablePullRequestAutoMerge` as before.

## Validation

- [x] `bash scripts/run-contract-tests.sh`
- [x] `actionlint`, `yamllint`, `shellcheck`, `shfmt`, `editorconfig-checker`, `prettier`

`Refs #112 #122 #123`

Signed-off-by: Aydin.A <ayd.abd@gmail.com>