### PR TITLE
fix: auto-dispatch generated-repo E2E for breaking maintenance PRs

### DIFF
--- a/.github/workflows/dispatch-maintenance-e2e.yml
+++ b/.github/workflows/dispatch-maintenance-e2e.yml
@@ -1,0 +1,112 @@
+name: Dispatch Maintenance E2E
+
+# Major/breaking maintenance PRs carry the "automation: breaking" label, and
+# validate-maintenance-safety.sh then requires a passing generated-repository
+# E2E run for the exact PR head SHA before the PR can merge. That E2E workflow
+# is workflow_dispatch-only, so this workflow supplies the missing trigger:
+# whenever a maintenance PR is labelled breaking (or its head moves while the
+# label is present) it dispatches Test Generated Repository E2E against the PR
+# head branch with the credentialed E2E inputs, keeping the path hands-off.
+
+on:
+  pull_request_target:
+    types: [labeled, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+# Serialize dispatch attempts per PR so a labeled+synchronize race cannot both
+# pass the "already dispatched?" check and start duplicate E2E runs.
+concurrency:
+  group: dispatch-maintenance-e2e-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  dispatch:
+    name: Dispatch generated-repository E2E for breaking maintenance PRs
+    if: >-
+      github.event.pull_request.state == 'open' &&
+      github.event.pull_request.base.ref == 'main' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(github.event.pull_request.labels.*.name, 'automation: maintenance') &&
+      contains(github.event.pull_request.labels.*.name, 'automation: breaking')
+    runs-on: ubuntu-24.04
+    environment: production-maintenance
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout validation helpers
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        env:
+          GIT_CONFIG_COUNT: 1
+          GIT_CONFIG_KEY_0: init.defaultBranch
+          GIT_CONFIG_VALUE_0: main
+        with:
+          persist-credentials: false
+          ref: main
+          sparse-checkout: |
+            .github/actions/resolve-gh-token/action.yml
+            scripts/github-setup/gh-common.sh
+            scripts/github-setup/validate-app-auth.sh
+
+      - name: Resolve Reviewer App token
+        id: resolve-token
+        uses: ./.github/actions/resolve-gh-token
+        with:
+          client_id: ${{ vars.BOOTSTRAP_REVIEWER_APP_CLIENT_ID }}
+          app_private_key: ${{ secrets.BOOTSTRAP_REVIEWER_APP_PRIVATE_KEY }}
+          app_owner: ${{ github.repository_owner }}
+          target_owner: ${{ github.repository_owner }}
+          permission_profile: workflow-approval
+          repositories: ${{ github.event.repository.name }}
+
+      - name: Verify resolved Reviewer App identity
+        env:
+          APP_SLUG: ${{ steps.resolve-token.outputs.app_slug }}
+          EXPECTED_APP_SLUG: ${{ vars.BOOTSTRAP_MAINTENANCE_REVIEWER_APP_SLUG }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "$APP_SLUG" ] || { echo "Reviewer App slug was not resolved" >&2; exit 1; }
+          [ -n "$EXPECTED_APP_SLUG" ] || { echo "Expected maintenance Reviewer App slug is not configured" >&2; exit 1; }
+          [ "$APP_SLUG" = "$EXPECTED_APP_SLUG" ] || { echo "Resolved App is not the configured maintenance Reviewer" >&2; exit 1; }
+
+      - name: Dispatch generated-repository E2E against the PR head
+        env:
+          GH_TOKEN: ${{ steps.resolve-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PROVISIONER_APP_CLIENT_ID: ${{ vars.BOOTSTRAP_PROVISIONER_APP_CLIENT_ID }}
+          E2E_APP_OWNER: ${{ github.repository_owner }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          [ -n "$PROVISIONER_APP_CLIENT_ID" ] || { echo "Provisioner App client ID is not configured" >&2; exit 1; }
+
+          pr_file="$RUNNER_TEMP/pull-request.json"
+          gh api "/repos/$REPOSITORY/pulls/$PR_NUMBER" > "$pr_file"
+          head_ref="$(jq -r '.head.ref // empty' "$pr_file")"
+          head_sha="$(jq -r '.head.sha // empty' "$pr_file")"
+          [ -n "$head_ref" ] || { echo "could not resolve the pull request head branch" >&2; exit 1; }
+          [[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]] || { echo "could not resolve a 40-character head SHA" >&2; exit 1; }
+
+          # A re-label or a repeated synchronize must not stack duplicate E2E
+          # runs; skip when a run for this exact head SHA already exists.
+          existing="$(gh api \
+            "/repos/$REPOSITORY/actions/workflows/test-generated-repository-e2e.yml/runs?head_sha=$head_sha&per_page=1" \
+            --jq '.total_count')"
+          if [ "${existing:-0}" -gt 0 ]; then
+            echo "Generated-repository E2E already dispatched for $head_sha; nothing to do."
+            exit 0
+          fi
+
+          # Dispatch against the PR head branch so the resulting run's own
+          # head_sha is the PR head; maintenance safety correlates the E2E run to
+          # the PR by that SHA. head_sha pins the internal creation dispatch.
+          gh workflow run test-generated-repository-e2e.yml --repo "$REPOSITORY" --ref "$head_ref" \
+            -f head_sha="$head_sha" \
+            -f client_id="$PROVISIONER_APP_CLIENT_ID" \
+            -f app_owner="$E2E_APP_OWNER"
+          echo "Dispatched Test Generated Repository E2E for PR #$PR_NUMBER at $head_sha ($head_ref)."

--- a/.github/workflows/maintenance-safety.yml
+++ b/.github/workflows/maintenance-safety.yml
@@ -34,7 +34,9 @@ jobs:
     name: Maintenance safety
     if: |
       github.event_name != 'workflow_run' ||
-      github.event.workflow_run.pull_requests[0].number
+      github.event.workflow_run.pull_requests[0].number ||
+      (github.event.workflow_run.name == 'Test Generated Repository E2E' &&
+      github.event.workflow_run.head_branch != 'main')
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout validation helpers
@@ -56,6 +58,7 @@ jobs:
           COPILOT_REVIEWER_LOGIN: ${{ vars.BOOTSTRAP_COPILOT_REVIEWER_LOGIN }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.event.inputs.head_sha || github.event.client_payload.head_sha }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.workflow_run.pull_requests[0].number || github.event.inputs.pr_number || github.event.client_payload.pr_number }}
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         shell: bash
         run: |
           set -euo pipefail
@@ -65,6 +68,23 @@ jobs:
           trap cleanup EXIT
 
           [ -n "$HEAD_SHA" ] || { echo "maintenance safety head SHA is missing" >&2; exit 1; }
+
+          # A dispatched Test Generated Repository E2E run carries no
+          # pull_requests[0]; recover the PR from its head branch so completing
+          # the E2E gate re-evaluates safety without a manual nudge.
+          if [ -z "$PR_NUMBER" ] && [ -n "$HEAD_BRANCH" ] && [ "$HEAD_BRANCH" != "main" ]; then
+            PR_NUMBER="$(gh api --method GET "repos/$GITHUB_REPOSITORY/pulls" \
+              -f head="${GITHUB_REPOSITORY%%/*}:$HEAD_BRANCH" -f base=main -f state=open \
+              --jq '.[0].number // empty')"
+          fi
+
+          # A routine or manual E2E run with no open maintenance PR is not a
+          # gate failure; there is simply nothing to validate.
+          if [ -z "$PR_NUMBER" ] && [ "${GITHUB_EVENT_NAME:-}" = "workflow_run" ]; then
+            echo "no open maintenance PR for this run; nothing to validate."
+            exit 0
+          fi
+
           [ -n "$PR_NUMBER" ] || { echo "maintenance safety pull request number is missing" >&2; exit 1; }
           [ -n "$COPILOT_REVIEWER_LOGIN" ] || { echo "Copilot reviewer identity is not configured" >&2; exit 1; }
 

--- a/scripts/github-setup/test-dispatch-maintenance-e2e-contract.sh
+++ b/scripts/github-setup/test-dispatch-maintenance-e2e-contract.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# The assertions below are literal workflow substrings, not shell to expand.
+# shellcheck disable=SC2016
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+workflow="$script_dir/../../.github/workflows/dispatch-maintenance-e2e.yml"
+
+[ -f "$workflow" ] || {
+    echo "dispatch-maintenance-e2e workflow is missing: $workflow" >&2
+    exit 1
+}
+
+assert_contains() {
+    grep -Fq -- "$1" "$workflow" || {
+        echo "dispatch-maintenance-e2e workflow is missing expected substring: $1" >&2
+        exit 1
+    }
+}
+
+assert_absent() {
+    if grep -Fq -- "$1" "$workflow"; then
+        echo "dispatch-maintenance-e2e workflow must not contain: $1" >&2
+        exit 1
+    fi
+}
+
+# Trigger: a maintenance PR gaining the breaking label, or its head moving while
+# the label is present.
+assert_contains "pull_request_target:"
+assert_contains "types: [labeled, synchronize]"
+
+# Fail-closed gate: both labels required, and the head must live in this repo so
+# a fork PR can never drive a credentialed dispatch.
+assert_contains "contains(github.event.pull_request.labels.*.name, 'automation: maintenance')"
+assert_contains "contains(github.event.pull_request.labels.*.name, 'automation: breaking')"
+assert_contains "github.event.pull_request.head.repo.full_name == github.repository"
+assert_contains "github.event.pull_request.base.ref == 'main'"
+
+# The dispatch endpoint needs actions:write, which only the Reviewer App's
+# workflow-approval profile carries; the default token stays read-only.
+assert_contains "environment: production-maintenance"
+assert_contains "permission_profile: workflow-approval"
+assert_contains "BOOTSTRAP_REVIEWER_APP_PRIVATE_KEY"
+assert_contains "BOOTSTRAP_MAINTENANCE_REVIEWER_APP_SLUG"
+assert_contains "Resolved App is not the configured maintenance Reviewer"
+assert_absent "actions: write"
+
+# Dispatch Test Generated Repository E2E against the PR head branch so the run's
+# own head_sha is the PR head, and pin the internal creation dispatch with
+# head_sha. client_id/app_owner come from configuration, never literals.
+assert_contains "gh workflow run test-generated-repository-e2e.yml"
+assert_contains '--ref "$head_ref"'
+assert_contains '-f head_sha="$head_sha"'
+assert_contains '-f client_id="$PROVISIONER_APP_CLIENT_ID"'
+assert_contains '-f app_owner="$E2E_APP_OWNER"'
+assert_contains "vars.BOOTSTRAP_PROVISIONER_APP_CLIENT_ID"
+assert_contains '[[ "$head_sha" =~ ^[0-9a-fA-F]{40}$ ]]'
+
+# A re-label or repeated synchronize must not stack duplicate E2E runs: a
+# per-PR concurrency group serializes attempts, and the run-count check is the
+# second guard.
+assert_contains "concurrency:"
+assert_contains "group: dispatch-maintenance-e2e-\${{ github.event.pull_request.number }}"
+assert_contains 'runs?head_sha=$head_sha&per_page=1'
+assert_contains ".total_count"
+assert_contains 'already dispatched for $head_sha; nothing to do.'
+
+echo "Dispatch maintenance E2E contract passed."

--- a/scripts/github-setup/test-maintenance-safety-contract.sh
+++ b/scripts/github-setup/test-maintenance-safety-contract.sh
@@ -75,6 +75,17 @@ grep -Fq "actions/runs?head_sha=\$HEAD_SHA" "$workflow"
 grep -Fq 'all(. == "completed")' "$workflow"
 grep -Fq 'test-generated-repository-e2e.yml' "$workflow"
 grep -Fq 'BOOTSTRAP_COPILOT_REVIEWER_LOGIN' "$workflow"
+# A dispatched Test Generated Repository E2E run carries no pull_requests[0];
+# completing that gate must still re-evaluate safety via the PR head branch,
+# but only for non-main heads so routine/manual E2E runs do not spawn a failing
+# safety run, and a run with no open PR skips rather than fails.
+grep -Fq "github.event.workflow_run.name == 'Test Generated Repository E2E'" "$workflow"
+grep -Fq "github.event.workflow_run.head_branch != 'main'" "$workflow"
+grep -Fq 'no open maintenance PR for this run; nothing to validate.' "$workflow"
+# shellcheck disable=SC2016  # literal workflow substrings, not shell to expand
+grep -Fq 'HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}' "$workflow"
+# shellcheck disable=SC2016
+grep -Fq 'head="${GITHUB_REPOSITORY%%/*}:$HEAD_BRANCH"' "$workflow"
 grep -Fq 'required_status_checks' "$ruleset"
 grep -Fq 'Maintenance safety' "$ruleset"
 grep -Fq 'bypass_actors' "$ruleset"

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -21,6 +21,7 @@ contract_tests=(
     "$script_dir/github-setup/test-workflow-approval-contract.sh"
     "$script_dir/github-setup/test-copilot-review-contract.sh"
     "$script_dir/github-setup/test-maintenance-safety-contract.sh"
+    "$script_dir/github-setup/test-dispatch-maintenance-e2e-contract.sh"
     "$script_dir/github-setup/test-maintenance-merge-contract.sh"
     "$script_dir/github-setup/test-maintenance-pr-contract.sh"
     "$script_dir/github-setup/test-install-app-secrets-contract.sh"


### PR DESCRIPTION
## What

Closes #117 — the last piece needed to make major/breaking maintenance PRs merge hands-off.

`validate-maintenance-safety.sh` already requires a passing **Test Generated Repository E2E** run at the exact PR head SHA whenever `automation: breaking` is present, but that workflow is `workflow_dispatch`-only and nothing triggered it, so breaking PRs stalled until someone ran it by hand with the E2E App inputs.

## Changes

- **`.github/workflows/dispatch-maintenance-e2e.yml`** (new): on `pull_request_target: [labeled, synchronize]`, gated to open, same-repo, `main`-targeted PRs carrying both `automation: maintenance` and `automation: breaking`. Runs in `production-maintenance`, resolves a **Reviewer App** token with the `workflow-approval` profile (the only one carrying `actions: write`), verifies the App slug, then dispatches the E2E workflow **against the PR head branch** with `head_sha`, the Provisioner `client_id`, and `app_owner`. De-dupes on the exact head SHA; ignores forks.
- **`.github/workflows/maintenance-safety.yml`**: a dispatched E2E run carries no `pull_requests[0]`, so allow the `workflow_run` completion of `Test Generated Repository E2E` to re-evaluate the gate, recovering the PR from the run's head branch via the REST head filter.
- Contract tests: new `test-dispatch-maintenance-e2e-contract.sh` (registered in `run-contract-tests.sh`); extended `test-maintenance-safety-contract.sh`.

## Trust boundary

No App added to `bypass_actors`. Dispatch uses the Reviewer App (`workflow-approval`, `actions: write` only). `client_id`/`app_owner` come from configuration, never literals; the private key stays a `production-maintenance` secret.

## Verification

- `bash scripts/run-contract-tests.sh` — all pass
- `actionlint`, `yamllint` (repo config), `shellcheck`, `prettier --check` — clean on changed files