### PR TITLE
build: auto-sync shared workflow assets

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,13 +7,7 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions" # See documentation for possible values
-    # Update the live workflows and their templates/ mirrors together. The
-    # verify-* action files and commit-policy.yml must stay byte-identical
-    # between root and templates/ (scripts/check-github-workflow-assets.sh);
-    # bumping only "/" desynced them and failed every Actions update PR.
-    directories:
-      - "/"
-      - "/templates"
+    directory: "/"
     schedule:
       interval: "weekly"
     cooldown:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -150,6 +150,22 @@ repos:
         pass_filenames: false
         files: '(^|/)(\.github/(skills|agents|ISSUE_TEMPLATE)|\.github/pull_request_template\.md|templates/)'
 
+      - id: sync-workflow-assets
+        name: sync shared workflow assets
+        entry: bash
+        args:
+          - -c
+          - |
+            if [ "${LINT_MODE:-fix}" = "check" ]; then
+              ./scripts/sync-workflow-assets.sh --check
+            else
+              ./scripts/sync-workflow-assets.sh
+            fi
+          - sync-workflow-assets
+        language: system
+        pass_filenames: false
+        files: '(^\.github/|^templates/\.github/)'
+
       - id: lint-actions
         name: actionlint and zizmor
         entry: ./scripts/lint-github-actions.sh

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -143,13 +143,6 @@ repos:
         pass_filenames: false
         files: '\.github/skills/|\.claude/skills/'
 
-      - id: github-workflow-assets
-        name: github workflow assets
-        entry: ./scripts/check-github-workflow-assets.sh
-        language: system
-        pass_filenames: false
-        files: '(^|/)(\.github/(skills|agents|ISSUE_TEMPLATE)|\.github/pull_request_template\.md|templates/)'
-
       - id: sync-workflow-assets
         name: sync shared workflow assets
         entry: bash
@@ -165,6 +158,13 @@ repos:
         language: system
         pass_filenames: false
         files: '(^\.github/|^templates/\.github/)'
+
+      - id: github-workflow-assets
+        name: github workflow assets
+        entry: ./scripts/check-github-workflow-assets.sh
+        language: system
+        pass_filenames: false
+        files: '(^|/)(\.github/(skills|agents|ISSUE_TEMPLATE)|\.github/pull_request_template\.md|templates/)'
 
       - id: lint-actions
         name: actionlint and zizmor

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -9,6 +9,7 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 contract_tests=(
     "$script_dir/test-action-lint-contract.sh"
     "$script_dir/test-quality-contract.sh"
+    "$script_dir/test-workflow-asset-sync-contract.sh"
     "$script_dir/test-precommit-sha-pins-contract.sh"
     "$script_dir/test-uv-python-tooling-contract.sh"
     "$script_dir/check-commit-policy-fixtures.sh"

--- a/scripts/sync-workflow-assets.sh
+++ b/scripts/sync-workflow-assets.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+root_dir="$(cd "$script_dir/.." && pwd)"
+
+shared_assets=(
+    ".github/workflows/commit-policy.yml"
+    ".github/actions/verify-conventional-commits/action.yml"
+    ".github/actions/verify-conventional-commits/validate.sh"
+    ".github/actions/verify-pull-request-title/action.yml"
+    ".github/actions/verify-pull-request-title/validate.sh"
+    ".github/actions/verify-signed-off-by/action.yml"
+)
+
+mode="${1:-sync}"
+case "$mode" in
+    sync|--check) ;;
+    *)
+        echo "Usage: $0 [--check]" >&2
+        exit 2
+        ;;
+esac
+
+errors=0
+for relative_path in "${shared_assets[@]}"; do
+    source_path="$root_dir/$relative_path"
+    template_path="$root_dir/templates/$relative_path"
+
+    if [ ! -s "$source_path" ]; then
+        echo "MISSING_OR_EMPTY: $source_path" >&2
+        errors=$((errors + 1))
+        continue
+    fi
+
+    if [ "$mode" = "--check" ]; then
+        if ! cmp -s "$source_path" "$template_path" 2> /dev/null; then
+            echo "OUT_OF_SYNC: $relative_path differs between root and templates" >&2
+            errors=$((errors + 1))
+        fi
+        continue
+    fi
+
+    mkdir -p "$(dirname "$template_path")"
+    cp "$source_path" "$template_path"
+    echo "SYNCED: $relative_path"
+done
+
+if [ "$errors" -ne 0 ]; then
+    if [ "$mode" = "--check" ]; then
+        echo "Workflow asset sync check failed." >&2
+    fi
+    exit 1
+fi
+
+if [ "$mode" = "--check" ]; then
+    echo "Workflow asset sync check passed."
+fi

--- a/scripts/sync-workflow-assets.sh
+++ b/scripts/sync-workflow-assets.sh
@@ -15,7 +15,7 @@ shared_assets=(
 
 mode="${1:-sync}"
 case "$mode" in
-    sync|--check) ;;
+    sync | --check) ;;
     *)
         echo "Usage: $0 [--check]" >&2
         exit 2

