### PR TITLE
fix: unblock Dependabot Actions PRs (commit body rule + template sync)

### DIFF
--- a/.github/actions/verify-conventional-commits/validate.sh
+++ b/.github/actions/verify-conventional-commits/validate.sh
@@ -2,16 +2,30 @@
 set -euo pipefail
 
 commits_file="$(mktemp)"
+messages_file="$(mktemp)"
+export messages_file
 trap 'rm -f "$commits_file" "$messages_file"' EXIT
+
 gh api --paginate --slurp \
     "/repos/$REPOSITORY/pulls/$PR_NUMBER/commits?per_page=100" \
     > "$commits_file"
 jq -e 'flatten | length > 0' "$commits_file" > /dev/null
 
-messages_file="$(mktemp)"
-export messages_file
-trap 'rm -f "$messages_file"' EXIT
-jq -jr 'flatten[] | .commit.message, "\u0000"' "$commits_file" > "$messages_file"
+# Trusted automation bots author machine-generated commits (for example
+# Dependabot's grouped update bodies) whose long reference lines trip the stock
+# Conventional Commits body rules even though their headlines are compliant. The
+# signed-off-by check exempts the same identities.
+jq -jr '
+    ["github-actions[bot]", "repository-maintenance-writer[bot]", "dependabot[bot]"] as $trusted_bots
+    | flatten[]
+    | (.author.login? // "") as $login
+    | select($trusted_bots | index($login) | not)
+    | .commit.message,"\u0000"' "$commits_file" > "$messages_file"
+
+if [ ! -s "$messages_file" ]; then
+    echo "All pull-request commits are authored by a trusted automation bot; commitlint not applicable."
+    exit 0
+fi
 
 if [ -n "$CONFIG_PATH" ]; then
     # shellcheck disable=SC2016

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,13 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
-    directory: "/" # Location of package manifests
+    # Update the live workflows and their templates/ mirrors together. The
+    # verify-* action files and commit-policy.yml must stay byte-identical
+    # between root and templates/ (scripts/check-github-workflow-assets.sh);
+    # bumping only "/" desynced them and failed every Actions update PR.
+    directories:
+      - "/"
+      - "/templates"
     schedule:
       interval: "weekly"
     cooldown:

--- a/templates/.github/actions/verify-conventional-commits/validate.sh
+++ b/templates/.github/actions/verify-conventional-commits/validate.sh
@@ -2,16 +2,30 @@
 set -euo pipefail
 
 commits_file="$(mktemp)"
+messages_file="$(mktemp)"
+export messages_file
 trap 'rm -f "$commits_file" "$messages_file"' EXIT
+
 gh api --paginate --slurp \
     "/repos/$REPOSITORY/pulls/$PR_NUMBER/commits?per_page=100" \
     > "$commits_file"
 jq -e 'flatten | length > 0' "$commits_file" > /dev/null
 
-messages_file="$(mktemp)"
-export messages_file
-trap 'rm -f "$messages_file"' EXIT
-jq -jr 'flatten[] | .commit.message, "\u0000"' "$commits_file" > "$messages_file"
+# Trusted automation bots author machine-generated commits (for example
+# Dependabot's grouped update bodies) whose long reference lines trip the stock
+# Conventional Commits body rules even though their headlines are compliant. The
+# signed-off-by check exempts the same identities.
+jq -jr '
+    ["github-actions[bot]", "repository-maintenance-writer[bot]", "dependabot[bot]"] as $trusted_bots
+    | flatten[]
+    | (.author.login? // "") as $login
+    | select($trusted_bots | index($login) | not)
+    | .commit.message,"\u0000"' "$commits_file" > "$messages_file"
+
+if [ ! -s "$messages_file" ]; then
+    echo "All pull-request commits are authored by a trusted automation bot; commitlint not applicable."
+    exit 0
+fi
 
 if [ -n "$CONFIG_PATH" ]; then
     # shellcheck disable=SC2016


### PR DESCRIPTION
## What

Two independent failures kept every Dependabot `github-actions` PR (e.g. #97) permanently red. Closes #97.

### 1. `Conventional commits` check — `body-max-line-length`

`.github/workflows/commit-policy.yml` invokes the shared `verify-conventional-commits` action **without a config path**, so it runs the stock `@commitlint/config-conventional`, whose `body-max-line-length: 100` rejects Dependabot's grouped commit body (the `[Commits](…/compare/<40hex>...<40hex>)` line is ~110 chars). The repo's `.commitlintrc.yml` has no body rule, and the `quality` job's own commitlint run passes — so the two disagreed.

**Fix:** exempt trusted automation bots (`dependabot[bot]`, `repository-maintenance-writer[bot]`, `github-actions[bot]`) from commitlint in `verify-conventional-commits/validate.sh`, mirroring how `verify-signed-off-by` already exempts the same identities. A PR whose commits are all bot-authored skips cleanly (`exit 0`).

### 2. `quality` check — root/template desync

`scripts/check-github-workflow-assets.sh` requires `.github/workflows/commit-policy.yml` and the `verify-*` action files to be **byte-identical** between root and `templates/`. Dependabot's `github-actions` entry only scanned `directory: "/"`, so an `actions/checkout` pin bump changed the root copy but not its `templates/` mirror → `OUT_OF_SYNC`.

**Fix:** switch that entry to `directories: ["/", "/templates"]` so grouped Actions updates bump both trees in one PR.

## Verification

- `shellcheck` / `yamllint` (repo config) / `prettier --check` — clean
- `scripts/check-github-workflow-assets.sh` — OK (root ≡ templates)
- `scripts/run-contract-tests.sh` — all pass
- jq filter tested against page-wrapped commit fixtures (bot-only → empty → skip; mixed → only human commits linted)

## Follow-up

After merge, `@dependabot rebase` on #97 so it regenerates against the new config (covering both directories) and re-runs with the fixed check.