--- a/scripts/test-workflow-asset-sync-contract.sh
+++ b/scripts/test-workflow-asset-sync-contract.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+sync_script="$repo_root/scripts/sync-workflow-assets.sh"
+
+[ -x "$sync_script" ] || {
+    echo "workflow asset sync script must be executable" >&2
+    exit 1
+}
+
+grep -Fq 'sync-workflow-assets.sh --check' "$repo_root/.pre-commit-config.yaml" || {
+    echo "pre-commit must run the workflow asset sync check" >&2
+    exit 1
+}
+
+if grep -Fq '"/templates"' "$repo_root/.github/dependabot.yml"; then
+    echo "root Dependabot Actions config must not scan /templates" >&2
+    exit 1
+fi
+
+if grep -Fq '"/templates"' "$repo_root/templates/.github/dependabot.yml"; then
+    echo "template Dependabot Actions config must not scan /templates" >&2
+    exit 1
+fi
+
+"$sync_script" --check
+
+fixture_dir="$(mktemp -d)"
+trap 'rm -rf "$fixture_dir"' EXIT
+mkdir -p "$fixture_dir/scripts" "$fixture_dir/.github/workflows" "$fixture_dir/templates/.github/workflows"
+cp "$sync_script" "$fixture_dir/scripts/sync-workflow-assets.sh"
+chmod +x "$fixture_dir/scripts/sync-workflow-assets.sh"
+printf 'root version\n' > "$fixture_dir/.github/workflows/commit-policy.yml"
+printf 'template version\n' > "$fixture_dir/templates/.github/workflows/commit-policy.yml"
+for relative_path in \
+    ".github/actions/verify-conventional-commits/action.yml" \
+    ".github/actions/verify-conventional-commits/validate.sh" \
+    ".github/actions/verify-pull-request-title/action.yml" \
+    ".github/actions/verify-pull-request-title/validate.sh" \
+    ".github/actions/verify-signed-off-by/action.yml"; do
+    mkdir -p "$fixture_dir/$(dirname "$relative_path")" \
+        "$fixture_dir/templates/$(dirname "$relative_path")"
+    printf 'shared asset\n' > "$fixture_dir/$relative_path"
+    cp "$fixture_dir/$relative_path" "$fixture_dir/templates/$relative_path"
+done
+
+if "$fixture_dir/scripts/sync-workflow-assets.sh" --check; then
+    echo "sync check must fail for divergent fixture" >&2
+    exit 1
+fi
+
+"$fixture_dir/scripts/sync-workflow-assets.sh"
+cmp -s "$fixture_dir/.github/workflows/commit-policy.yml" \
+    "$fixture_dir/templates/.github/workflows/commit-policy.yml"
+
+echo "Workflow asset sync contract checks passed."

--- a/scripts/test-workflow-asset-sync-contract.sh
+++ b/scripts/test-workflow-asset-sync-contract.sh
@@ -14,12 +14,19 @@ grep -Fq 'sync-workflow-assets.sh --check' "$repo_root/.pre-commit-config.yaml" 
     exit 1
 }
 
-if grep -Fq '"/templates"' "$repo_root/.github/dependabot.yml"; then
+sync_hook_line="$(grep -n '^      - id: sync-workflow-assets$' "$repo_root/.pre-commit-config.yaml" | cut -d: -f1)"
+parity_hook_line="$(grep -n '^      - id: github-workflow-assets$' "$repo_root/.pre-commit-config.yaml" | cut -d: -f1)"
+if [ "$sync_hook_line" -ge "$parity_hook_line" ]; then
+    echo "sync hook must run before the workflow asset parity check" >&2
+    exit 1
+fi
+
+if grep -Fq '/templates' "$repo_root/.github/dependabot.yml"; then
     echo "root Dependabot Actions config must not scan /templates" >&2
     exit 1
 fi
 
-if grep -Fq '"/templates"' "$repo_root/templates/.github/dependabot.yml"; then
+if grep -Fq '/templates' "$repo_root/templates/.github/dependabot.yml"; then
     echo "template Dependabot Actions config must not scan /templates" >&2
     exit 1
 fi


### PR DESCRIPTION
## Summary

Add automatic synchronization for shared GitHub workflow assets so root-only Dependabot Actions updates keep the `templates/` mirrors aligned. Remove the ineffective `/templates` Dependabot directory configuration.

## Related Issue

Closes #191

## Validation

- [x] Focused workflow asset sync contract test passes
- [ ] Full deterministic suite is blocked by an existing local HTTP-server test that the sandbox cannot run
- [ ] Full lint and security checks are blocked by unavailable micromamba/DNS setup
- [x] Generated-file/template parity is verified with `sync-workflow-assets.sh --check`
- [x] Shellcheck, YAML parsing, and `git diff --check` pass

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer