### PR TITLE
build: lock conda environments

### DIFF
--- a/.github/actions/configure-provider-tooling-files/action.yml
+++ b/.github/actions/configure-provider-tooling-files/action.yml
@@ -1,7 +1,7 @@
 ---
 name: Configure Provider Tooling Files
 description: >-
-  Copy language/provider-specific tooling files (Makefile, environment.yml,
+  Copy language/provider-specific tooling files (Makefile, environment.yml, conda-lock.yml,
   mise.toml, and scripts) into the generated repository and
   substitute repository placeholders.
 
@@ -71,8 +71,9 @@ runs:
         fi
 
         cp "$PROVIDER_DIR/Makefile" "$REPO_DIR/Makefile"
-        rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/mise.toml"
+        rm -f "$REPO_DIR/environment.yml" "$REPO_DIR/conda-lock.yml" "$REPO_DIR/mise.toml"
         [ -f "$PROVIDER_DIR/environment.yml" ] && cp "$PROVIDER_DIR/environment.yml" "$REPO_DIR/environment.yml"
+        [ -f "$PROVIDER_DIR/conda-lock.yml" ] && cp "$PROVIDER_DIR/conda-lock.yml" "$REPO_DIR/conda-lock.yml"
         [ -f "$PROVIDER_DIR/mise.toml" ] && cp "$PROVIDER_DIR/mise.toml" "$REPO_DIR/mise.toml"
         # uv is the single source of truth for Python tooling across every provider.
         cp "$TEMPLATE_DIR/pyproject.toml" "$REPO_DIR/pyproject.toml"
@@ -91,6 +92,21 @@ runs:
           sed -i "s/{{NODE_VERSION}}/$NODE_VERSION/g" "$REPO_DIR/environment.yml"
           sed -i "s/{{GO_VERSION}}/$GO_VERSION/g" "$REPO_DIR/environment.yml"
           sed -i "s/{{JAVA_VERSION}}/$JAVA_VERSION/g" "$REPO_DIR/environment.yml"
+
+          lock_tmp_dir="$(mktemp -d)"
+          trap 'rm -rf "$lock_tmp_dir"' EXIT
+          for lock_platform in linux-64 osx-64 osx-arm64; do
+            "$GITHUB_WORKSPACE/scripts/generate-conda-lock.sh" \
+              "$REPO_DIR/environment.yml" \
+              "$lock_tmp_dir/$lock_platform.yml" \
+              "$lock_platform"
+          done
+          uv run --no-project --with pyyaml==6.0.3 python \
+            "$GITHUB_WORKSPACE/scripts/merge-conda-locks.py" \
+            "$REPO_DIR/conda-lock.yml" \
+            "$lock_tmp_dir/linux-64.yml" \
+            "$lock_tmp_dir/osx-64.yml" \
+            "$lock_tmp_dir/osx-arm64.yml"
         fi
         if [ -f "$REPO_DIR/mise.toml" ]; then
           sed -i "s/{{REPOSITORY_NAME}}/$REPO_NAME/g" "$REPO_DIR/mise.toml"

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -1,0 +1,102 @@
+name: Verify Conda Lockfiles
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  solve:
+    name: Solve ${{ matrix.platform }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-64
+            runner: ubuntu-24.04
+          - platform: osx-64
+            runner: macos-26-intel
+          - platform: osx-arm64
+            runner: macos-26
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+      - name: Generate native lockfiles
+        shell: bash
+        env:
+          PLATFORM: ${{ matrix.platform }}
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/locks"
+          while IFS= read -r environment_file; do
+            relative="${environment_file#./}"
+            if [ "$relative" = "environment.yml" ]; then
+              concrete="$RUNNER_TEMP/environment.yml"
+              cp "$environment_file" "$concrete"
+              output="locks/environment.yml"
+            else
+              language="$(printf '%s' "$relative" | cut -d/ -f3)"
+              concrete="$RUNNER_TEMP/${language}-environment.yml"
+              cp "$environment_file" "$concrete"
+              sed -i.bak \
+                -e 's/{{REPOSITORY_NAME}}/conda-lock-verification/g' \
+                -e 's/{{PYTHON_VERSION}}/3.13/g' \
+                -e 's/{{NODE_VERSION}}/24/g' \
+                -e 's/{{GO_VERSION}}/1.26/g' \
+                -e 's/{{JAVA_VERSION}}/25/g' "$concrete"
+              output="locks/${language}-environment.yml"
+            fi
+            mkdir -p "$(dirname "$output")"
+            scripts/generate-conda-lock.sh "$concrete" "$output" "$PLATFORM"
+          done < <(find . -path '*/providers/micromamba/environment.yml' -type f | sort)
+      - name: Upload native lockfiles
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: conda-lock-${{ matrix.platform }}
+          path: locks
+          if-no-files-found: error
+
+  verify:
+    name: Verify merged lockfiles
+    needs: solve
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Download native lockfiles
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: conda-lock-*
+          path: native-locks
+          merge-multiple: false
+      - name: Merge and validate lockfiles
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p merged
+          for name in environment python golang typescript java; do
+            python3 scripts/merge-conda-locks.py \
+              "merged/${name}-conda-lock.yml" \
+              native-locks/conda-lock-linux-64/${name}-environment.yml \
+              native-locks/conda-lock-osx-64/${name}-environment.yml \
+              native-locks/conda-lock-osx-arm64/${name}-environment.yml
+          done
+          for lock in merged/*.yml; do
+            grep -Fq -- '- linux-64' "$lock"
+            grep -Fq -- '- osx-64' "$lock"
+            grep -Fq -- '- osx-arm64' "$lock"
+          done

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -40,7 +40,11 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/locks"
+          environment_files=(./environment.yml)
           while IFS= read -r environment_file; do
+            environment_files+=("$environment_file")
+          done < <(find templates/languages -path '*/providers/micromamba/environment.yml' -type f | sort)
+          for environment_file in "${environment_files[@]}"; do
             relative="${environment_file#./}"
             if [ "$relative" = "environment.yml" ]; then
               concrete="$RUNNER_TEMP/environment.yml"
@@ -60,7 +64,7 @@ jobs:
             fi
             mkdir -p "$(dirname "$output")"
             scripts/generate-conda-lock.sh "$concrete" "$output" "$PLATFORM"
-          done < <(find . -path '*/providers/micromamba/environment.yml' -type f | sort)
+          done
       - name: Upload native lockfiles
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
@@ -83,18 +87,22 @@ jobs:
           pattern: conda-lock-*
           path: native-locks
           merge-multiple: false
+      - name: Install PyYAML for lock merge
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
       - name: Merge and validate lockfiles
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p merged
-          for name in environment python golang typescript java; do
+          for name in environment agnostic python golang typescript java; do
             if [ "$name" = environment ]; then
               lock_name=environment.yml
             else
               lock_name="${name}-environment.yml"
             fi
-            python3 scripts/merge-conda-locks.py \
+            uv run --no-project --with pyyaml==6.0.3 python scripts/merge-conda-locks.py \
               "merged/${name}-conda-lock.yml" \
               "native-locks/conda-lock-linux-64/$lock_name" \
               "native-locks/conda-lock-osx-64/$lock_name" \

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -96,9 +96,9 @@ jobs:
             fi
             python3 scripts/merge-conda-locks.py \
               "merged/${name}-conda-lock.yml" \
-              "native-locks/conda-lock-linux-64/$lock_name" \
-              "native-locks/conda-lock-osx-64/$lock_name" \
-              "native-locks/conda-lock-osx-arm64/$lock_name"
+              "native-locks/conda-lock-linux-64/locks/$lock_name" \
+              "native-locks/conda-lock-osx-64/locks/$lock_name" \
+              "native-locks/conda-lock-osx-arm64/locks/$lock_name"
           done
           for lock in merged/*.yml; do
             grep -Fq -- '- linux-64' "$lock"

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -89,11 +89,16 @@ jobs:
           set -euo pipefail
           mkdir -p merged
           for name in environment python golang typescript java; do
+            if [ "$name" = environment ]; then
+              lock_name=environment.yml
+            else
+              lock_name="${name}-environment.yml"
+            fi
             python3 scripts/merge-conda-locks.py \
               "merged/${name}-conda-lock.yml" \
-              native-locks/conda-lock-linux-64/${name}-environment.yml \
-              native-locks/conda-lock-osx-64/${name}-environment.yml \
-              native-locks/conda-lock-osx-arm64/${name}-environment.yml
+              "native-locks/conda-lock-linux-64/$lock_name" \
+              "native-locks/conda-lock-osx-64/$lock_name" \
+              "native-locks/conda-lock-osx-arm64/$lock_name"
           done
           for lock in merged/*.yml; do
             grep -Fq -- '- linux-64' "$lock"

--- a/.github/workflows/conda-lock.yml
+++ b/.github/workflows/conda-lock.yml
@@ -96,9 +96,9 @@ jobs:
             fi
             python3 scripts/merge-conda-locks.py \
               "merged/${name}-conda-lock.yml" \
-              "native-locks/conda-lock-linux-64/locks/$lock_name" \
-              "native-locks/conda-lock-osx-64/locks/$lock_name" \
-              "native-locks/conda-lock-osx-arm64/locks/$lock_name"
+              "native-locks/conda-lock-linux-64/$lock_name" \
+              "native-locks/conda-lock-osx-64/$lock_name" \
+              "native-locks/conda-lock-osx-arm64/$lock_name"
           done
           for lock in merged/*.yml; do
             grep -Fq -- '- linux-64' "$lock"

--- a/.github/workflows/create-repository.yml
+++ b/.github/workflows/create-repository.yml
@@ -785,6 +785,11 @@ jobs:
           root_language: ${{ steps.validate-inputs.outputs.root_language }}
           languages: ${{ steps.validate-inputs.outputs.normalized_languages }}
 
+      - name: Set up uv for conda lock rendering
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
       - name: Configure provider tooling files
         uses: ./.github/actions/configure-provider-tooling-files
         with:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Setup micromamba environment
         uses: mamba-org/setup-micromamba@f457c30a868e4760d3a6fcea5f25dc655b8edf39 # v3.2.1
         with:
-          environment-file: environment.yml
+          environment-file: conda-lock.yml
           environment-name: github-bootstrap
           cache-environment: true
           cache-downloads: true

--- a/.github/workflows/terraform-create-repository.yml
+++ b/.github/workflows/terraform-create-repository.yml
@@ -693,6 +693,11 @@ jobs:
           root_language: ${{ steps.validate-inputs.outputs.root_language }}
           languages: ${{ steps.validate-inputs.outputs.normalized_languages }}
 
+      - name: Set up uv for conda lock rendering
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+        with:
+          enable-cache: true
+
       - name: Configure provider tooling files
         uses: ./.github/actions/configure-provider-tooling-files
         with:

--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -107,6 +107,10 @@ jobs:
           ENV_MANAGER=micromamba make tooling-update-repo
           ENV_MANAGER=micromamba make tooling-update-templates
 
+      - name: Regenerate conda lockfiles
+        shell: bash
+        run: scripts/regenerate-conda-locks.sh
+
       - name: Normalize generated files
         shell: bash
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -98,6 +98,7 @@ repos:
         entry: yamllint
         args: [--config-file, .github/linters/.yaml-lint.yml]
         language: system
+        exclude: '(^|/)conda-lock\.yml$'
         types: [yaml]
 
       # ── Markdown: linting (markdownlint-cli) ──────────────────────────────
@@ -133,6 +134,7 @@ repos:
             fi
           - prettier
         language: system
+        exclude: '(^|/)conda-lock\.yml$'
         types_or: [json, yaml, markdown]
 
       # ── Skill parity: .claude/skills symlinks → .github/skills ─────────────

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 .git/
 node_modules/
 CHANGELOG.md
+**/conda-lock.yml
 templates/.github/workflows/codeql.yml

--- a/conda-lock-virtual-packages.yml
+++ b/conda-lock-virtual-packages.yml
@@ -1,0 +1,17 @@
+subdirs:
+  linux-64:
+    packages:
+      __unix: "0"
+      __linux: "5.10"
+      __archspec: "1 x86_64"
+      __glibc: "2.28"
+  osx-64:
+    packages:
+      __unix: "0"
+      __archspec: "1 x86_64"
+      __osx: "26.0"
+  osx-arm64:
+    packages:
+      __unix: "0"
+      __archspec: "1 arm64"
+      __osx: "26.0"

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -5,1992 +5,1992 @@ metadata:
     osx-64: a6d3602aa797de91de7558c7b6054dab59b9be8a1bcf4e013d29e974a9a3c7fe
     osx-arm64: bacbc76c476e4cd2504bbbc96ba08fc0b63be655dde3b8ead8071210c50669f2
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - environment.yml
+    - environment.yml
 package:
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 76f94c0e00d08432e003a7b54a1adf53
-    sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: go
-  version: 1.26.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _go_select: 2.3.0
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.6-he1b14cc_0.conda
-  hash:
-    md5: 52dcb117459204b262d596dfaa59276d
-    sha256: cd22e28d2b73a30c5f052b86f502352cb03e39c7f8133ac1a6f47d86e2aa0ae9
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: libabseil
-  version: '20260526.0'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
-  hash:
-    md5: 6983bfe8e09992014b9cf393769c7a84
-    sha256: 7bb3d495411b7059e85225aae500d84e7846a4bb02ebd77e4450200b20c180f0
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
-  hash:
-    md5: 5e92b8413fd1c8f8f3006f4661b12def
-    sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
-  hash:
-    md5: c22348a769bb072b6184eb6f7f05e4f2
-    sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=26.5.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h24b164e_0.conda
-  hash:
-    md5: b10d06a8e4a12f62c34615f6ac8c0746
-    sha256: cc219147f045c6089c3046334a6b9cc857add86dee5629288322a165def03e51
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 26.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libabseil: '*,>=20260526.0,<20260527.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.6.0-ha5cdc1e_1.conda
-  hash:
-    md5: d903d505831909e2ef5695bff7607f74
-    sha256: 498f165fa043485271a6a0e554daab74a31a02882e0223494bfb012a21aa1d3e
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=26.4.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-hdf27b9d_0.conda
-  hash:
-    md5: 80aad096113bc9b62c9d6b454ed474ac
-    sha256: f5c747c93a2e07b36826e47749c0ad10a2086eabdaa77f58c372da161fe88164
-  category: main
-  optional: false
-- name: python
-  version: 3.14.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=14'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.2,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-    python_abi: 3.14.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
-  hash:
-    md5: 9b6c336ef7195fbee1c10c09bfcf901b
-    sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.14'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
-  hash:
-    md5: 350d89b50d7de805abf2e63e29dee451
-    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 4c1913031a736507963a5fb938cefe85
-    sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
-  hash:
-    md5: b9e2e7fcf1926cedbdb216a6974d67e3
-    sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go
-  version: 1.26.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    _go_select: 2.3.0
-    libcxx: '>=21'
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.6-h489f395_0.conda
-  hash:
-    md5: c193ac372b4607ba21779e6c61908d9f
-    sha256: 8969f38d95fe6efa68b3c3b38403cad7ae42c115da2e3e5e588422e4bcd38dfa
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libabseil
-  version: '20260526.0'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h6e8c311_2.conda
-  hash:
-    md5: 02e11f8c54cef4f022bc1a086d5f7c2f
-    sha256: d077578fc3a684f7ad246f87622a3a9702d429dd14e690a1bbfc6644480ebb92
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-  hash:
-    md5: fb1dd570751271b86cb17aee0bc39c48
-    sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
-  hash:
-    md5: ca9281db8c52184ade04b615b2f3959d
-    sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
-  hash:
-    md5: eaabc48679544820bef810523a703bf0
-    sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
-  hash:
-    md5: b4b0db08caeeaf14d50ee200c9067725
-    sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=26.4.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-h6073398_0.conda
-  hash:
-    md5: 78567ced2073a52e7a23d5653a9abfe1
-    sha256: 3b790d06f7f068edef5223001224b2fb7ead9cde4698776860b124cdc3549af8
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 26.6.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libabseil: '*,>=20260526.0,<20260527.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-26.6.0-hb4a83e6_1.conda
-  hash:
-    md5: b6be28aba53d915c3b05b2fca0f939cd
-    sha256: ce4521b21ab42f39b864ee74382ec2e5e3fa7fdeeabb5c6adc15e50cf5f0a3e2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=26.4.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h99b04b3_0.conda
-  hash:
-    md5: e14692ebe7fe7a8fbab96621470e71ea
-    sha256: 2d1ddd235a15f1b38ee15e0d9beee9e0694b13cca477bbdbc487953ddf8309f6
-  category: main
-  optional: false
-- name: python
-  version: 3.14.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-    python_abi: 3.14.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-hb933c43_102_cp314.conda
-  hash:
-    md5: 8c2a3f8e3e9aaca5d8336deca3ba483b
-    sha256: 19e3a84df66b88348387113e2ffa5c5a5d244e15064dc02f805add29815934e2
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.14'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
-  hash:
-    md5: 350d89b50d7de805abf2e63e29dee451
-    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 79a39651abfce773c2948175d9b62986
-    sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
-  hash:
-    md5: a2d706b4a7d603524133037c34f7fb76
-    sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go
-  version: 1.26.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    _go_select: 2.3.0
-    libcxx: '>=21'
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.6-h8a7d722_0.conda
-  hash:
-    md5: ba712905af1b1a7c0020240031380979
-    sha256: aeb5a935c264f2a482ba68e1a52d97fba7eb0f8ddc3602862aa7ef900f6b6423
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libabseil
-  version: '20260526.0'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h4c27e2a_2.conda
-  hash:
-    md5: 2aa5e7dc7b5d218908effd2a8c70a8a8
-    sha256: d9c62dae9d8f5bebadf72fcf369c00cc353183cb2521f9fffbf4c2f70b58bef9
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-  hash:
-    md5: 408af8d9d5226ff45ff04756ff1aa91e
-    sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
-  hash:
-    md5: aa6c627acd0f5709d9c79bf708a7b81b
-    sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
-  hash:
-    md5: d54390644d893d50e739b19145aae45f
-    sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
-  hash:
-    md5: 0affff5130a421d11d4d77ffbb00dad7
-    sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=26.5.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-hb00f674_0.conda
-  hash:
-    md5: 0335130bfc11ceddf1a6a397c9f30817
-    sha256: 7ce00a4244295f69c2653f9fdeaa013291c34e055f487c5693b21fba42907685
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 26.6.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libabseil: '*,>=20260526.0,<20260527.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-26.6.0-h8d74fab_1.conda
-  hash:
-    md5: 9b23981d8d33d7f9b680d883db25a7fb
-    sha256: cf15a50c840ba5affc3099c440bce53a6d0e69f054fbf1bd2320b30668c8994a
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=26.4.0,<27.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-he13c965_0.conda
-  hash:
-    md5: c3545e847ab788906e0d3fbc27a92ffb
-    sha256: c62773af062d268ee080ffacf55295ad7d14bbd57108a66090669b289a65f393
-  category: main
-  optional: false
-- name: python
-  version: 3.14.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-    python_abi: 3.14.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
-  hash:
-    md5: 8da4ea285021110e2617f7538c386afc
-    sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.14'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
-  hash:
-    md5: 350d89b50d7de805abf2e63e29dee451
-    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 76f94c0e00d08432e003a7b54a1adf53
+      sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _go_select: 2.3.0
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.6-he1b14cc_0.conda
+    hash:
+      md5: 52dcb117459204b262d596dfaa59276d
+      sha256: cd22e28d2b73a30c5f052b86f502352cb03e39c7f8133ac1a6f47d86e2aa0ae9
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: libabseil
+    version: "20260526.0"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+    hash:
+      md5: 6983bfe8e09992014b9cf393769c7a84
+      sha256: 7bb3d495411b7059e85225aae500d84e7846a4bb02ebd77e4450200b20c180f0
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+    hash:
+      md5: 5e92b8413fd1c8f8f3006f4661b12def
+      sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+    hash:
+      md5: c22348a769bb072b6184eb6f7f05e4f2
+      sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=26.5.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h24b164e_0.conda
+    hash:
+      md5: b10d06a8e4a12f62c34615f6ac8c0746
+      sha256: cc219147f045c6089c3046334a6b9cc857add86dee5629288322a165def03e51
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 26.6.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libabseil: "*,>=20260526.0,<20260527.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.6.0-ha5cdc1e_1.conda
+    hash:
+      md5: d903d505831909e2ef5695bff7607f74
+      sha256: 498f165fa043485271a6a0e554daab74a31a02882e0223494bfb012a21aa1d3e
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=26.4.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-hdf27b9d_0.conda
+    hash:
+      md5: 80aad096113bc9b62c9d6b454ed474ac
+      sha256: f5c747c93a2e07b36826e47749c0ad10a2086eabdaa77f58c372da161fe88164
+    category: main
+    optional: false
+  - name: python
+    version: 3.14.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=14"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.2,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+      python_abi: 3.14.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+    hash:
+      md5: 9b6c336ef7195fbee1c10c09bfcf901b
+      sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.14"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+    hash:
+      md5: 350d89b50d7de805abf2e63e29dee451
+      sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 4c1913031a736507963a5fb938cefe85
+      sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      llvm-openmp: ">=9.0.1"
+    url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+    hash:
+      md5: b9e2e7fcf1926cedbdb216a6974d67e3
+      sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      _go_select: 2.3.0
+      libcxx: ">=21"
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.6-h489f395_0.conda
+    hash:
+      md5: c193ac372b4607ba21779e6c61908d9f
+      sha256: 8969f38d95fe6efa68b3c3b38403cad7ae42c115da2e3e5e588422e4bcd38dfa
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libabseil
+    version: "20260526.0"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h6e8c311_2.conda
+    hash:
+      md5: 02e11f8c54cef4f022bc1a086d5f7c2f
+      sha256: d077578fc3a684f7ad246f87622a3a9702d429dd14e690a1bbfc6644480ebb92
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      _openmp_mutex: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
+    hash:
+      md5: fb1dd570751271b86cb17aee0bc39c48
+      sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
+    hash:
+      md5: ca9281db8c52184ade04b615b2f3959d
+      sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
+    hash:
+      md5: eaabc48679544820bef810523a703bf0
+      sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: llvm-openmp
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
+    hash:
+      md5: b4b0db08caeeaf14d50ee200c9067725
+      sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=26.4.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-h6073398_0.conda
+    hash:
+      md5: 78567ced2073a52e7a23d5653a9abfe1
+      sha256: 3b790d06f7f068edef5223001224b2fb7ead9cde4698776860b124cdc3549af8
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 26.6.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libabseil: "*,>=20260526.0,<20260527.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-26.6.0-hb4a83e6_1.conda
+    hash:
+      md5: b6be28aba53d915c3b05b2fca0f939cd
+      sha256: ce4521b21ab42f39b864ee74382ec2e5e3fa7fdeeabb5c6adc15e50cf5f0a3e2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=26.4.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h99b04b3_0.conda
+    hash:
+      md5: e14692ebe7fe7a8fbab96621470e71ea
+      sha256: 2d1ddd235a15f1b38ee15e0d9beee9e0694b13cca477bbdbc487953ddf8309f6
+    category: main
+    optional: false
+  - name: python
+    version: 3.14.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+      python_abi: 3.14.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-hb933c43_102_cp314.conda
+    hash:
+      md5: 8c2a3f8e3e9aaca5d8336deca3ba483b
+      sha256: 19e3a84df66b88348387113e2ffa5c5a5d244e15064dc02f805add29815934e2
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.14"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+    hash:
+      md5: 350d89b50d7de805abf2e63e29dee451
+      sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 79a39651abfce773c2948175d9b62986
+      sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      llvm-openmp: ">=9.0.1"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
+    hash:
+      md5: a2d706b4a7d603524133037c34f7fb76
+      sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      _go_select: 2.3.0
+      libcxx: ">=21"
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.6-h8a7d722_0.conda
+    hash:
+      md5: ba712905af1b1a7c0020240031380979
+      sha256: aeb5a935c264f2a482ba68e1a52d97fba7eb0f8ddc3602862aa7ef900f6b6423
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libabseil
+    version: "20260526.0"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h4c27e2a_2.conda
+    hash:
+      md5: 2aa5e7dc7b5d218908effd2a8c70a8a8
+      sha256: d9c62dae9d8f5bebadf72fcf369c00cc353183cb2521f9fffbf4c2f70b58bef9
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      _openmp_mutex: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
+    hash:
+      md5: 408af8d9d5226ff45ff04756ff1aa91e
+      sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
+    hash:
+      md5: aa6c627acd0f5709d9c79bf708a7b81b
+      sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
+    hash:
+      md5: d54390644d893d50e739b19145aae45f
+      sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: llvm-openmp
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
+    hash:
+      md5: 0affff5130a421d11d4d77ffbb00dad7
+      sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=26.5.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-hb00f674_0.conda
+    hash:
+      md5: 0335130bfc11ceddf1a6a397c9f30817
+      sha256: 7ce00a4244295f69c2653f9fdeaa013291c34e055f487c5693b21fba42907685
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 26.6.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libabseil: "*,>=20260526.0,<20260527.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-26.6.0-h8d74fab_1.conda
+    hash:
+      md5: 9b23981d8d33d7f9b680d883db25a7fb
+      sha256: cf15a50c840ba5affc3099c440bce53a6d0e69f054fbf1bd2320b30668c8994a
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=26.4.0,<27.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-he13c965_0.conda
+    hash:
+      md5: c3545e847ab788906e0d3fbc27a92ffb
+      sha256: c62773af062d268ee080ffacf55295ad7d14bbd57108a66090669b289a65f393
+    category: main
+    optional: false
+  - name: python
+    version: 3.14.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+      python_abi: 3.14.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
+    hash:
+      md5: 8da4ea285021110e2617f7538c386afc
+      sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.14"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+    hash:
+      md5: 350d89b50d7de805abf2e63e29dee451
+      sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/conda-lock.yml
+++ b/conda-lock.yml
@@ -1,0 +1,1996 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: 3373a293f30913985f498608e1d30412d51c527cef5f41dcf6d2f32db207a2c9
+    osx-64: a6d3602aa797de91de7558c7b6054dab59b9be8a1bcf4e013d29e974a9a3c7fe
+    osx-arm64: bacbc76c476e4cd2504bbbc96ba08fc0b63be655dde3b8ead8071210c50669f2
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - environment.yml
+package:
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 76f94c0e00d08432e003a7b54a1adf53
+    sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: go
+  version: 1.26.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _go_select: 2.3.0
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.6-he1b14cc_0.conda
+  hash:
+    md5: 52dcb117459204b262d596dfaa59276d
+    sha256: cd22e28d2b73a30c5f052b86f502352cb03e39c7f8133ac1a6f47d86e2aa0ae9
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: libabseil
+  version: '20260526.0'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libabseil-20260526.0-cxx17_h0dc7533_2.conda
+  hash:
+    md5: 6983bfe8e09992014b9cf393769c7a84
+    sha256: 7bb3d495411b7059e85225aae500d84e7846a4bb02ebd77e4450200b20c180f0
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+  hash:
+    md5: 5e92b8413fd1c8f8f3006f4661b12def
+    sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+  hash:
+    md5: c22348a769bb072b6184eb6f7f05e4f2
+    sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=26.5.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h24b164e_0.conda
+  hash:
+    md5: b10d06a8e4a12f62c34615f6ac8c0746
+    sha256: cc219147f045c6089c3046334a6b9cc857add86dee5629288322a165def03e51
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 26.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-26.6.0-ha5cdc1e_1.conda
+  hash:
+    md5: d903d505831909e2ef5695bff7607f74
+    sha256: 498f165fa043485271a6a0e554daab74a31a02882e0223494bfb012a21aa1d3e
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=26.4.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-hdf27b9d_0.conda
+  hash:
+    md5: 80aad096113bc9b62c9d6b454ed474ac
+    sha256: f5c747c93a2e07b36826e47749c0ad10a2086eabdaa77f58c372da161fe88164
+  category: main
+  optional: false
+- name: python
+  version: 3.14.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=14'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.2,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+    python_abi: 3.14.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.14.6-h242f9ac_102_cp314.conda
+  hash:
+    md5: 9b6c336ef7195fbee1c10c09bfcf901b
+    sha256: f5ff5c1fac471dfed4fc4288856a63eb9d771e6042d9f70420d75b9f488400d8
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.14'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+  hash:
+    md5: 350d89b50d7de805abf2e63e29dee451
+    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 4c1913031a736507963a5fb938cefe85
+    sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+  hash:
+    md5: b9e2e7fcf1926cedbdb216a6974d67e3
+    sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go
+  version: 1.26.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    _go_select: 2.3.0
+    libcxx: '>=21'
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.6-h489f395_0.conda
+  hash:
+    md5: c193ac372b4607ba21779e6c61908d9f
+    sha256: 8969f38d95fe6efa68b3c3b38403cad7ae42c115da2e3e5e588422e4bcd38dfa
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libabseil
+  version: '20260526.0'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libabseil-20260526.0-cxx17_h6e8c311_2.conda
+  hash:
+    md5: 02e11f8c54cef4f022bc1a086d5f7c2f
+    sha256: d077578fc3a684f7ad246f87622a3a9702d429dd14e690a1bbfc6644480ebb92
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    _openmp_mutex: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
+  hash:
+    md5: fb1dd570751271b86cb17aee0bc39c48
+    sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
+  hash:
+    md5: ca9281db8c52184ade04b615b2f3959d
+    sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
+  hash:
+    md5: eaabc48679544820bef810523a703bf0
+    sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
+  hash:
+    md5: b4b0db08caeeaf14d50ee200c9067725
+    sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=26.4.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-h6073398_0.conda
+  hash:
+    md5: 78567ced2073a52e7a23d5653a9abfe1
+    sha256: 3b790d06f7f068edef5223001224b2fb7ead9cde4698776860b124cdc3549af8
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 26.6.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-26.6.0-hb4a83e6_1.conda
+  hash:
+    md5: b6be28aba53d915c3b05b2fca0f939cd
+    sha256: ce4521b21ab42f39b864ee74382ec2e5e3fa7fdeeabb5c6adc15e50cf5f0a3e2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=26.4.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h99b04b3_0.conda
+  hash:
+    md5: e14692ebe7fe7a8fbab96621470e71ea
+    sha256: 2d1ddd235a15f1b38ee15e0d9beee9e0694b13cca477bbdbc487953ddf8309f6
+  category: main
+  optional: false
+- name: python
+  version: 3.14.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+    python_abi: 3.14.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.14.6-hb933c43_102_cp314.conda
+  hash:
+    md5: 8c2a3f8e3e9aaca5d8336deca3ba483b
+    sha256: 19e3a84df66b88348387113e2ffa5c5a5d244e15064dc02f805add29815934e2
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.14'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+  hash:
+    md5: 350d89b50d7de805abf2e63e29dee451
+    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 79a39651abfce773c2948175d9b62986
+    sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
+  hash:
+    md5: a2d706b4a7d603524133037c34f7fb76
+    sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go
+  version: 1.26.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    _go_select: 2.3.0
+    libcxx: '>=21'
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.6-h8a7d722_0.conda
+  hash:
+    md5: ba712905af1b1a7c0020240031380979
+    sha256: aeb5a935c264f2a482ba68e1a52d97fba7eb0f8ddc3602862aa7ef900f6b6423
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libabseil
+  version: '20260526.0'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libabseil-20260526.0-cxx17_h4c27e2a_2.conda
+  hash:
+    md5: 2aa5e7dc7b5d218908effd2a8c70a8a8
+    sha256: d9c62dae9d8f5bebadf72fcf369c00cc353183cb2521f9fffbf4c2f70b58bef9
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    _openmp_mutex: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
+  hash:
+    md5: 408af8d9d5226ff45ff04756ff1aa91e
+    sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
+  hash:
+    md5: aa6c627acd0f5709d9c79bf708a7b81b
+    sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
+  hash:
+    md5: d54390644d893d50e739b19145aae45f
+    sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
+  hash:
+    md5: 0affff5130a421d11d4d77ffbb00dad7
+    sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=26.5.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-hb00f674_0.conda
+  hash:
+    md5: 0335130bfc11ceddf1a6a397c9f30817
+    sha256: 7ce00a4244295f69c2653f9fdeaa013291c34e055f487c5693b21fba42907685
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 26.6.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libabseil: '*,>=20260526.0,<20260527.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-26.6.0-h8d74fab_1.conda
+  hash:
+    md5: 9b23981d8d33d7f9b680d883db25a7fb
+    sha256: cf15a50c840ba5affc3099c440bce53a6d0e69f054fbf1bd2320b30668c8994a
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=26.4.0,<27.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-he13c965_0.conda
+  hash:
+    md5: c3545e847ab788906e0d3fbc27a92ffb
+    sha256: c62773af062d268ee080ffacf55295ad7d14bbd57108a66090669b289a65f393
+  category: main
+  optional: false
+- name: python
+  version: 3.14.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+    python_abi: 3.14.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.14.6-hf4d206d_102_cp314.conda
+  hash:
+    md5: 8da4ea285021110e2617f7538c386afc
+    sha256: 9767b5eee5cef50716708787bb3b4225d2a974bcd50653e856f9db5910a4b17e
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.14'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.14-9_cp314.conda
+  hash:
+    md5: 350d89b50d7de805abf2e63e29dee451
+    sha256: e7f8e965bbfb98e08feb2365cacdad8bb218fa5b5a0a2752f747287f425f213c
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/make/common.mk
+++ b/make/common.mk
@@ -24,7 +24,7 @@ INTERNAL_TARGETS := _install-hooks
 .PHONY: $(PUBLIC_TARGETS) $(INTERNAL_TARGETS)
 
 MAMBA_ENV  := github-bootstrap
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA ?= $(CURDIR)/.provider/bin/micromamba
 MISE ?= $(CURDIR)/.provider/bin/mise
 

--- a/scripts/generate-conda-lock.sh
+++ b/scripts/generate-conda-lock.sh
@@ -12,8 +12,11 @@ lock_file=$2
 platform=$3
 
 case "$platform" in
-    linux-64|osx-64|osx-arm64) ;;
-    *) echo "unsupported conda platform: $platform" >&2; exit 2 ;;
+    linux-64 | osx-64 | osx-arm64) ;;
+    *)
+        echo "unsupported conda platform: $platform" >&2
+        exit 2
+        ;;
 esac
 
 grep -Eq '^name: *[^"{][^[:space:]]*|^name: *"?[A-Za-z0-9_.-]+"?$' "$environment_file" || {
@@ -44,7 +47,7 @@ if [ "$lock_rc" -ne 0 ]; then
         exit "$lock_rc"
     }
     mamba_bin="$(command -v micromamba || command -v mamba)"
-    "$mamba_bin" create --dry-run --json -n conda-lock-validation -f "$lock_file" >/dev/null
+    "$mamba_bin" create --dry-run --json -n conda-lock-validation -f "$lock_file" > /dev/null
     grep -Fq "platform: $platform" "$lock_file" || {
         echo "conda-lock output is missing platform $platform" >&2
         exit 1

--- a/scripts/generate-conda-lock.sh
+++ b/scripts/generate-conda-lock.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 <environment.yml> <conda-lock.yml> <platform>" >&2
+    exit 2
+}
+
+[ "$#" -eq 3 ] || usage
+environment_file=$1
+lock_file=$2
+platform=$3
+
+case "$platform" in
+    linux-64|osx-64|osx-arm64) ;;
+    *) echo "unsupported conda platform: $platform" >&2; exit 2 ;;
+esac
+
+grep -Eq '^name: *[^"{][^[:space:]]*|^name: *"?[A-Za-z0-9_.-]+"?$' "$environment_file" || {
+    echo "environment file must have a concrete name before locking: $environment_file" >&2
+    exit 1
+}
+if grep -Eq '\{\{[A-Z0-9_]+\}\}' "$environment_file"; then
+    echo "environment file still contains template placeholders: $environment_file" >&2
+    exit 1
+fi
+
+mkdir -p "$(dirname "$lock_file")"
+lock_command=(uvx --from conda-lock==4.0.2 conda-lock lock --no-mamba --file "$environment_file" --platform "$platform")
+if [[ "$platform" == osx-* ]]; then
+    lock_command+=(--virtual-package-spec conda-lock-virtual-packages.yml)
+fi
+set +e
+"${lock_command[@]}" --lockfile "$lock_file" --strip-auth
+lock_rc=$?
+set -e
+
+# conda-lock 4.0.2 can return non-zero after writing a valid lock when mamba
+# rejects its synthetic virtual-package record. Never accept the file blindly:
+# mamba must still parse and validate the complete lockfile.
+if [ "$lock_rc" -ne 0 ]; then
+    [ -s "$lock_file" ] || {
+        echo "conda-lock failed without producing $lock_file" >&2
+        exit "$lock_rc"
+    }
+    mamba_bin="$(command -v micromamba || command -v mamba)"
+    "$mamba_bin" create --dry-run --json -n conda-lock-validation -f "$lock_file" >/dev/null
+    grep -Fq "platform: $platform" "$lock_file" || {
+        echo "conda-lock output is missing platform $platform" >&2
+        exit 1
+    }
+fi

--- a/scripts/merge-conda-locks.py
+++ b/scripts/merge-conda-locks.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Merge native single-platform conda-lock files deterministically."""
+from __future__ import annotations
+
+import pathlib
+import sys
+
+import yaml
+
+
+def main() -> int:
+    if len(sys.argv) < 3:
+        raise SystemExit("Usage: merge-conda-locks.py OUTPUT INPUT...")
+    output = pathlib.Path(sys.argv[1])
+    inputs = [pathlib.Path(value) for value in sys.argv[2:]]
+    documents = [yaml.safe_load(path.read_text()) for path in inputs]
+    first = documents[0]
+    packages: dict[tuple[str, str, str, str, str], dict] = {}
+    platforms: set[str] = set()
+    content_hash: dict[str, str] = {}
+    for document in documents:
+        if document.get("version") != first.get("version"):
+            raise SystemExit("cannot merge lockfiles with different formats")
+        content_hash.update(document.get("metadata", {}).get("content_hash", {}))
+        for package in document.get("package", []):
+            platform = package.get("platform", "")
+            platforms.add(platform)
+            key = tuple(str(package.get(field, "")) for field in ("manager", "platform", "name", "version", "build"))
+            packages[key] = package
+    merged = dict(first)
+    merged["package"] = [packages[key] for key in sorted(packages)]
+    metadata = merged.setdefault("metadata", {})
+    metadata["content_hash"] = content_hash
+    metadata["platforms"] = sorted(platforms)
+    metadata["sources"] = ["environment.yml"]
+    output.write_text(yaml.safe_dump(merged, sort_keys=False, allow_unicode=False))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/regenerate-conda-locks.sh
+++ b/scripts/regenerate-conda-locks.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+generate_one() {
+    local environment_file=$1
+    local lock_file=$2
+    local language=$3
+    local temp_environment="$tmp_root/${language}-environment.yml"
+    cp "$environment_file" "$temp_environment"
+    if [ "$language" != root ]; then
+        sed -i \
+            -e 's/{{REPOSITORY_NAME}}/generated-repository/g' \
+            -e 's/{{PYTHON_VERSION}}/3.13/g' \
+            -e 's/{{NODE_VERSION}}/24/g' \
+            -e 's/{{GO_VERSION}}/1.26/g' \
+            -e 's/{{JAVA_VERSION}}/25/g' "$temp_environment"
+    fi
+    local lock_tmp="$tmp_root/$language"
+    mkdir -p "$lock_tmp"
+    for platform in linux-64 osx-64 osx-arm64; do
+        "$repo_root/scripts/generate-conda-lock.sh" \
+            "$temp_environment" "$lock_tmp/$platform.yml" "$platform"
+    done
+    uv run --no-project --with pyyaml==6.0.3 python \
+        "$repo_root/scripts/merge-conda-locks.py" "$lock_file" \
+        "$lock_tmp/linux-64.yml" "$lock_tmp/osx-64.yml" "$lock_tmp/osx-arm64.yml"
+}
+
+generate_one "$repo_root/environment.yml" "$repo_root/conda-lock.yml" root
+while IFS= read -r environment_file; do
+    language="$(printf '%s' "$environment_file" | cut -d/ -f3)"
+    generate_one "$environment_file" \
+        "$repo_root/templates/languages/$language/providers/micromamba/conda-lock.yml" \
+        "$language"
+done < <(find "$repo_root/templates/languages" -path '*/providers/micromamba/environment.yml' -type f | sort)

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -7,6 +7,8 @@ script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # test-local-setup-scripts.sh is deliberately excluded: it is a live E2E test
 # that requires an explicitly supplied repository and cleanup authorization.
 contract_tests=(
+    "$script_dir/test-conda-lock-contract.sh"
+    "$script_dir/test-conda-lock-workflow-contract.sh"
     "$script_dir/test-action-lint-contract.sh"
     "$script_dir/test-quality-contract.sh"
     "$script_dir/test-workflow-asset-sync-contract.sh"

--- a/scripts/test-conda-lock-contract.sh
+++ b/scripts/test-conda-lock-contract.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+required_platforms=(linux-64 osx-64 osx-arm64)
+
+environment_files=("$repo_root/environment.yml")
+while IFS= read -r environment_file; do
+    environment_files+=("$environment_file")
+done < <(find "$repo_root/templates/languages" -path '*/providers/micromamba/environment.yml' -type f | sort)
+
+for environment_file in "${environment_files[@]}"; do
+    lock_file="${environment_file%/*}/conda-lock.yml"
+    [ -f "$lock_file" ] || {
+        echo "missing conda lockfile for ${environment_file#"$repo_root/"}" >&2
+        exit 1
+    }
+    grep -Fq 'platforms:' "$lock_file" || {
+        echo "missing platforms declaration in ${lock_file#"$repo_root/"}" >&2
+        exit 1
+    }
+    for platform in "${required_platforms[@]}"; do
+        grep -Fq -- "- $platform" "$lock_file" || {
+            echo "missing $platform lock entries in ${lock_file#"$repo_root/"}" >&2
+            exit 1
+        }
+    done
+    if grep -Eq '^\s*pip\s*:' "$environment_file"; then
+        echo "pip section is not allowed in ${environment_file#"$repo_root/"}" >&2
+        exit 1
+    fi
+done
+
+echo "Conda lock contract checks passed."

--- a/scripts/test-conda-lock-workflow-contract.sh
+++ b/scripts/test-conda-lock-workflow-contract.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+workflow="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.github/workflows/conda-lock.yml"
+grep -Fq 'ubuntu-24.04' "$workflow"
+grep -Fq 'macos-26-intel' "$workflow"
+grep -Fq 'macos-26' "$workflow"
+grep -Fq 'conda-lock==4.0.2' "$(dirname "$workflow")/../../scripts/generate-conda-lock.sh"
+if grep -Eq 'macos-1[0-9]|macos-latest' "$workflow"; then
+    echo "workflow uses an older or floating macOS runner" >&2
+    exit 1
+fi
+grep -Fq 'merge-conda-locks.py' "$workflow"
+echo "Conda lock workflow contract checks passed."

--- a/scripts/test-conda-lock-workflow-contract.sh
+++ b/scripts/test-conda-lock-workflow-contract.sh
@@ -11,8 +11,8 @@ if grep -Eq 'macos-1[0-9]|macos-latest' "$workflow"; then
     exit 1
 fi
 grep -Fq 'merge-conda-locks.py' "$workflow"
-grep -Fq 'native-locks/conda-lock-linux-64/$lock_name' "$workflow"
-if grep -Fq 'native-locks/conda-lock-linux-64/locks/$lock_name' "$workflow"; then
+grep -Fq "native-locks/conda-lock-linux-64/\$lock_name" "$workflow"
+if grep -Fq "native-locks/conda-lock-linux-64/locks/\$lock_name" "$workflow"; then
     echo "workflow assumes upload-artifact preserves the source directory" >&2
     exit 1
 fi

--- a/scripts/test-conda-lock-workflow-contract.sh
+++ b/scripts/test-conda-lock-workflow-contract.sh
@@ -11,4 +11,9 @@ if grep -Eq 'macos-1[0-9]|macos-latest' "$workflow"; then
     exit 1
 fi
 grep -Fq 'merge-conda-locks.py' "$workflow"
+grep -Fq 'native-locks/conda-lock-linux-64/$lock_name' "$workflow"
+if grep -Fq 'native-locks/conda-lock-linux-64/locks/$lock_name' "$workflow"; then
+    echo "workflow assumes upload-artifact preserves the source directory" >&2
+    exit 1
+fi
 echo "Conda lock workflow contract checks passed."

--- a/scripts/test-conda-lock-workflow-contract.sh
+++ b/scripts/test-conda-lock-workflow-contract.sh
@@ -11,6 +11,9 @@ if grep -Eq 'macos-1[0-9]|macos-latest' "$workflow"; then
     exit 1
 fi
 grep -Fq 'merge-conda-locks.py' "$workflow"
+grep -Fq 'environment_files=(./environment.yml)' "$workflow"
+grep -Fq 'for name in environment agnostic python golang typescript java' "$workflow"
+grep -Fq 'uv run --no-project --with pyyaml==6.0.3 python' "$workflow"
 grep -Fq "native-locks/conda-lock-linux-64/\$lock_name" "$workflow"
 if grep -Fq "native-locks/conda-lock-linux-64/locks/\$lock_name" "$workflow"; then
     echo "workflow assumes upload-artifact preserves the source directory" >&2

--- a/templates/languages/agnostic/providers/micromamba/Makefile
+++ b/templates/languages/agnostic/providers/micromamba/Makefile
@@ -29,7 +29,7 @@ MAKEFLAGS += --no-builtin-rules
 # Configuration
 # =============================================================================
 MAMBA_ENV  := {{REPOSITORY_NAME}}
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA := $(CURDIR)/.provider/bin/micromamba
 
 # LINT_MODE: fix (default, local dev) or check (CI, no auto-fix)

--- a/templates/languages/agnostic/providers/micromamba/conda-lock.yml
+++ b/templates/languages/agnostic/providers/micromamba/conda-lock.yml
@@ -1,0 +1,1764 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: c09e630355ed05511eb38c30cdbfed3f2b85841d58b22bd6e174cf2cfcfed50f
+    osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
+    osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - ../tmp.DaUeAPrj0h
+package:
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+  hash:
+    md5: e64cd43bbd07afafbc458138e979c851
+    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+  hash:
+    md5: 2e632ce02d57623142f2e4b8ab725f2b
+    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+  hash:
+    md5: fd10c0e72a410d57f4c5073dbc4ec505
+    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+  hash:
+    md5: 52df3de33d8bed542df618f403fa5b85
+    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.3,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+  hash:
+    md5: 641613f2d89da811bc29fa4cde88ef20
+    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+  hash:
+    md5: 887123b5b70893ef32ec962b00625415
+    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+  hash:
+    md5: 2a60e3342ea849f65068573003279ec4
+    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+  hash:
+    md5: 96abedd31106b39ec30864f6fa695afc
+    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+  hash:
+    md5: 137339f92677a33a2500d3cd5361a654
+    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+  hash:
+    md5: 8cb4d8953ebe0460fd0d04157bc790f5
+    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+  hash:
+    md5: f45d325d3a8739b81d47a8288b6357e2
+    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+  hash:
+    md5: a57a8ea605573b733bb3d2010fbaf86d
+    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+  hash:
+    md5: c4c8e364e4031850bcd232c221792e1c
+    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+  hash:
+    md5: 9be48326058aa380b7400617e73d7da6
+    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+  hash:
+    md5: 4745cefb2d63de33e85b73cbae7ff9d2
+    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/templates/languages/agnostic/providers/micromamba/conda-lock.yml
+++ b/templates/languages/agnostic/providers/micromamba/conda-lock.yml
@@ -5,1760 +5,1760 @@ metadata:
     osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
     osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - ../tmp.DaUeAPrj0h
+    - ../tmp.DaUeAPrj0h
 package:
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
-  hash:
-    md5: e64cd43bbd07afafbc458138e979c851
-    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
-  hash:
-    md5: 2e632ce02d57623142f2e4b8ab725f2b
-    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
-  hash:
-    md5: fd10c0e72a410d57f4c5073dbc4ec505
-    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
-  hash:
-    md5: 52df3de33d8bed542df618f403fa5b85
-    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.3,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
-  hash:
-    md5: 641613f2d89da811bc29fa4cde88ef20
-    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
-  hash:
-    md5: 887123b5b70893ef32ec962b00625415
-    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
-  hash:
-    md5: 2a60e3342ea849f65068573003279ec4
-    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
-  hash:
-    md5: 96abedd31106b39ec30864f6fa695afc
-    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
-  hash:
-    md5: 137339f92677a33a2500d3cd5361a654
-    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
-  hash:
-    md5: 8cb4d8953ebe0460fd0d04157bc790f5
-    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
-  hash:
-    md5: f45d325d3a8739b81d47a8288b6357e2
-    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
-  hash:
-    md5: a57a8ea605573b733bb3d2010fbaf86d
-    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
-  hash:
-    md5: c4c8e364e4031850bcd232c221792e1c
-    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
-  hash:
-    md5: 9be48326058aa380b7400617e73d7da6
-    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
-  hash:
-    md5: 4745cefb2d63de33e85b73cbae7ff9d2
-    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+    hash:
+      md5: e64cd43bbd07afafbc458138e979c851
+      sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+    hash:
+      md5: 2e632ce02d57623142f2e4b8ab725f2b
+      sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+    hash:
+      md5: fd10c0e72a410d57f4c5073dbc4ec505
+      sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+    hash:
+      md5: 52df3de33d8bed542df618f403fa5b85
+      sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.3,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+    hash:
+      md5: 641613f2d89da811bc29fa4cde88ef20
+      sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+    hash:
+      md5: 887123b5b70893ef32ec962b00625415
+      sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+    hash:
+      md5: 2a60e3342ea849f65068573003279ec4
+      sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+    hash:
+      md5: 96abedd31106b39ec30864f6fa695afc
+      sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+    hash:
+      md5: 137339f92677a33a2500d3cd5361a654
+      sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+    hash:
+      md5: 8cb4d8953ebe0460fd0d04157bc790f5
+      sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+    hash:
+      md5: f45d325d3a8739b81d47a8288b6357e2
+      sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+    hash:
+      md5: a57a8ea605573b733bb3d2010fbaf86d
+      sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+    hash:
+      md5: c4c8e364e4031850bcd232c221792e1c
+      sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+    hash:
+      md5: 9be48326058aa380b7400617e73d7da6
+      sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+    hash:
+      md5: 4745cefb2d63de33e85b73cbae7ff9d2
+      sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/templates/languages/golang/providers/micromamba/Makefile
+++ b/templates/languages/golang/providers/micromamba/Makefile
@@ -29,7 +29,7 @@ MAKEFLAGS += --no-builtin-rules
 # Configuration
 # =============================================================================
 MAMBA_ENV  := {{REPOSITORY_NAME}}
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA := $(CURDIR)/.provider/bin/micromamba
 
 # LINT_MODE: fix (default, local dev) or check (CI, no auto-fix)

--- a/templates/languages/golang/providers/micromamba/conda-lock.yml
+++ b/templates/languages/golang/providers/micromamba/conda-lock.yml
@@ -5,2022 +5,2022 @@ metadata:
     osx-64: 0155288e99249aa3ba21c86b4fdde8343025207dc4a81f22f3acc34ce5c389a7
     osx-arm64: 7f50804c9263dc0a2ce76f891e4c7e6297d3fbd2d4d38a8bf3438a6ceff13837
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - ../tmp.63aLgmyHxL
+    - ../tmp.63aLgmyHxL
 package:
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 76f94c0e00d08432e003a7b54a1adf53
-    sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: go
-  version: 1.26.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _go_select: 2.3.0
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.7-he1b14cc_0.conda
-  hash:
-    md5: 0224fec123d2db9ecc8eaefe198b52aa
-    sha256: 0d10aa290a84d48542fad2d866eed0d8aa35ebaa6c5c58eef9f4a932c22cb839
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: golangci-lint
-  version: 2.13.2
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/golangci-lint-2.13.2-hfc2019e_2.conda
-  hash:
-    md5: dd3d6cd3ec6050132b5a8dafb0ab6116
-    sha256: 150bce3a03938a779c2394ff8538b947a5d50a433759faedfbf81568bec98faf
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
-  hash:
-    md5: 5e92b8413fd1c8f8f3006f4661b12def
-    sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
-  hash:
-    md5: c22348a769bb072b6184eb6f7f05e4f2
-    sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
-  hash:
-    md5: e64cd43bbd07afafbc458138e979c851
-    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
-  hash:
-    md5: 2e632ce02d57623142f2e4b8ab725f2b
-    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
-  hash:
-    md5: fd10c0e72a410d57f4c5073dbc4ec505
-    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
-  hash:
-    md5: 52df3de33d8bed542df618f403fa5b85
-    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.3,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
-  hash:
-    md5: 641613f2d89da811bc29fa4cde88ef20
-    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 4c1913031a736507963a5fb938cefe85
-    sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
-  hash:
-    md5: b9e2e7fcf1926cedbdb216a6974d67e3
-    sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go
-  version: 1.26.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    _go_select: 2.3.0
-    libcxx: '>=21'
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.7-h489f395_0.conda
-  hash:
-    md5: dbf952175e0a5649c8ebf8570e5d8104
-    sha256: c320887436b81e24bdbec85622bec5b91aa72919b5352b923acd81ac404b3900
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: golangci-lint
-  version: 2.13.2
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/golangci-lint-2.13.2-h5839d16_2.conda
-  hash:
-    md5: 6583ef9eac7a6e820b567e952c3b27d6
-    sha256: e69b88c50e25bc5ba78275ee9e1f4822e03f948fa56e35856649a4cc8e44757c
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
-  hash:
-    md5: fb1dd570751271b86cb17aee0bc39c48
-    sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
-  hash:
-    md5: ca9281db8c52184ade04b615b2f3959d
-    sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
-  hash:
-    md5: eaabc48679544820bef810523a703bf0
-    sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
-  hash:
-    md5: 887123b5b70893ef32ec962b00625415
-    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
-  hash:
-    md5: b4b0db08caeeaf14d50ee200c9067725
-    sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
-  hash:
-    md5: 2a60e3342ea849f65068573003279ec4
-    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
-  hash:
-    md5: 96abedd31106b39ec30864f6fa695afc
-    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
-  hash:
-    md5: 137339f92677a33a2500d3cd5361a654
-    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
-  hash:
-    md5: 8cb4d8953ebe0460fd0d04157bc790f5
-    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: _go_select
-  version: 2.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
-  hash:
-    md5: 79a39651abfce773c2948175d9b62986
-    sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
-  category: main
-  optional: false
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    llvm-openmp: '>=9.0.1'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
-  hash:
-    md5: a2d706b4a7d603524133037c34f7fb76
-    sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go
-  version: 1.26.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    _go_select: 2.3.0
-    libcxx: '>=21'
-    libgcc: '>=15'
-    libgfortran: ''
-    libgfortran5: '>=15.3.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.7-h8a7d722_0.conda
-  hash:
-    md5: aba86feb5de9bd1a198d711b31374ff6
-    sha256: a364b7abb57cdff72271a74a825e4126003f51a06ebdace2fc9dec1057871ad7
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: golangci-lint
-  version: 2.13.2
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/golangci-lint-2.13.2-hf76c51c_2.conda
-  hash:
-    md5: bf84614b69d82895d54d6886beb3870e
-    sha256: de5148901196869343e3bbd5bb551a8a27757bc70a4b933bc16a672d211290d4
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    _openmp_mutex: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
-  hash:
-    md5: 408af8d9d5226ff45ff04756ff1aa91e
-    sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
-  category: main
-  optional: false
-- name: libgfortran
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgfortran5: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
-  hash:
-    md5: aa6c627acd0f5709d9c79bf708a7b81b
-    sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
-  category: main
-  optional: false
-- name: libgfortran5
-  version: 16.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    libgcc: '>=16.2.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
-  hash:
-    md5: d54390644d893d50e739b19145aae45f
-    sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
-  hash:
-    md5: f45d325d3a8739b81d47a8288b6357e2
-    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: llvm-openmp
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
-  hash:
-    md5: 0affff5130a421d11d4d77ffbb00dad7
-    sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
-  hash:
-    md5: a57a8ea605573b733bb3d2010fbaf86d
-    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
-  hash:
-    md5: c4c8e364e4031850bcd232c221792e1c
-    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
-  hash:
-    md5: 9be48326058aa380b7400617e73d7da6
-    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
-  hash:
-    md5: 4745cefb2d63de33e85b73cbae7ff9d2
-    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 76f94c0e00d08432e003a7b54a1adf53
+      sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _go_select: 2.3.0
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.7-he1b14cc_0.conda
+    hash:
+      md5: 0224fec123d2db9ecc8eaefe198b52aa
+      sha256: 0d10aa290a84d48542fad2d866eed0d8aa35ebaa6c5c58eef9f4a932c22cb839
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: golangci-lint
+    version: 2.13.2
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/golangci-lint-2.13.2-hfc2019e_2.conda
+    hash:
+      md5: dd3d6cd3ec6050132b5a8dafb0ab6116
+      sha256: 150bce3a03938a779c2394ff8538b947a5d50a433759faedfbf81568bec98faf
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+    hash:
+      md5: 5e92b8413fd1c8f8f3006f4661b12def
+      sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+    hash:
+      md5: c22348a769bb072b6184eb6f7f05e4f2
+      sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+    hash:
+      md5: e64cd43bbd07afafbc458138e979c851
+      sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+    hash:
+      md5: 2e632ce02d57623142f2e4b8ab725f2b
+      sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+    hash:
+      md5: fd10c0e72a410d57f4c5073dbc4ec505
+      sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+    hash:
+      md5: 52df3de33d8bed542df618f403fa5b85
+      sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.3,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+    hash:
+      md5: 641613f2d89da811bc29fa4cde88ef20
+      sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 4c1913031a736507963a5fb938cefe85
+      sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      llvm-openmp: ">=9.0.1"
+    url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+    hash:
+      md5: b9e2e7fcf1926cedbdb216a6974d67e3
+      sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      _go_select: 2.3.0
+      libcxx: ">=21"
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.7-h489f395_0.conda
+    hash:
+      md5: dbf952175e0a5649c8ebf8570e5d8104
+      sha256: c320887436b81e24bdbec85622bec5b91aa72919b5352b923acd81ac404b3900
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: golangci-lint
+    version: 2.13.2
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/golangci-lint-2.13.2-h5839d16_2.conda
+    hash:
+      md5: 6583ef9eac7a6e820b567e952c3b27d6
+      sha256: e69b88c50e25bc5ba78275ee9e1f4822e03f948fa56e35856649a4cc8e44757c
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      _openmp_mutex: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
+    hash:
+      md5: fb1dd570751271b86cb17aee0bc39c48
+      sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
+    hash:
+      md5: ca9281db8c52184ade04b615b2f3959d
+      sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
+    hash:
+      md5: eaabc48679544820bef810523a703bf0
+      sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+    hash:
+      md5: 887123b5b70893ef32ec962b00625415
+      sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: llvm-openmp
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
+    hash:
+      md5: b4b0db08caeeaf14d50ee200c9067725
+      sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+    hash:
+      md5: 2a60e3342ea849f65068573003279ec4
+      sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+    hash:
+      md5: 96abedd31106b39ec30864f6fa695afc
+      sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+    hash:
+      md5: 137339f92677a33a2500d3cd5361a654
+      sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+    hash:
+      md5: 8cb4d8953ebe0460fd0d04157bc790f5
+      sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: _go_select
+    version: 2.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
+    hash:
+      md5: 79a39651abfce773c2948175d9b62986
+      sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
+    category: main
+    optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      llvm-openmp: ">=9.0.1"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
+    hash:
+      md5: a2d706b4a7d603524133037c34f7fb76
+      sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go
+    version: 1.26.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      _go_select: 2.3.0
+      libcxx: ">=21"
+      libgcc: ">=15"
+      libgfortran: ""
+      libgfortran5: ">=15.3.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.7-h8a7d722_0.conda
+    hash:
+      md5: aba86feb5de9bd1a198d711b31374ff6
+      sha256: a364b7abb57cdff72271a74a825e4126003f51a06ebdace2fc9dec1057871ad7
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: golangci-lint
+    version: 2.13.2
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/golangci-lint-2.13.2-hf76c51c_2.conda
+    hash:
+      md5: bf84614b69d82895d54d6886beb3870e
+      sha256: de5148901196869343e3bbd5bb551a8a27757bc70a4b933bc16a672d211290d4
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      _openmp_mutex: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
+    hash:
+      md5: 408af8d9d5226ff45ff04756ff1aa91e
+      sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
+    category: main
+    optional: false
+  - name: libgfortran
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgfortran5: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
+    hash:
+      md5: aa6c627acd0f5709d9c79bf708a7b81b
+      sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
+    category: main
+    optional: false
+  - name: libgfortran5
+    version: 16.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      libgcc: ">=16.2.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
+    hash:
+      md5: d54390644d893d50e739b19145aae45f
+      sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+    hash:
+      md5: f45d325d3a8739b81d47a8288b6357e2
+      sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: llvm-openmp
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
+    hash:
+      md5: 0affff5130a421d11d4d77ffbb00dad7
+      sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+    hash:
+      md5: a57a8ea605573b733bb3d2010fbaf86d
+      sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+    hash:
+      md5: c4c8e364e4031850bcd232c221792e1c
+      sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+    hash:
+      md5: 9be48326058aa380b7400617e73d7da6
+      sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+    hash:
+      md5: 4745cefb2d63de33e85b73cbae7ff9d2
+      sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/templates/languages/golang/providers/micromamba/conda-lock.yml
+++ b/templates/languages/golang/providers/micromamba/conda-lock.yml
@@ -1,0 +1,2026 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: 0b5ce7a9a67146ad4066771721c3cb957a711183b29f6eb20ac279dc6213caa9
+    osx-64: 0155288e99249aa3ba21c86b4fdde8343025207dc4a81f22f3acc34ce5c389a7
+    osx-arm64: 7f50804c9263dc0a2ce76f891e4c7e6297d3fbd2d4d38a8bf3438a6ceff13837
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - ../tmp.63aLgmyHxL
+package:
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 76f94c0e00d08432e003a7b54a1adf53
+    sha256: d86836d4f3094b4ac149dcdc55f1f12be6e84ed1206a4234404a024e49769832
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: go
+  version: 1.26.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _go_select: 2.3.0
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-1.26.7-he1b14cc_0.conda
+  hash:
+    md5: 0224fec123d2db9ecc8eaefe198b52aa
+    sha256: 0d10aa290a84d48542fad2d866eed0d8aa35ebaa6c5c58eef9f4a932c22cb839
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: golangci-lint
+  version: 2.13.2
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/golangci-lint-2.13.2-hfc2019e_2.conda
+  hash:
+    md5: dd3d6cd3ec6050132b5a8dafb0ab6116
+    sha256: 150bce3a03938a779c2394ff8538b947a5d50a433759faedfbf81568bec98faf
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran-16.2.0-h69a702a_4.conda
+  hash:
+    md5: 5e92b8413fd1c8f8f3006f4661b12def
+    sha256: 7653be4d88a4d74676c38dd892914d027dcecc0c65c406be772d31cb641f8cfd
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgfortran5-16.2.0-h6b99dfc_4.conda
+  hash:
+    md5: c22348a769bb072b6184eb6f7f05e4f2
+    sha256: a5510cbcea3b9e9ab24b336429de997fa727af1dba323031500a962a20e38600
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+  hash:
+    md5: e64cd43bbd07afafbc458138e979c851
+    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+  hash:
+    md5: 2e632ce02d57623142f2e4b8ab725f2b
+    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+  hash:
+    md5: fd10c0e72a410d57f4c5073dbc4ec505
+    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+  hash:
+    md5: 52df3de33d8bed542df618f403fa5b85
+    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.3,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+  hash:
+    md5: 641613f2d89da811bc29fa4cde88ef20
+    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 4c1913031a736507963a5fb938cefe85
+    sha256: faf9b29f369ccf41da3998b00945e56daa331d01a8ffe7832e45651db0716028
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-64/_openmp_mutex-4.5-8_kmp_llvm.conda
+  hash:
+    md5: b9e2e7fcf1926cedbdb216a6974d67e3
+    sha256: 09ba32614a1512b729e3cb608b0714c24654f37b5d0f8239bdb77d7be0ede4f7
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go
+  version: 1.26.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    _go_select: 2.3.0
+    libcxx: '>=21'
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-1.26.7-h489f395_0.conda
+  hash:
+    md5: dbf952175e0a5649c8ebf8570e5d8104
+    sha256: c320887436b81e24bdbec85622bec5b91aa72919b5352b923acd81ac404b3900
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: golangci-lint
+  version: 2.13.2
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/golangci-lint-2.13.2-h5839d16_2.conda
+  hash:
+    md5: 6583ef9eac7a6e820b567e952c3b27d6
+    sha256: e69b88c50e25bc5ba78275ee9e1f4822e03f948fa56e35856649a4cc8e44757c
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    _openmp_mutex: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgcc-16.2.0-h13771c8_4.conda
+  hash:
+    md5: fb1dd570751271b86cb17aee0bc39c48
+    sha256: 28a03bad58ff5b9e560c66f1b2d89384db93e9ed470c0a7d3a80f2166ed35268
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran-16.2.0-h7e5c614_4.conda
+  hash:
+    md5: ca9281db8c52184ade04b615b2f3959d
+    sha256: a596fa89c4b1e0d3743d76bf18df31d2bf3317cb4a4391d5877e1a3e8eaaa4d0
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libgfortran5-16.2.0-h2539e6c_4.conda
+  hash:
+    md5: eaabc48679544820bef810523a703bf0
+    sha256: f566ced21e65d05acfce2b451d48bbe232398b5d57e87ff5d28b9f25b1bbe79b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+  hash:
+    md5: 887123b5b70893ef32ec962b00625415
+    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/llvm-openmp-23.1.0-h8c1e6b9_0.conda
+  hash:
+    md5: b4b0db08caeeaf14d50ee200c9067725
+    sha256: b366ff12607fe26f3ddccfd62d66f91fa9dc860728f9b9df38795438c3ad1f81
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+  hash:
+    md5: 2a60e3342ea849f65068573003279ec4
+    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+  hash:
+    md5: 96abedd31106b39ec30864f6fa695afc
+    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+  hash:
+    md5: 137339f92677a33a2500d3cd5361a654
+    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+  hash:
+    md5: 8cb4d8953ebe0460fd0d04157bc790f5
+    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: _go_select
+  version: 2.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/_go_select-2.3.0-cgo.tar.bz2
+  hash:
+    md5: 79a39651abfce773c2948175d9b62986
+    sha256: 5cd5dd9817d0d671ad3e2f85c967b4dcd1a297a686b7d5820e625e2f4f962558
+  category: main
+  optional: false
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    llvm-openmp: '>=9.0.1'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/_openmp_mutex-4.5-8_kmp_llvm.conda
+  hash:
+    md5: a2d706b4a7d603524133037c34f7fb76
+    sha256: c7c98ce74f6a7ff25aaa4706d06fa41d63a333add4d697b73aa4d8d2d7ad7651
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go
+  version: 1.26.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    _go_select: 2.3.0
+    libcxx: '>=21'
+    libgcc: '>=15'
+    libgfortran: ''
+    libgfortran5: '>=15.3.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-1.26.7-h8a7d722_0.conda
+  hash:
+    md5: aba86feb5de9bd1a198d711b31374ff6
+    sha256: a364b7abb57cdff72271a74a825e4126003f51a06ebdace2fc9dec1057871ad7
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: golangci-lint
+  version: 2.13.2
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/golangci-lint-2.13.2-hf76c51c_2.conda
+  hash:
+    md5: bf84614b69d82895d54d6886beb3870e
+    sha256: de5148901196869343e3bbd5bb551a8a27757bc70a4b933bc16a672d211290d4
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    _openmp_mutex: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgcc-16.2.0-h3cf6597_4.conda
+  hash:
+    md5: 408af8d9d5226ff45ff04756ff1aa91e
+    sha256: 00b8d07ea98344c72c6e332a09b8060f4176849d5fd0eb78dd5b30176ad97ca4
+  category: main
+  optional: false
+- name: libgfortran
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libgfortran5: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran-16.2.0-h07b0088_4.conda
+  hash:
+    md5: aa6c627acd0f5709d9c79bf708a7b81b
+    sha256: 7582efbbffc6964093afd80e01c2ac60d89aa4e404cac664544675b9d4d1c5e7
+  category: main
+  optional: false
+- name: libgfortran5
+  version: 16.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    libgcc: '>=16.2.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libgfortran5-16.2.0-hdb7a957_4.conda
+  hash:
+    md5: d54390644d893d50e739b19145aae45f
+    sha256: 902719c38c7a390d305435a362dc83893754c3f933569a38347c434cd1c12540
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+  hash:
+    md5: f45d325d3a8739b81d47a8288b6357e2
+    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: llvm-openmp
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/llvm-openmp-23.1.0-hdb3d66b_0.conda
+  hash:
+    md5: 0affff5130a421d11d4d77ffbb00dad7
+    sha256: 996d3a9de61c8ccc3fcb265938f9845f11868251f38e6db4e7190de3f9a971a2
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+  hash:
+    md5: a57a8ea605573b733bb3d2010fbaf86d
+    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+  hash:
+    md5: c4c8e364e4031850bcd232c221792e1c
+    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+  hash:
+    md5: 9be48326058aa380b7400617e73d7da6
+    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+  hash:
+    md5: 4745cefb2d63de33e85b73cbae7ff9d2
+    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/templates/languages/java/providers/micromamba/Makefile
+++ b/templates/languages/java/providers/micromamba/Makefile
@@ -29,7 +29,7 @@ MAKEFLAGS += --no-builtin-rules
 # Configuration
 # =============================================================================
 MAMBA_ENV  := {{REPOSITORY_NAME}}
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA := $(CURDIR)/.provider/bin/micromamba
 
 # LINT_MODE: fix (default, local dev) or check (CI, no auto-fix)

--- a/templates/languages/java/providers/micromamba/conda-lock.yml
+++ b/templates/languages/java/providers/micromamba/conda-lock.yml
@@ -5,2478 +5,2478 @@ metadata:
     osx-64: 2e07c615c6c304ad7b43feb07e200db47230206bb8ec1c1f15d5d090e238c84c
     osx-arm64: 4fa5f78643a5e85906a019606bebb0c67ade8b34dacbc2c5e96f3d56d99c582a
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - ../tmp.2zoonlDcWC
+    - ../tmp.2zoonlDcWC
 package:
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: alsa-lib
-  version: 1.2.16.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
-  hash:
-    md5: 7094e0d8d14de0eff6d83f0d2f1f661e
-    sha256: a35bddac04be093769e81814465a537961c6ed0f8d3cc23d6dce6ecdfaf71821
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: cairo
-  version: 1.18.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    fontconfig: '>=2.18.3,<3.0a0'
-    fonts-conda-ecosystem: ''
-    icu: '>=78.3,<79.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=15'
-    libglib: '>=2.88.3,<3.0a0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libstdcxx: '>=15'
-    libxcb: '>=1.17.0,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    pixman: '>=0.46.4,<1.0a0'
-    xorg-libice: '>=1.1.2,<2.0a0'
-    xorg-libsm: '>=1.2.6,<2.0a0'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-    xorg-libxext: '>=1.3.7,<2.0a0'
-    xorg-libxrender: '>=0.9.12,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_3.conda
-  hash:
-    md5: 7b870cffbaa8430290e567a0facd8dca
-    sha256: 6b551d9346997bc4c6fadf96b7b92442b8f3244011cc462e4ee77afc714d52c5
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: font-ttf-dejavu-sans-mono
-  version: '2.37'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
-  hash:
-    md5: 0c96522c6bdaed4b1566d11387caaf45
-    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
-  category: main
-  optional: false
-- name: font-ttf-inconsolata
-  version: '3.000'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
-  hash:
-    md5: 34893075a5c9e55cdafac56607368fc6
-    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
-  category: main
-  optional: false
-- name: font-ttf-source-code-pro
-  version: '2.038'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
-  hash:
-    md5: 4d59c254e01d9cde7957100457e2d5fb
-    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
-  category: main
-  optional: false
-- name: font-ttf-ubuntu
-  version: '0.83'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
-  hash:
-    md5: 49023d73832ef61042f6a237cb2687e7
-    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
-  category: main
-  optional: false
-- name: fontconfig
-  version: 2.18.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=15'
-    libuuid: '>=2.42.2,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
-  hash:
-    md5: 922776b528a470ab5afa81fd42abfa1d
-    sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
-  category: main
-  optional: false
-- name: fonts-conda-ecosystem
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    fonts-conda-forge: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
-  hash:
-    md5: fee5683a3f04bd15cbd8318b096a27ab
-    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
-  category: main
-  optional: false
-- name: fonts-conda-forge
-  version: '1'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    font-ttf-dejavu-sans-mono: ''
-    font-ttf-inconsolata: ''
-    font-ttf-source-code-pro: ''
-    font-ttf-ubuntu: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
-  hash:
-    md5: a7970cd949a077b7cb9696379d338681
-    sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
-  category: main
-  optional: false
-- name: giflib
-  version: 6.1.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
-  hash:
-    md5: 6d9a90cfee2c7343d6c05a1b37ef75fb
-    sha256: 734cd8518063b707aa098932cb109f779b8cf5a3c31633f227d22557a6bfaf53
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: gradle
-  version: 9.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-    openjdk: '>=17,<26'
-  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
-  hash:
-    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
-    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
-  category: main
-  optional: false
-- name: graphite2
-  version: 1.3.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
-  hash:
-    md5: f9fe2984587fa8235a6af6004760cd18
-    sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: keyutils
-  version: 1.6.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
-  hash:
-    md5: ba55d1b89fd7775e67de8291029b4059
-    sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
-  category: main
-  optional: false
-- name: krb5
-  version: 1.22.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    keyutils: '>=1.6.3,<2.0a0'
-    libedit: '>=3.1.20250104,<3.2.0a0,>=3.1.20250104,<4.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
-  hash:
-    md5: 53318d715316929a574f83591308b1f8
-    sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
-  category: main
-  optional: false
-- name: lcms2
-  version: 2.19.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libjpeg-turbo: '>=3.2.0,<4.0a0'
-    libtiff: '>=4.7.2,<4.8.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h9073bf1_2.conda
-  hash:
-    md5: b68c7304d2edb0f1a5bdfb875094d603
-    sha256: 8cdec1ff3f276cd2069dca0dae4f45f3dc5c224e2d72daef78227832938467a6
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: lerc
-  version: 4.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
-  hash:
-    md5: fb9d356b1a57d6d54768be7ebd5fce09
-    sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libcups
-  version: 2.3.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    krb5: '>=1.22.2,<1.23.0a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-    libzlib: '>=1.3.1,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
-  hash:
-    md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
-    sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
-  category: main
-  optional: false
-- name: libdeflate
-  version: '1.25'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
-  hash:
-    md5: 40f9b31aa9cf007789867df0decd0492
-    sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
-  category: main
-  optional: false
-- name: libedit
-  version: 3.1.20250104
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
-  hash:
-    md5: 50708d3b951d0f8e2d7f2df5b5edc040
-    sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libfreetype
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    libfreetype6: '>=2.14.3'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
-  hash:
-    md5: f8054e759d0ddddaf34a5c8fedc900a1
-    sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
-  category: main
-  optional: false
-- name: libfreetype6
-  version: 2.14.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
-  hash:
-    md5: b72a266a9317036fd0464cb98b027cd0
-    sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libglib
-  version: 2.88.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    libiconv: '>=1.18,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    pcre2: '>=10.47,<10.48.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_3.conda
-  hash:
-    md5: d216efacca3f34f2b13ddd1632f53833
-    sha256: f57bf3954dbba8b27ec68540e84f8b2c2375ffa5702f89ca9741e17329fc3953
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libharfbuzz
-  version: 14.4.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    cairo: '>=1.18.4,<2.0a0'
-    graphite2: '>=1.3.15,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=15'
-    libglib: '>=2.88.3,<3.0a0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_1.conda
-  hash:
-    md5: c44470b6bfa6a582cb4dd42cbda3401e
-    sha256: 979b14ba13054aab9e90363809aac470a58b7c37203c330216327356a98c8f60
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: libjpeg-turbo
-  version: 3.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
-  hash:
-    md5: 898d1c9793eaa52efc4727bd84d2e39a
-    sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libpng
-  version: 1.6.58
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
-  hash:
-    md5: fcf71c8d979148873f6f8ad4cfc73d86
-    sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
-  hash:
-    md5: e64cd43bbd07afafbc458138e979c851
-    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libtiff
-  version: 4.7.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    lerc: '>=4.2.0,<5.0a0'
-    libdeflate: '>=1.25,<1.26.0a0'
-    libgcc: '>=15'
-    libjpeg-turbo: '>=3.2.0,<4.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libstdcxx: '>=15'
-    libwebp-base: '>=1.6.0,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
-  hash:
-    md5: 0907d876f460ebc941ae590338b6102f
-    sha256: 10e125da82ca93e09191e66e5a94d566b2cf8d4024e2a0db3a9114297447e0d9
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libwebp-base
-  version: 1.6.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
-  hash:
-    md5: 9332b53d0ea93c5d39e33be03a0c611a
-    sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
-  category: main
-  optional: false
-- name: libxcb
-  version: 1.17.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    pthread-stubs: ''
-    xorg-libxau: '>=1.0.12,<2.0a0'
-    xorg-libxdmcp: '>=1.1.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
-  hash:
-    md5: 61f0ffba9161cbb3a77722869b21e4bb
-    sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
-  hash:
-    md5: 2e632ce02d57623142f2e4b8ab725f2b
-    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
-  hash:
-    md5: fd10c0e72a410d57f4c5073dbc4ec505
-    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openjdk
-  version: 25.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    alsa-lib: '>=1.2.16.1,<1.3.0a0'
-    fontconfig: '>=2.18.3,<3.0a0'
-    fonts-conda-ecosystem: ''
-    giflib: '>=6.1.3,<6.2.0a0'
-    lcms2: '>=2.19.1,<3.0a0'
-    libcups: '>=2.3.3,<2.4.0a0'
-    libfreetype: '>=2.14.3'
-    libfreetype6: '>=2.14.3'
-    libgcc: '>=15'
-    libharfbuzz: '>=14.4.0'
-    libjpeg-turbo: '>=3.2.0,<4.0a0'
-    libpng: '>=1.6.58,<1.7.0a0'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-    xorg-libxext: '>=1.3.7,<2.0a0'
-    xorg-libxi: '>=1.8.3,<2.0a0'
-    xorg-libxrandr: '>=1.5.5,<2.0a0'
-    xorg-libxrender: '>=0.9.12,<0.10.0a0'
-    xorg-libxt: '>=1.3.1,<2.0a0'
-    xorg-libxtst: '>=1.2.5,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-h1602c4f_26.conda
-  hash:
-    md5: 920916925a5d103cf923d51813cc947d
-    sha256: 703aa71462f1b7b8804e1ba6f2663073c47808c693e8a912eb0ce3191ebe90fb
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: pcre2
-  version: '10.47'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
-  hash:
-    md5: 06f6113cf1ff4a54b65f87ead132a5f1
-    sha256: 9ebb10a4eb3be51ae67d85c679f5a7a50cb040ed25c783e6331a225ea09991d4
-  category: main
-  optional: false
-- name: pixman
-  version: 0.46.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
-  hash:
-    md5: 0ee5bb30034b081a1386c1e2c98ab0a7
-    sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
-  hash:
-    md5: 52df3de33d8bed542df618f403fa5b85
-    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
-  category: main
-  optional: false
-- name: pthread-stubs
-  version: '0.4'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h7cc23a3_1004.conda
-  hash:
-    md5: bb66b610707b811e3c65181a6431e7a8
-    sha256: 4a44fd00ea73b79ca2c89b0727b9ccf61c506ead71e67a9abfa4c590042b5a4a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.3,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
-  hash:
-    md5: 641613f2d89da811bc29fa4cde88ef20
-    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: xorg-libice
-  version: 1.1.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
-  hash:
-    md5: 85c9442aec283b4e464fa9ecc484a2f3
-    sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
-  category: main
-  optional: false
-- name: xorg-libsm
-  version: 1.2.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libuuid: '>=2.42.2,<3.0a0'
-    xorg-libice: '>=1.1.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
-  hash:
-    md5: aa7459ed9ad086ba11dda843d764b33d
-    sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
-  category: main
-  optional: false
-- name: xorg-libx11
-  version: 1.8.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libxcb: '>=1.17.0,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
-  hash:
-    md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
-    sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
-  category: main
-  optional: false
-- name: xorg-libxau
-  version: 1.0.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
-  hash:
-    md5: f06ef439c280a5f90b8bf62355008dbc
-    sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
-  category: main
-  optional: false
-- name: xorg-libxdmcp
-  version: 1.1.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
-  hash:
-    md5: 2e66c929f3d879708335b6ea4557c838
-    sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
-  category: main
-  optional: false
-- name: xorg-libxext
-  version: 1.3.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
-  hash:
-    md5: e5b6b28536b81b3f4cb20db4668a4642
-    sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
-  category: main
-  optional: false
-- name: xorg-libxfixes
-  version: 6.0.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
-  hash:
-    md5: 09132e874fe0e1f5e4492b0b6b904b6e
-    sha256: aec84f554fc897bf4085c7bc8b8f0740e4c224e13bca3cc51c93e7699d56f83a
-  category: main
-  optional: false
-- name: xorg-libxi
-  version: 1.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-    xorg-libxext: '>=1.3.7,<2.0a0'
-    xorg-libxfixes: '>=6.0.2,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
-  hash:
-    md5: a1412b2b1184dacda45f8476fef2cc25
-    sha256: a523d71344a2f640efe6fc42b88fc261d9cd389d4f9838a5d42dcdb120c2b0c8
-  category: main
-  optional: false
-- name: xorg-libxrandr
-  version: 1.5.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-    xorg-libxext: '>=1.3.7,<2.0a0'
-    xorg-libxrender: '>=0.9.12,<0.10.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
-  hash:
-    md5: 798a8c9d171859a022e1cb89e7d0eb10
-    sha256: 05a7f25d7f7f5cd32b27a019233ece97167fd8ade255bc13a0e49e53387f4c30
-  category: main
-  optional: false
-- name: xorg-libxrender
-  version: 0.9.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
-  hash:
-    md5: e470d224a7a5be1b1d021bded7abb536
-    sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
-  category: main
-  optional: false
-- name: xorg-libxt
-  version: 1.3.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libice: '>=1.1.2,<2.0a0'
-    xorg-libsm: '>=1.2.6,<2.0a0'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-h7cc23a3_1.conda
-  hash:
-    md5: 2121765de9c261e2a95ab9fc6efabefb
-    sha256: dff31677674be86f98ee929a796edf2cf7c78bf38610b122a63af9af752d5bf7
-  category: main
-  optional: false
-- name: xorg-libxtst
-  version: 1.2.5
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    xorg-libx11: '>=1.8.13,<2.0a0'
-    xorg-libxext: '>=1.3.7,<2.0a0'
-    xorg-libxi: '>=1.8.3,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
-  hash:
-    md5: 752a5ac9322e0fbbc24146c1ce3ae44e
-    sha256: d66525e7b1c492aa179c6c55610fc8dfb0a9a62ea7d4fb9f904fa6af62127f61
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: gradle
-  version: 9.3.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-    openjdk: '>=17,<26'
-  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
-  hash:
-    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
-    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
-  hash:
-    md5: 887123b5b70893ef32ec962b00625415
-    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
-  hash:
-    md5: 2a60e3342ea849f65068573003279ec4
-    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
-  hash:
-    md5: 96abedd31106b39ec30864f6fa695afc
-    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openjdk
-  version: 25.0.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h3ebe2c2_26.conda
-  hash:
-    md5: 7189e6da02ba66eec990c7108aaf249c
-    sha256: e89f4b39b6ef5fc155061f3af3bac0994a757a7e534bc8b1de0d967195be1051
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
-  hash:
-    md5: 137339f92677a33a2500d3cd5361a654
-    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
-  hash:
-    md5: 8cb4d8953ebe0460fd0d04157bc790f5
-    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: gradle
-  version: 9.3.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-    openjdk: '>=17,<26'
-  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
-  hash:
-    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
-    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
-  hash:
-    md5: f45d325d3a8739b81d47a8288b6357e2
-    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
-  hash:
-    md5: a57a8ea605573b733bb3d2010fbaf86d
-    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
-  hash:
-    md5: c4c8e364e4031850bcd232c221792e1c
-    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openjdk
-  version: 25.0.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-hff8554d_26.conda
-  hash:
-    md5: 2f6b81bc2c67823ae56fe071291f9a70
-    sha256: d2c8f03a0a108a45d2200060ee9e73ef9d174fca24c832f1ded7ad94985ef3ec
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
-  hash:
-    md5: 9be48326058aa380b7400617e73d7da6
-    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
-  hash:
-    md5: 4745cefb2d63de33e85b73cbae7ff9d2
-    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: alsa-lib
+    version: 1.2.16.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+    hash:
+      md5: 7094e0d8d14de0eff6d83f0d2f1f661e
+      sha256: a35bddac04be093769e81814465a537961c6ed0f8d3cc23d6dce6ecdfaf71821
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: cairo
+    version: 1.18.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      fontconfig: ">=2.18.3,<3.0a0"
+      fonts-conda-ecosystem: ""
+      icu: ">=78.3,<79.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libfreetype: ">=2.14.3"
+      libfreetype6: ">=2.14.3"
+      libgcc: ">=15"
+      libglib: ">=2.88.3,<3.0a0"
+      libpng: ">=1.6.58,<1.7.0a0"
+      libstdcxx: ">=15"
+      libxcb: ">=1.17.0,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      pixman: ">=0.46.4,<1.0a0"
+      xorg-libice: ">=1.1.2,<2.0a0"
+      xorg-libsm: ">=1.2.6,<2.0a0"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+      xorg-libxext: ">=1.3.7,<2.0a0"
+      xorg-libxrender: ">=0.9.12,<0.10.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_3.conda
+    hash:
+      md5: 7b870cffbaa8430290e567a0facd8dca
+      sha256: 6b551d9346997bc4c6fadf96b7b92442b8f3244011cc462e4ee77afc714d52c5
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: font-ttf-dejavu-sans-mono
+    version: "2.37"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+    hash:
+      md5: 0c96522c6bdaed4b1566d11387caaf45
+      sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+    category: main
+    optional: false
+  - name: font-ttf-inconsolata
+    version: "3.000"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+    hash:
+      md5: 34893075a5c9e55cdafac56607368fc6
+      sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+    category: main
+    optional: false
+  - name: font-ttf-source-code-pro
+    version: "2.038"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+    hash:
+      md5: 4d59c254e01d9cde7957100457e2d5fb
+      sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+    category: main
+    optional: false
+  - name: font-ttf-ubuntu
+    version: "0.83"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+    hash:
+      md5: 49023d73832ef61042f6a237cb2687e7
+      sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+    category: main
+    optional: false
+  - name: fontconfig
+    version: 2.18.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libfreetype: ">=2.14.3"
+      libfreetype6: ">=2.14.3"
+      libgcc: ">=15"
+      libuuid: ">=2.42.2,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+    hash:
+      md5: 922776b528a470ab5afa81fd42abfa1d
+      sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+    category: main
+    optional: false
+  - name: fonts-conda-ecosystem
+    version: "1"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      fonts-conda-forge: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+    hash:
+      md5: fee5683a3f04bd15cbd8318b096a27ab
+      sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+    category: main
+    optional: false
+  - name: fonts-conda-forge
+    version: "1"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      font-ttf-dejavu-sans-mono: ""
+      font-ttf-inconsolata: ""
+      font-ttf-source-code-pro: ""
+      font-ttf-ubuntu: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+    hash:
+      md5: a7970cd949a077b7cb9696379d338681
+      sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+    category: main
+    optional: false
+  - name: giflib
+    version: 6.1.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
+    hash:
+      md5: 6d9a90cfee2c7343d6c05a1b37ef75fb
+      sha256: 734cd8518063b707aa098932cb109f779b8cf5a3c31633f227d22557a6bfaf53
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: gradle
+    version: 9.3.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+      openjdk: ">=17,<26"
+    url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+    hash:
+      md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+      sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+    category: main
+    optional: false
+  - name: graphite2
+    version: 1.3.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+    hash:
+      md5: f9fe2984587fa8235a6af6004760cd18
+      sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: keyutils
+    version: 1.6.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+    hash:
+      md5: ba55d1b89fd7775e67de8291029b4059
+      sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+    category: main
+    optional: false
+  - name: krb5
+    version: 1.22.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      keyutils: ">=1.6.3,<2.0a0"
+      libedit: ">=3.1.20250104,<3.2.0a0,>=3.1.20250104,<4.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+    hash:
+      md5: 53318d715316929a574f83591308b1f8
+      sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+    category: main
+    optional: false
+  - name: lcms2
+    version: 2.19.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libjpeg-turbo: ">=3.2.0,<4.0a0"
+      libtiff: ">=4.7.2,<4.8.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h9073bf1_2.conda
+    hash:
+      md5: b68c7304d2edb0f1a5bdfb875094d603
+      sha256: 8cdec1ff3f276cd2069dca0dae4f45f3dc5c224e2d72daef78227832938467a6
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: lerc
+    version: 4.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+    hash:
+      md5: fb9d356b1a57d6d54768be7ebd5fce09
+      sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libcups
+    version: 2.3.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      krb5: ">=1.22.2,<1.23.0a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+      libzlib: ">=1.3.1,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+    hash:
+      md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+      sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+    category: main
+    optional: false
+  - name: libdeflate
+    version: "1.25"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+    hash:
+      md5: 40f9b31aa9cf007789867df0decd0492
+      sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+    category: main
+    optional: false
+  - name: libedit
+    version: 3.1.20250104
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+    hash:
+      md5: 50708d3b951d0f8e2d7f2df5b5edc040
+      sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libfreetype
+    version: 2.14.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      libfreetype6: ">=2.14.3"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+    hash:
+      md5: f8054e759d0ddddaf34a5c8fedc900a1
+      sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+    category: main
+    optional: false
+  - name: libfreetype6
+    version: 2.14.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libpng: ">=1.6.58,<1.7.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+    hash:
+      md5: b72a266a9317036fd0464cb98b027cd0
+      sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libglib
+    version: 2.88.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      libiconv: ">=1.18,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      pcre2: ">=10.47,<10.48.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_3.conda
+    hash:
+      md5: d216efacca3f34f2b13ddd1632f53833
+      sha256: f57bf3954dbba8b27ec68540e84f8b2c2375ffa5702f89ca9741e17329fc3953
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libharfbuzz
+    version: 14.4.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      cairo: ">=1.18.4,<2.0a0"
+      graphite2: ">=1.3.15,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libfreetype: ">=2.14.3"
+      libfreetype6: ">=2.14.3"
+      libgcc: ">=15"
+      libglib: ">=2.88.3,<3.0a0"
+      libpng: ">=1.6.58,<1.7.0a0"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_1.conda
+    hash:
+      md5: c44470b6bfa6a582cb4dd42cbda3401e
+      sha256: 979b14ba13054aab9e90363809aac470a58b7c37203c330216327356a98c8f60
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: libjpeg-turbo
+    version: 3.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+    hash:
+      md5: 898d1c9793eaa52efc4727bd84d2e39a
+      sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libpng
+    version: 1.6.58
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+    hash:
+      md5: fcf71c8d979148873f6f8ad4cfc73d86
+      sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+    hash:
+      md5: e64cd43bbd07afafbc458138e979c851
+      sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libtiff
+    version: 4.7.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      lerc: ">=4.2.0,<5.0a0"
+      libdeflate: ">=1.25,<1.26.0a0"
+      libgcc: ">=15"
+      libjpeg-turbo: ">=3.2.0,<4.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libstdcxx: ">=15"
+      libwebp-base: ">=1.6.0,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+    hash:
+      md5: 0907d876f460ebc941ae590338b6102f
+      sha256: 10e125da82ca93e09191e66e5a94d566b2cf8d4024e2a0db3a9114297447e0d9
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libwebp-base
+    version: 1.6.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+    hash:
+      md5: 9332b53d0ea93c5d39e33be03a0c611a
+      sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+    category: main
+    optional: false
+  - name: libxcb
+    version: 1.17.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      pthread-stubs: ""
+      xorg-libxau: ">=1.0.12,<2.0a0"
+      xorg-libxdmcp: ">=1.1.5,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
+    hash:
+      md5: 61f0ffba9161cbb3a77722869b21e4bb
+      sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+    hash:
+      md5: 2e632ce02d57623142f2e4b8ab725f2b
+      sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+    hash:
+      md5: fd10c0e72a410d57f4c5073dbc4ec505
+      sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openjdk
+    version: 25.0.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      alsa-lib: ">=1.2.16.1,<1.3.0a0"
+      fontconfig: ">=2.18.3,<3.0a0"
+      fonts-conda-ecosystem: ""
+      giflib: ">=6.1.3,<6.2.0a0"
+      lcms2: ">=2.19.1,<3.0a0"
+      libcups: ">=2.3.3,<2.4.0a0"
+      libfreetype: ">=2.14.3"
+      libfreetype6: ">=2.14.3"
+      libgcc: ">=15"
+      libharfbuzz: ">=14.4.0"
+      libjpeg-turbo: ">=3.2.0,<4.0a0"
+      libpng: ">=1.6.58,<1.7.0a0"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+      xorg-libxext: ">=1.3.7,<2.0a0"
+      xorg-libxi: ">=1.8.3,<2.0a0"
+      xorg-libxrandr: ">=1.5.5,<2.0a0"
+      xorg-libxrender: ">=0.9.12,<0.10.0a0"
+      xorg-libxt: ">=1.3.1,<2.0a0"
+      xorg-libxtst: ">=1.2.5,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-h1602c4f_26.conda
+    hash:
+      md5: 920916925a5d103cf923d51813cc947d
+      sha256: 703aa71462f1b7b8804e1ba6f2663073c47808c693e8a912eb0ce3191ebe90fb
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: pcre2
+    version: "10.47"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+    hash:
+      md5: 06f6113cf1ff4a54b65f87ead132a5f1
+      sha256: 9ebb10a4eb3be51ae67d85c679f5a7a50cb040ed25c783e6331a225ea09991d4
+    category: main
+    optional: false
+  - name: pixman
+    version: 0.46.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+    hash:
+      md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+      sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+    hash:
+      md5: 52df3de33d8bed542df618f403fa5b85
+      sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+    category: main
+    optional: false
+  - name: pthread-stubs
+    version: "0.4"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h7cc23a3_1004.conda
+    hash:
+      md5: bb66b610707b811e3c65181a6431e7a8
+      sha256: 4a44fd00ea73b79ca2c89b0727b9ccf61c506ead71e67a9abfa4c590042b5a4a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.3,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+    hash:
+      md5: 641613f2d89da811bc29fa4cde88ef20
+      sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: xorg-libice
+    version: 1.1.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+    hash:
+      md5: 85c9442aec283b4e464fa9ecc484a2f3
+      sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+    category: main
+    optional: false
+  - name: xorg-libsm
+    version: 1.2.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libuuid: ">=2.42.2,<3.0a0"
+      xorg-libice: ">=1.1.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+    hash:
+      md5: aa7459ed9ad086ba11dda843d764b33d
+      sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+    category: main
+    optional: false
+  - name: xorg-libx11
+    version: 1.8.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libxcb: ">=1.17.0,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+    hash:
+      md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+      sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+    category: main
+    optional: false
+  - name: xorg-libxau
+    version: 1.0.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+    hash:
+      md5: f06ef439c280a5f90b8bf62355008dbc
+      sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+    category: main
+    optional: false
+  - name: xorg-libxdmcp
+    version: 1.1.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+    hash:
+      md5: 2e66c929f3d879708335b6ea4557c838
+      sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+    category: main
+    optional: false
+  - name: xorg-libxext
+    version: 1.3.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+    hash:
+      md5: e5b6b28536b81b3f4cb20db4668a4642
+      sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+    category: main
+    optional: false
+  - name: xorg-libxfixes
+    version: 6.0.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+    hash:
+      md5: 09132e874fe0e1f5e4492b0b6b904b6e
+      sha256: aec84f554fc897bf4085c7bc8b8f0740e4c224e13bca3cc51c93e7699d56f83a
+    category: main
+    optional: false
+  - name: xorg-libxi
+    version: 1.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+      xorg-libxext: ">=1.3.7,<2.0a0"
+      xorg-libxfixes: ">=6.0.2,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+    hash:
+      md5: a1412b2b1184dacda45f8476fef2cc25
+      sha256: a523d71344a2f640efe6fc42b88fc261d9cd389d4f9838a5d42dcdb120c2b0c8
+    category: main
+    optional: false
+  - name: xorg-libxrandr
+    version: 1.5.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+      xorg-libxext: ">=1.3.7,<2.0a0"
+      xorg-libxrender: ">=0.9.12,<0.10.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+    hash:
+      md5: 798a8c9d171859a022e1cb89e7d0eb10
+      sha256: 05a7f25d7f7f5cd32b27a019233ece97167fd8ade255bc13a0e49e53387f4c30
+    category: main
+    optional: false
+  - name: xorg-libxrender
+    version: 0.9.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+    hash:
+      md5: e470d224a7a5be1b1d021bded7abb536
+      sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+    category: main
+    optional: false
+  - name: xorg-libxt
+    version: 1.3.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libice: ">=1.1.2,<2.0a0"
+      xorg-libsm: ">=1.2.6,<2.0a0"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-h7cc23a3_1.conda
+    hash:
+      md5: 2121765de9c261e2a95ab9fc6efabefb
+      sha256: dff31677674be86f98ee929a796edf2cf7c78bf38610b122a63af9af752d5bf7
+    category: main
+    optional: false
+  - name: xorg-libxtst
+    version: 1.2.5
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      xorg-libx11: ">=1.8.13,<2.0a0"
+      xorg-libxext: ">=1.3.7,<2.0a0"
+      xorg-libxi: ">=1.8.3,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+    hash:
+      md5: 752a5ac9322e0fbbc24146c1ce3ae44e
+      sha256: d66525e7b1c492aa179c6c55610fc8dfb0a9a62ea7d4fb9f904fa6af62127f61
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: gradle
+    version: 9.3.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+      openjdk: ">=17,<26"
+    url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+    hash:
+      md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+      sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+    hash:
+      md5: 887123b5b70893ef32ec962b00625415
+      sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+    hash:
+      md5: 2a60e3342ea849f65068573003279ec4
+      sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+    hash:
+      md5: 96abedd31106b39ec30864f6fa695afc
+      sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openjdk
+    version: 25.0.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h3ebe2c2_26.conda
+    hash:
+      md5: 7189e6da02ba66eec990c7108aaf249c
+      sha256: e89f4b39b6ef5fc155061f3af3bac0994a757a7e534bc8b1de0d967195be1051
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+    hash:
+      md5: 137339f92677a33a2500d3cd5361a654
+      sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+    hash:
+      md5: 8cb4d8953ebe0460fd0d04157bc790f5
+      sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: gradle
+    version: 9.3.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+      openjdk: ">=17,<26"
+    url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+    hash:
+      md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+      sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+    hash:
+      md5: f45d325d3a8739b81d47a8288b6357e2
+      sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+    hash:
+      md5: a57a8ea605573b733bb3d2010fbaf86d
+      sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+    hash:
+      md5: c4c8e364e4031850bcd232c221792e1c
+      sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openjdk
+    version: 25.0.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-hff8554d_26.conda
+    hash:
+      md5: 2f6b81bc2c67823ae56fe071291f9a70
+      sha256: d2c8f03a0a108a45d2200060ee9e73ef9d174fca24c832f1ded7ad94985ef3ec
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+    hash:
+      md5: 9be48326058aa380b7400617e73d7da6
+      sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+    hash:
+      md5: 4745cefb2d63de33e85b73cbae7ff9d2
+      sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/templates/languages/java/providers/micromamba/conda-lock.yml
+++ b/templates/languages/java/providers/micromamba/conda-lock.yml
@@ -1,0 +1,2482 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: 03fe9d208418b7fe1e1c284ed30f03e39d7c38f4f10bf97eb582023f77c4f3cb
+    osx-64: 2e07c615c6c304ad7b43feb07e200db47230206bb8ec1c1f15d5d090e238c84c
+    osx-arm64: 4fa5f78643a5e85906a019606bebb0c67ade8b34dacbc2c5e96f3d56d99c582a
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - ../tmp.2zoonlDcWC
+package:
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: alsa-lib
+  version: 1.2.16.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/alsa-lib-1.2.16.1-h7cc23a3_1.conda
+  hash:
+    md5: 7094e0d8d14de0eff6d83f0d2f1f661e
+    sha256: a35bddac04be093769e81814465a537961c6ed0f8d3cc23d6dce6ecdfaf71821
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: cairo
+  version: 1.18.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    fontconfig: '>=2.18.3,<3.0a0'
+    fonts-conda-ecosystem: ''
+    icu: '>=78.3,<79.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=15'
+    libglib: '>=2.88.3,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=15'
+    libxcb: '>=1.17.0,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    pixman: '>=0.46.4,<1.0a0'
+    xorg-libice: '>=1.1.2,<2.0a0'
+    xorg-libsm: '>=1.2.6,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/cairo-1.18.4-h3c89d7e_3.conda
+  hash:
+    md5: 7b870cffbaa8430290e567a0facd8dca
+    sha256: 6b551d9346997bc4c6fadf96b7b92442b8f3244011cc462e4ee77afc714d52c5
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: font-ttf-dejavu-sans-mono
+  version: '2.37'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-dejavu-sans-mono-2.37-hab24e00_0.tar.bz2
+  hash:
+    md5: 0c96522c6bdaed4b1566d11387caaf45
+    sha256: 58d7f40d2940dd0a8aa28651239adbf5613254df0f75789919c4e6762054403b
+  category: main
+  optional: false
+- name: font-ttf-inconsolata
+  version: '3.000'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-inconsolata-3.000-h77eed37_0.tar.bz2
+  hash:
+    md5: 34893075a5c9e55cdafac56607368fc6
+    sha256: c52a29fdac682c20d252facc50f01e7c2e7ceac52aa9817aaf0bb83f7559ec5c
+  category: main
+  optional: false
+- name: font-ttf-source-code-pro
+  version: '2.038'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-source-code-pro-2.038-h77eed37_0.tar.bz2
+  hash:
+    md5: 4d59c254e01d9cde7957100457e2d5fb
+    sha256: 00925c8c055a2275614b4d983e1df637245e19058d79fc7dd1a93b8d9fb4b139
+  category: main
+  optional: false
+- name: font-ttf-ubuntu
+  version: '0.83'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/font-ttf-ubuntu-0.83-h77eed37_3.conda
+  hash:
+    md5: 49023d73832ef61042f6a237cb2687e7
+    sha256: 2821ec1dc454bd8b9a31d0ed22a7ce22422c0aef163c59f49dfdf915d0f0ca14
+  category: main
+  optional: false
+- name: fontconfig
+  version: 2.18.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=15'
+    libuuid: '>=2.42.2,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/fontconfig-2.18.3-h4db4eae_1.conda
+  hash:
+    md5: 922776b528a470ab5afa81fd42abfa1d
+    sha256: 5a3eb10b18a97223ab06b3a7f0d7f56658db2f2800e2f2af95836fe3bf55ba63
+  category: main
+  optional: false
+- name: fonts-conda-ecosystem
+  version: '1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    fonts-conda-forge: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-ecosystem-1-0.tar.bz2
+  hash:
+    md5: fee5683a3f04bd15cbd8318b096a27ab
+    sha256: a997f2f1921bb9c9d76e6fa2f6b408b7fa549edd349a77639c9fe7a23ea93e61
+  category: main
+  optional: false
+- name: fonts-conda-forge
+  version: '1'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    font-ttf-dejavu-sans-mono: ''
+    font-ttf-inconsolata: ''
+    font-ttf-source-code-pro: ''
+    font-ttf-ubuntu: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/fonts-conda-forge-1-hc364b38_1.conda
+  hash:
+    md5: a7970cd949a077b7cb9696379d338681
+    sha256: 54eea8469786bc2291cc40bca5f46438d3e062a399e8f53f013b6a9f50e98333
+  category: main
+  optional: false
+- name: giflib
+  version: 6.1.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/giflib-6.1.3-h280c20c_1.conda
+  hash:
+    md5: 6d9a90cfee2c7343d6c05a1b37ef75fb
+    sha256: 734cd8518063b707aa098932cb109f779b8cf5a3c31633f227d22557a6bfaf53
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: gradle
+  version: 9.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+    openjdk: '>=17,<26'
+  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+  hash:
+    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+  category: main
+  optional: false
+- name: graphite2
+  version: 1.3.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/graphite2-1.3.15-h54a6638_1.conda
+  hash:
+    md5: f9fe2984587fa8235a6af6004760cd18
+    sha256: 7fa3b6a9c081fa3e545573152a788d061a0a0ba57df7251cc0f4f75225fc93e7
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: keyutils
+  version: 1.6.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/keyutils-1.6.3-h7cc23a3_1.conda
+  hash:
+    md5: ba55d1b89fd7775e67de8291029b4059
+    sha256: dd053c96dcb0dcfd59422aefea9d2fe937a190167f34fba7893ec1e10a7e8963
+  category: main
+  optional: false
+- name: krb5
+  version: 1.22.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    keyutils: '>=1.6.3,<2.0a0'
+    libedit: '>=3.1.20250104,<3.2.0a0,>=3.1.20250104,<4.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/krb5-1.22.2-hbc21106_2.conda
+  hash:
+    md5: 53318d715316929a574f83591308b1f8
+    sha256: 2a5c38c85e63df84c4e69ee71439841ce570d259ae3060627bb9a49a938d66f4
+  category: main
+  optional: false
+- name: lcms2
+  version: 2.19.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libjpeg-turbo: '>=3.2.0,<4.0a0'
+    libtiff: '>=4.7.2,<4.8.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lcms2-2.19.1-h9073bf1_2.conda
+  hash:
+    md5: b68c7304d2edb0f1a5bdfb875094d603
+    sha256: 8cdec1ff3f276cd2069dca0dae4f45f3dc5c224e2d72daef78227832938467a6
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: lerc
+  version: 4.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/lerc-4.2.0-hdb68285_0.conda
+  hash:
+    md5: fb9d356b1a57d6d54768be7ebd5fce09
+    sha256: bf9fdebf55d8bc99d83531cdffda00703f4dc5f93a1a956768c147362c72feda
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libcups
+  version: 2.3.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    krb5: '>=1.22.2,<1.23.0a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+    libzlib: '>=1.3.1,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libcups-2.3.3-h7a8fb5f_6.conda
+  hash:
+    md5: 49c553b47ff679a6a1e9fc80b9c5a2d4
+    sha256: 205c4f19550f3647832ec44e35e6d93c8c206782bdd620c1d7cf66237580ff9c
+  category: main
+  optional: false
+- name: libdeflate
+  version: '1.25'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libdeflate-1.25-hd45a770_1.conda
+  hash:
+    md5: 40f9b31aa9cf007789867df0decd0492
+    sha256: 82e134c8a08b1eed9a2ed8ab578b89aa1730dcde3dea8dd87645ed0637878e54
+  category: main
+  optional: false
+- name: libedit
+  version: 3.1.20250104
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libedit-3.1.20250104-pl5321h373387f_1.conda
+  hash:
+    md5: 50708d3b951d0f8e2d7f2df5b5edc040
+    sha256: 6473eb8caf2aae830f37caa93db9b26dddf7ac84b63229e8bf7fc0e5c3ab95b0
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libfreetype
+  version: 2.14.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    libfreetype6: '>=2.14.3'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype-2.14.3-ha770c72_2.conda
+  hash:
+    md5: f8054e759d0ddddaf34a5c8fedc900a1
+    sha256: fb12ecb46c30d18d928c0e8fc346ab13b5f6fc8a9cacae4f2f4bb188782586f5
+  category: main
+  optional: false
+- name: libfreetype6
+  version: 2.14.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libfreetype6-2.14.3-h5e6c136_2.conda
+  hash:
+    md5: b72a266a9317036fd0464cb98b027cd0
+    sha256: ec607dd5445dd17ff6bf8b7fe6832e5504c226dd91d3aaea7ba83569808b0ce4
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libglib
+  version: 2.88.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    libiconv: '>=1.18,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    pcre2: '>=10.47,<10.48.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libglib-2.88.3-he503a2a_3.conda
+  hash:
+    md5: d216efacca3f34f2b13ddd1632f53833
+    sha256: f57bf3954dbba8b27ec68540e84f8b2c2375ffa5702f89ca9741e17329fc3953
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libharfbuzz
+  version: 14.4.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    cairo: '>=1.18.4,<2.0a0'
+    graphite2: '>=1.3.15,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=15'
+    libglib: '>=2.88.3,<3.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libharfbuzz-14.4.0-h23af247_1.conda
+  hash:
+    md5: c44470b6bfa6a582cb4dd42cbda3401e
+    sha256: 979b14ba13054aab9e90363809aac470a58b7c37203c330216327356a98c8f60
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: libjpeg-turbo
+  version: 3.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libjpeg-turbo-3.2.0-hb03c661_1.conda
+  hash:
+    md5: 898d1c9793eaa52efc4727bd84d2e39a
+    sha256: bba8538e6538ed58a8479b332337b96986561f975d06cfa2039a016c2d246ee4
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libpng
+  version: 1.6.58
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpng-1.6.58-h922cc85_1.conda
+  hash:
+    md5: fcf71c8d979148873f6f8ad4cfc73d86
+    sha256: c19eefb87d70d9b4b0629fa48414a155a47a1be4f04583ae71ed8c5a9a32fdcb
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+  hash:
+    md5: e64cd43bbd07afafbc458138e979c851
+    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libtiff
+  version: 4.7.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    lerc: '>=4.2.0,<5.0a0'
+    libdeflate: '>=1.25,<1.26.0a0'
+    libgcc: '>=15'
+    libjpeg-turbo: '>=3.2.0,<4.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libstdcxx: '>=15'
+    libwebp-base: '>=1.6.0,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libtiff-4.7.2-hcc2c06a_1.conda
+  hash:
+    md5: 0907d876f460ebc941ae590338b6102f
+    sha256: 10e125da82ca93e09191e66e5a94d566b2cf8d4024e2a0db3a9114297447e0d9
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libwebp-base
+  version: 1.6.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libwebp-base-1.6.0-hd42ef1d_1.conda
+  hash:
+    md5: 9332b53d0ea93c5d39e33be03a0c611a
+    sha256: 8415001414f488c85b72b9d8cc2071dfb3981a47bc3c8eb56ef91a57d12eae7f
+  category: main
+  optional: false
+- name: libxcb
+  version: 1.17.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    pthread-stubs: ''
+    xorg-libxau: '>=1.0.12,<2.0a0'
+    xorg-libxdmcp: '>=1.1.5,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxcb-1.17.0-hb83e432_2.conda
+  hash:
+    md5: 61f0ffba9161cbb3a77722869b21e4bb
+    sha256: 7b49e6fd2a584b7f072943e6adf4149677af5121246975278804782d37752837
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+  hash:
+    md5: 2e632ce02d57623142f2e4b8ab725f2b
+    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+  hash:
+    md5: fd10c0e72a410d57f4c5073dbc4ec505
+    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openjdk
+  version: 25.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    alsa-lib: '>=1.2.16.1,<1.3.0a0'
+    fontconfig: '>=2.18.3,<3.0a0'
+    fonts-conda-ecosystem: ''
+    giflib: '>=6.1.3,<6.2.0a0'
+    lcms2: '>=2.19.1,<3.0a0'
+    libcups: '>=2.3.3,<2.4.0a0'
+    libfreetype: '>=2.14.3'
+    libfreetype6: '>=2.14.3'
+    libgcc: '>=15'
+    libharfbuzz: '>=14.4.0'
+    libjpeg-turbo: '>=3.2.0,<4.0a0'
+    libpng: '>=1.6.58,<1.7.0a0'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxi: '>=1.8.3,<2.0a0'
+    xorg-libxrandr: '>=1.5.5,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+    xorg-libxt: '>=1.3.1,<2.0a0'
+    xorg-libxtst: '>=1.2.5,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openjdk-25.0.2-h1602c4f_26.conda
+  hash:
+    md5: 920916925a5d103cf923d51813cc947d
+    sha256: 703aa71462f1b7b8804e1ba6f2663073c47808c693e8a912eb0ce3191ebe90fb
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: pcre2
+  version: '10.47'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pcre2-10.47-h8b3dc9c_1.conda
+  hash:
+    md5: 06f6113cf1ff4a54b65f87ead132a5f1
+    sha256: 9ebb10a4eb3be51ae67d85c679f5a7a50cb040ed25c783e6331a225ea09991d4
+  category: main
+  optional: false
+- name: pixman
+  version: 0.46.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pixman-0.46.4-h54a6638_3.conda
+  hash:
+    md5: 0ee5bb30034b081a1386c1e2c98ab0a7
+    sha256: 829d8288764282de5a9f7b9169acb75cc7dc0b6c3fe2535cfe87dea3436bbc5d
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+  hash:
+    md5: 52df3de33d8bed542df618f403fa5b85
+    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+  category: main
+  optional: false
+- name: pthread-stubs
+  version: '0.4'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/pthread-stubs-0.4-h7cc23a3_1004.conda
+  hash:
+    md5: bb66b610707b811e3c65181a6431e7a8
+    sha256: 4a44fd00ea73b79ca2c89b0727b9ccf61c506ead71e67a9abfa4c590042b5a4a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.3,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+  hash:
+    md5: 641613f2d89da811bc29fa4cde88ef20
+    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: xorg-libice
+  version: 1.1.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libice-1.1.2-h280c20c_0.conda
+  hash:
+    md5: 85c9442aec283b4e464fa9ecc484a2f3
+    sha256: 49b532d1df875c6749d9078b56a76f3f5db49a5abe0ca620b593ed474ef0ebf1
+  category: main
+  optional: false
+- name: xorg-libsm
+  version: 1.2.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libuuid: '>=2.42.2,<3.0a0'
+    xorg-libice: '>=1.1.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libsm-1.2.6-h0d788c3_1.conda
+  hash:
+    md5: aa7459ed9ad086ba11dda843d764b33d
+    sha256: ef907caee0665cf3b0f775602cc50e388e3bade8ce22ecade0873ff26604b2fd
+  category: main
+  optional: false
+- name: xorg-libx11
+  version: 1.8.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libxcb: '>=1.17.0,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libx11-1.8.13-he1eb515_1.conda
+  hash:
+    md5: 8c282bbe4808a3cc80a5c98e9aec1cfc
+    sha256: 68053eebfa9f0d91666786c8fb5839d989aa9b869add92cb8815228bb2d7302c
+  category: main
+  optional: false
+- name: xorg-libxau
+  version: 1.0.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxau-1.0.12-hb03c661_2.conda
+  hash:
+    md5: f06ef439c280a5f90b8bf62355008dbc
+    sha256: cbf891f6cc1a859347680af1c8562bc6b033bf182a2a3bb536016932be3206de
+  category: main
+  optional: false
+- name: xorg-libxdmcp
+  version: 1.1.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxdmcp-1.1.5-hb03c661_2.conda
+  hash:
+    md5: 2e66c929f3d879708335b6ea4557c838
+    sha256: c50a16c05ccd7fe7dd6d6cfb539f4e9a491d50f9ed7a5c902fec638f7d0d27be
+  category: main
+  optional: false
+- name: xorg-libxext
+  version: 1.3.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxext-1.3.7-h7cc23a3_1.conda
+  hash:
+    md5: e5b6b28536b81b3f4cb20db4668a4642
+    sha256: aa9bbe8b278aacc194e280ff5037f9f9a1f2c5b33ed97de8e7f01cfbe90dda43
+  category: main
+  optional: false
+- name: xorg-libxfixes
+  version: 6.0.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxfixes-6.0.2-h7cc23a3_1.conda
+  hash:
+    md5: 09132e874fe0e1f5e4492b0b6b904b6e
+    sha256: aec84f554fc897bf4085c7bc8b8f0740e4c224e13bca3cc51c93e7699d56f83a
+  category: main
+  optional: false
+- name: xorg-libxi
+  version: 1.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxfixes: '>=6.0.2,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxi-1.8.3-h7cc23a3_1.conda
+  hash:
+    md5: a1412b2b1184dacda45f8476fef2cc25
+    sha256: a523d71344a2f640efe6fc42b88fc261d9cd389d4f9838a5d42dcdb120c2b0c8
+  category: main
+  optional: false
+- name: xorg-libxrandr
+  version: 1.5.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxrender: '>=0.9.12,<0.10.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrandr-1.5.5-h7cc23a3_1.conda
+  hash:
+    md5: 798a8c9d171859a022e1cb89e7d0eb10
+    sha256: 05a7f25d7f7f5cd32b27a019233ece97167fd8ade255bc13a0e49e53387f4c30
+  category: main
+  optional: false
+- name: xorg-libxrender
+  version: 0.9.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxrender-0.9.12-hb03c661_1.conda
+  hash:
+    md5: e470d224a7a5be1b1d021bded7abb536
+    sha256: 6901f91d398811e4ec89d7e20a69abac02a7bfebfaf073338b7ea3d1a99685b7
+  category: main
+  optional: false
+- name: xorg-libxt
+  version: 1.3.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libice: '>=1.1.2,<2.0a0'
+    xorg-libsm: '>=1.2.6,<2.0a0'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxt-1.3.1-h7cc23a3_1.conda
+  hash:
+    md5: 2121765de9c261e2a95ab9fc6efabefb
+    sha256: dff31677674be86f98ee929a796edf2cf7c78bf38610b122a63af9af752d5bf7
+  category: main
+  optional: false
+- name: xorg-libxtst
+  version: 1.2.5
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    xorg-libx11: '>=1.8.13,<2.0a0'
+    xorg-libxext: '>=1.3.7,<2.0a0'
+    xorg-libxi: '>=1.8.3,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/xorg-libxtst-1.2.5-h7cc23a3_4.conda
+  hash:
+    md5: 752a5ac9322e0fbbc24146c1ce3ae44e
+    sha256: d66525e7b1c492aa179c6c55610fc8dfb0a9a62ea7d4fb9f904fa6af62127f61
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: gradle
+  version: 9.3.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+    openjdk: '>=17,<26'
+  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+  hash:
+    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+  hash:
+    md5: 887123b5b70893ef32ec962b00625415
+    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+  hash:
+    md5: 2a60e3342ea849f65068573003279ec4
+    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+  hash:
+    md5: 96abedd31106b39ec30864f6fa695afc
+    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openjdk
+  version: 25.0.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/openjdk-25.0.2-h3ebe2c2_26.conda
+  hash:
+    md5: 7189e6da02ba66eec990c7108aaf249c
+    sha256: e89f4b39b6ef5fc155061f3af3bac0994a757a7e534bc8b1de0d967195be1051
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+  hash:
+    md5: 137339f92677a33a2500d3cd5361a654
+    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+  hash:
+    md5: 8cb4d8953ebe0460fd0d04157bc790f5
+    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: gradle
+  version: 9.3.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+    openjdk: '>=17,<26'
+  url: https://conda.anaconda.org/conda-forge/noarch/gradle-9.3.1-h707e725_0.conda
+  hash:
+    md5: 95f97ca1ddff8aec3a21e9cb78f40b10
+    sha256: b6a6e817bec22eef67e046b4b4f6cf023cabafd8b20a8872b6bcfe66967b3299
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+  hash:
+    md5: f45d325d3a8739b81d47a8288b6357e2
+    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+  hash:
+    md5: a57a8ea605573b733bb3d2010fbaf86d
+    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+  hash:
+    md5: c4c8e364e4031850bcd232c221792e1c
+    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openjdk
+  version: 25.0.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openjdk-25.0.2-hff8554d_26.conda
+  hash:
+    md5: 2f6b81bc2c67823ae56fe071291f9a70
+    sha256: d2c8f03a0a108a45d2200060ee9e73ef9d174fca24c832f1ded7ad94985ef3ec
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+  hash:
+    md5: 9be48326058aa380b7400617e73d7da6
+    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+  hash:
+    md5: 4745cefb2d63de33e85b73cbae7ff9d2
+    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/templates/languages/python/providers/micromamba/Makefile
+++ b/templates/languages/python/providers/micromamba/Makefile
@@ -29,7 +29,7 @@ MAKEFLAGS += --no-builtin-rules
 # Configuration
 # =============================================================================
 MAMBA_ENV  := {{REPOSITORY_NAME}}
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA := $(CURDIR)/.provider/bin/micromamba
 
 # LINT_MODE: fix (default, local dev) or check (CI, no auto-fix)

--- a/templates/languages/python/providers/micromamba/conda-lock.yml
+++ b/templates/languages/python/providers/micromamba/conda-lock.yml
@@ -5,1760 +5,1760 @@ metadata:
     osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
     osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - ../tmp.e5L3sFSdBk
+    - ../tmp.e5L3sFSdBk
 package:
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
-  hash:
-    md5: e64cd43bbd07afafbc458138e979c851
-    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
-  hash:
-    md5: 2e632ce02d57623142f2e4b8ab725f2b
-    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
-  hash:
-    md5: fd10c0e72a410d57f4c5073dbc4ec505
-    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
-  hash:
-    md5: 52df3de33d8bed542df618f403fa5b85
-    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.3,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
-  hash:
-    md5: 641613f2d89da811bc29fa4cde88ef20
-    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
-  hash:
-    md5: 887123b5b70893ef32ec962b00625415
-    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
-  hash:
-    md5: 2a60e3342ea849f65068573003279ec4
-    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
-  hash:
-    md5: 96abedd31106b39ec30864f6fa695afc
-    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
-  hash:
-    md5: 137339f92677a33a2500d3cd5361a654
-    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
-  hash:
-    md5: 8cb4d8953ebe0460fd0d04157bc790f5
-    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
-  hash:
-    md5: f45d325d3a8739b81d47a8288b6357e2
-    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
-  hash:
-    md5: a57a8ea605573b733bb3d2010fbaf86d
-    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
-  hash:
-    md5: c4c8e364e4031850bcd232c221792e1c
-    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
-  hash:
-    md5: 9be48326058aa380b7400617e73d7da6
-    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
-  hash:
-    md5: 4745cefb2d63de33e85b73cbae7ff9d2
-    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+    hash:
+      md5: e64cd43bbd07afafbc458138e979c851
+      sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+    hash:
+      md5: 2e632ce02d57623142f2e4b8ab725f2b
+      sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+    hash:
+      md5: fd10c0e72a410d57f4c5073dbc4ec505
+      sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+    hash:
+      md5: 52df3de33d8bed542df618f403fa5b85
+      sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.3,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+    hash:
+      md5: 641613f2d89da811bc29fa4cde88ef20
+      sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+    hash:
+      md5: 887123b5b70893ef32ec962b00625415
+      sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+    hash:
+      md5: 2a60e3342ea849f65068573003279ec4
+      sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+    hash:
+      md5: 96abedd31106b39ec30864f6fa695afc
+      sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+    hash:
+      md5: 137339f92677a33a2500d3cd5361a654
+      sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+    hash:
+      md5: 8cb4d8953ebe0460fd0d04157bc790f5
+      sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+    hash:
+      md5: f45d325d3a8739b81d47a8288b6357e2
+      sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+    hash:
+      md5: a57a8ea605573b733bb3d2010fbaf86d
+      sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+    hash:
+      md5: c4c8e364e4031850bcd232c221792e1c
+      sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+    hash:
+      md5: 9be48326058aa380b7400617e73d7da6
+      sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+    hash:
+      md5: 4745cefb2d63de33e85b73cbae7ff9d2
+      sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/templates/languages/python/providers/micromamba/conda-lock.yml
+++ b/templates/languages/python/providers/micromamba/conda-lock.yml
@@ -1,0 +1,1764 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: c09e630355ed05511eb38c30cdbfed3f2b85841d58b22bd6e174cf2cfcfed50f
+    osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
+    osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - ../tmp.e5L3sFSdBk
+package:
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+  hash:
+    md5: e64cd43bbd07afafbc458138e979c851
+    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+  hash:
+    md5: 2e632ce02d57623142f2e4b8ab725f2b
+    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+  hash:
+    md5: fd10c0e72a410d57f4c5073dbc4ec505
+    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+  hash:
+    md5: 52df3de33d8bed542df618f403fa5b85
+    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.3,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+  hash:
+    md5: 641613f2d89da811bc29fa4cde88ef20
+    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+  hash:
+    md5: 887123b5b70893ef32ec962b00625415
+    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+  hash:
+    md5: 2a60e3342ea849f65068573003279ec4
+    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+  hash:
+    md5: 96abedd31106b39ec30864f6fa695afc
+    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+  hash:
+    md5: 137339f92677a33a2500d3cd5361a654
+    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+  hash:
+    md5: 8cb4d8953ebe0460fd0d04157bc790f5
+    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+  hash:
+    md5: f45d325d3a8739b81d47a8288b6357e2
+    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+  hash:
+    md5: a57a8ea605573b733bb3d2010fbaf86d
+    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+  hash:
+    md5: c4c8e364e4031850bcd232c221792e1c
+    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+  hash:
+    md5: 9be48326058aa380b7400617e73d7da6
+    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+  hash:
+    md5: 4745cefb2d63de33e85b73cbae7ff9d2
+    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/templates/languages/typescript/providers/micromamba/Makefile
+++ b/templates/languages/typescript/providers/micromamba/Makefile
@@ -30,7 +30,7 @@ MAKEFLAGS += --no-builtin-rules
 # Configuration
 # =============================================================================
 MAMBA_ENV  := {{REPOSITORY_NAME}}
-MAMBA_SPEC := $(CURDIR)/environment.yml
+MAMBA_SPEC := $(CURDIR)/conda-lock.yml
 MICROMAMBA := $(CURDIR)/.provider/bin/micromamba
 
 # LINT_MODE: fix (default, local dev) or check (CI, no auto-fix)

--- a/templates/languages/typescript/providers/micromamba/conda-lock.yml
+++ b/templates/languages/typescript/providers/micromamba/conda-lock.yml
@@ -1,0 +1,1764 @@
+version: 1
+metadata:
+  content_hash:
+    linux-64: c09e630355ed05511eb38c30cdbfed3f2b85841d58b22bd6e174cf2cfcfed50f
+    osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
+    osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
+  channels:
+  - url: conda-forge
+    used_env_vars: []
+  platforms:
+  - linux-64
+  - osx-64
+  - osx-arm64
+  sources:
+  - ../tmp.gbfhRgp9Zi
+package:
+- name: _openmp_mutex
+  version: '4.5'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgomp: '>=7.5.0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+  hash:
+    md5: a9f577daf3de00bca7c3c76c0ecbd1de
+    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+  hash:
+    md5: bab393750db08f50eebaf96f50d18734
+    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+  hash:
+    md5: e675fabcf81499adc7edf58124fb1e01
+    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+  hash:
+    md5: 3ad2b403be8fc5612b9159e2ce621f69
+    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+  hash:
+    md5: c63e2851f3d99a32f4b6991d0460dd25
+    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+  hash:
+    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+  hash:
+    md5: 72a381cbad04f24b1c2a43ef707f45b4
+    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+  hash:
+    md5: 6ec056e539486e84f0c7acef6b5863f9
+    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+  category: main
+  optional: false
+- name: ld_impl_linux-64
+  version: 2.46.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+  hash:
+    md5: 449500f2c089da11c40f5c21312e3e07
+    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+  hash:
+    md5: df210655e30a05e3b069c91b7aaddd2d
+    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+  hash:
+    md5: 0cfd601eb03cca403dcc248844787486
+    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libbrotlicommon: 1.2.0
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+  hash:
+    md5: 4136f6e4ef4835cc7df39a707cbd511c
+    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+  hash:
+    md5: 7bc31538d6e3fb349e897353969237ec
+    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+  hash:
+    md5: b24d3c612f71e7aa74158d92106318b2
+    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+  hash:
+    md5: 6525a0b06aa4fd390795f0740636a9dd
+    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+  category: main
+  optional: false
+- name: libgcc
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    _openmp_mutex: '>=4.5'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+  hash:
+    md5: cba14d01083fc62ffd32c24d7d390633
+    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+  category: main
+  optional: false
+- name: libgomp
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+  hash:
+    md5: 89d2c1231f47bd818f5d624b9411459d
+    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+  hash:
+    md5: f92233bf33e24a25668bb2119e2c51f9
+    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+  hash:
+    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+  hash:
+    md5: fcfed1dc5053eb1901b66e7b1fc32588
+    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+  hash:
+    md5: 75d211f04ac87506f1f43420712a69fe
+    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libstdcxx: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+  hash:
+    md5: e64cd43bbd07afafbc458138e979c851
+    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+  hash:
+    md5: e72bbec309c2b0f37823ee7d4fabfcd3
+    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+  category: main
+  optional: false
+- name: libstdcxx
+  version: 16.2.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: 16.2.0
+  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+  hash:
+    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+  category: main
+  optional: false
+- name: libuuid
+  version: 2.42.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+  hash:
+    md5: 74a0a409d9f4561265d36b789d3f398a
+    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+  hash:
+    md5: 01c4ed87826af55996768af6dbc936b4
+    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+  hash:
+    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    icu: '>=78.3,<79.0a0'
+    libgcc: '>=14'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+  hash:
+    md5: 20e4d67ec908f0405124f11612c48305
+    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+  hash:
+    md5: 0de0122d9570a8ab637c6b73db268389
+    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: linux-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+  hash:
+    md5: 2e632ce02d57623142f2e4b8ab725f2b
+    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+  hash:
+    md5: ee6c0cd80a60961a1f48aa3e0b91f986
+    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.28,<3.0.a0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libgcc: '>=15'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libstdcxx: '>=15'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+  hash:
+    md5: fd10c0e72a410d57f4c5073dbc4ec505
+    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+  hash:
+    md5: 16c8e401c682f9961676c201c888b1d9
+    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    ca-certificates: ''
+    libgcc: '>=15'
+  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+  hash:
+    md5: 16e3034a330cc625f2c685edec60cf4e
+    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+  hash:
+    md5: 52df3de33d8bed542df618f403fa5b85
+    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    bzip2: '>=1.0.8,<2.0a0'
+    ld_impl_linux-64: '>=2.36.1'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    libgcc: '>=15'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuuid: '>=2.42.3,<3.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+  hash:
+    md5: 641613f2d89da811bc29fa4cde88ef20
+    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+  hash:
+    md5: 69c01c781e7c8190bbdaf79e3848c5ca
+    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+  hash:
+    md5: 59f8f9cfb1dc2f62abdca662823e052a
+    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+  hash:
+    md5: 718059e50f92fa30cb9b4daa597b41ce
+    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+  hash:
+    md5: a7ebff8e3d9b0b52d01e27df8186578b
+    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=15'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+  hash:
+    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: linux-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libgcc: '>=14'
+    libstdcxx: '>=14'
+  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+  hash:
+    md5: e2aa261b3d22a8bbb3cc291619e7035a
+    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: linux-64
+  dependencies:
+    __glibc: '>=2.17,<3.0.a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+  hash:
+    md5: aa459086047c0e5e27023ab19f8cb86a
+    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+  hash:
+    md5: 7a360d28a2a40006bc138f05b93188d1
+    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+  hash:
+    md5: 9d9a39212a876e4bb751c1cc3927b678
+    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+  hash:
+    md5: 925ff9ab74f4b9262a28842766e9e7b1
+    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+  hash:
+    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+  hash:
+    md5: a02dd7bb48ecd345060a1203337aaa4a
+    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+  hash:
+    md5: 969f5550ba655de65ff0b7b4305b7f6c
+    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+  hash:
+    md5: f13f4740c18b562bf2662d494bad6099
+    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+  hash:
+    md5: 99ea337e58c6216a04473c8f52815435
+    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+  hash:
+    md5: faa59453024554888f67ac3142f6e4f4
+    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+  hash:
+    md5: 23362431ccf826a88ea0bdefd2ffa9dd
+    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+  hash:
+    md5: c9d01f04f03fff927a846e1985a89383
+    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+  hash:
+    md5: 925382e3a8a530f862be5be3b3aaf68b
+    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+  hash:
+    md5: 6d2f0447151b390bdaed846e143272e3
+    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+  hash:
+    md5: dcfdea7b7013beef0a4d744d776ea38f
+    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+  hash:
+    md5: e077b71ae65754eda067e4125364b905
+    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+  hash:
+    md5: 9fd2f77288f43e462ccc6b0e5f018c89
+    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+  hash:
+    md5: daf49067580fbfeae3ac7f9535400494
+    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+  hash:
+    md5: b10a43915a31193e06b2781b9d11aec3
+    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+  hash:
+    md5: b7c605bed8006cdeb822dd7de6ac87c7
+    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+  hash:
+    md5: 887123b5b70893ef32ec962b00625415
+    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+  hash:
+    md5: 254c302876eacc77a4682b3fa6f72385
+    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+  hash:
+    md5: 17b0d6c818992264752f1a720be711fc
+    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+  hash:
+    md5: 76a9680db40bf124688951cf08d82105
+    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+  hash:
+    md5: 0514c28a6085f32e7b4ef43f9398a447
+    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+  hash:
+    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+  hash:
+    md5: 2a60e3342ea849f65068573003279ec4
+    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+  hash:
+    md5: 88a79390f87c8f3334b9999a892e78d4
+    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+  hash:
+    md5: 96abedd31106b39ec30864f6fa695afc
+    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+  hash:
+    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+  hash:
+    md5: 7a1b628e987d25df3ac6986d45bb0979
+    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+  hash:
+    md5: 137339f92677a33a2500d3cd5361a654
+    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+  hash:
+    md5: 8cb4d8953ebe0460fd0d04157bc790f5
+    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+  hash:
+    md5: 434eb49340f57827ef7ca3bb21f77c32
+    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+  hash:
+    md5: 85b923438e74e1828639a39f674e5958
+    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+  hash:
+    md5: d0ca306378b3e170395e31aef18cca83
+    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+  hash:
+    md5: 713bfc46feeecfc049ffaa9f3fe25940
+    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+  hash:
+    md5: 71c9f1f0267f2639523e898c6b50a4dc
+    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+  hash:
+    md5: 94b1b7a6122698418badfbf60a2b11ad
+    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+  hash:
+    md5: c1d11f04327e40537ffe6cad5b131019
+    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+  category: main
+  optional: false
+- name: actionlint
+  version: 1.7.12
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+  hash:
+    md5: 87084addab359d538cbf8493726cf3f8
+    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+  category: main
+  optional: false
+- name: bzip2
+  version: 1.0.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+  hash:
+    md5: b50612e7d190b8061ab4e7dc119cf4d5
+    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+  category: main
+  optional: false
+- name: c-ares
+  version: 1.34.8
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+  hash:
+    md5: 4cc01a374215de38387d45e19c8c5c9c
+    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+  category: main
+  optional: false
+- name: ca-certificates
+  version: 2026.7.22
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __unix: ''
+  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+  hash:
+    md5: 0f51e2391ade309db462a55611263e9c
+    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+  category: main
+  optional: false
+- name: coreutils
+  version: '9.11'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+  hash:
+    md5: b9c285813535217aba1d2c8b55bf947a
+    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+  category: main
+  optional: false
+- name: gmp
+  version: 6.3.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+  hash:
+    md5: bbfa5bd261b68536ddcda39e03d3407f
+    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+  category: main
+  optional: false
+- name: go-shfmt
+  version: 3.13.1
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+  hash:
+    md5: 55beafb01e44f9527026dbffcea260ee
+    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+  category: main
+  optional: false
+- name: icu
+  version: '78.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+  hash:
+    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+  category: main
+  optional: false
+- name: jq
+  version: 1.8.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+  hash:
+    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+  category: main
+  optional: false
+- name: libbrotlicommon
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+  hash:
+    md5: 8f3981871d167a6cd323e636e1929dd4
+    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+  category: main
+  optional: false
+- name: libbrotlidec
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+  hash:
+    md5: da537a1643ef3e13bdccf16cca206f2c
+    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+  category: main
+  optional: false
+- name: libbrotlienc
+  version: 1.2.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libbrotlicommon: 1.2.0
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+  hash:
+    md5: 39a25d500b191c16996239c4afa104f1
+    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+  category: main
+  optional: false
+- name: libcxx
+  version: 23.1.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+  hash:
+    md5: 5303ba06fab927399ed8dfb3227b0af8
+    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+  category: main
+  optional: false
+- name: libev
+  version: '4.33'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+  hash:
+    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+  category: main
+  optional: false
+- name: libexpat
+  version: 2.8.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+  hash:
+    md5: a915151d5d3c5bf039f5ccc8402a436f
+    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+  category: main
+  optional: false
+- name: libffi
+  version: 3.7.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+  hash:
+    md5: 216bbcc23c11e9695b3db4a8771d76eb
+    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+  category: main
+  optional: false
+- name: libiconv
+  version: '1.18'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+  hash:
+    md5: 17f4744c0873e9f77ac9b5cd0a27c187
+    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+  category: main
+  optional: false
+- name: liblzma
+  version: 5.8.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+  hash:
+    md5: 8ab10323068b107661a4b9a4af84f3b5
+    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+  category: main
+  optional: false
+- name: libmpdec
+  version: 4.0.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+  hash:
+    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+  category: main
+  optional: false
+- name: libnghttp2
+  version: 1.68.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    libcxx: '>=21'
+    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.7,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+  hash:
+    md5: ac9902dcbe0417f50cf95ab2bde062fa
+    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+  category: main
+  optional: false
+- name: libpython
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=21'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+  hash:
+    md5: f45d325d3a8739b81d47a8288b6357e2
+    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+  category: main
+  optional: false
+- name: libsqlite
+  version: 3.53.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+  hash:
+    md5: fde96d40ebe9a9cb34e4122380189ddb
+    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+  category: main
+  optional: false
+- name: libuv
+  version: 1.52.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+  hash:
+    md5: de09bd0f175611e94f21b28f8c708e80
+    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+  category: main
+  optional: false
+- name: libxml2
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libxml2-16: 2.15.3
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+  hash:
+    md5: 06a3f8eb5cdde56b2d10b49ae3337954
+    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+  category: main
+  optional: false
+- name: libxml2-16
+  version: 2.15.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    icu: '>=78.3,<79.0a0'
+    libiconv: '>=1.18,<2.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+  hash:
+    md5: f86c0b8ac5c866049717b55df1049c2c
+    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+  category: main
+  optional: false
+- name: libzlib
+  version: 1.3.2
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+  hash:
+    md5: f39288f0ea63ae962e1a2e4f355a0d75
+    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+  category: main
+  optional: false
+- name: markdownlint-cli
+  version: 0.49.1
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+  hash:
+    md5: a57a8ea605573b733bb3d2010fbaf86d
+    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+  category: main
+  optional: false
+- name: ncurses
+  version: '6.6'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+  hash:
+    md5: 3dfa0d0316dc246cd44937a557de4501
+    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+  category: main
+  optional: false
+- name: nodejs
+  version: 24.19.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=12.0'
+    c-ares: '>=1.34.8,<2.0a0'
+    icu: '>=78.3,<79.0a0'
+    libbrotlicommon: '>=1.2.0,<1.3.0a0'
+    libbrotlidec: '>=1.2.0,<1.3.0a0'
+    libbrotlienc: '>=1.2.0,<1.3.0a0'
+    libcxx: '>=21'
+    libnghttp2: '>=1.68.1,<2.0a0'
+    libsqlite: '>=3.53.4,<4.0a0'
+    libuv: '>=1.52.1,<2.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    zstd: '>=1.5.7,<1.6.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+  hash:
+    md5: c4c8e364e4031850bcd232c221792e1c
+    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+  category: main
+  optional: false
+- name: oniguruma
+  version: 6.9.10
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+  hash:
+    md5: ffe6286c38000935f186202d469aab0a
+    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+  category: main
+  optional: false
+- name: openssl
+  version: 3.6.4
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ca-certificates: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+  hash:
+    md5: ae71ab40048c19a389a7dcccb86c2481
+    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+  category: main
+  optional: false
+- name: prettier
+  version: 3.9.3
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    nodejs: '>=24.18.0,<25.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+  hash:
+    md5: 9be48326058aa380b7400617e73d7da6
+    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+  category: main
+  optional: false
+- name: python
+  version: 3.13.15
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    bzip2: '>=1.0.8,<2.0a0'
+    libexpat: '>=2.8.1,<3.0a0'
+    libffi: '>=3.7.0,<3.8.0a0'
+    liblzma: '>=5.8.3,<6.0a0'
+    libmpdec: '>=4.0.0,<5.0a0'
+    libpython: 3.13.15
+    libsqlite: '>=3.53.4,<4.0a0'
+    libzlib: '>=1.3.2,<2.0a0'
+    ncurses: '>=6.6,<7.0a0'
+    openssl: '>=3.5.8,<4.0a0'
+    python_abi: 3.13.*
+    readline: '>=8.3,<9.0a0'
+    tk: '>=8.6.13,<8.7.0a0'
+    tzdata: ''
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+  hash:
+    md5: 4745cefb2d63de33e85b73cbae7ff9d2
+    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+  category: main
+  optional: false
+- name: python_abi
+  version: '3.13'
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+  hash:
+    md5: c5abc97af551bc12d71305852392f75c
+    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+  category: main
+  optional: false
+- name: readline
+  version: '8.3'
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    ncurses: '>=6.6,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+  hash:
+    md5: 9347fd56a002e6b58946831d48fe62f6
+    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+  category: main
+  optional: false
+- name: shellcheck
+  version: 0.11.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    gmp: '>=6.3.0,<7.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+  hash:
+    md5: 16c849ba724a6d59132a3b7547e2bd36
+    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+  category: main
+  optional: false
+- name: taplo
+  version: 0.10.0
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    openssl: '>=3.5.6,<4.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+  hash:
+    md5: 8ee9613094590d6b7cbb2e98e5a75314
+    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+  category: main
+  optional: false
+- name: terraform
+  version: 1.15.6
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+  hash:
+    md5: 1f7d7177d1a3b1cd872457e20eca56b2
+    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+  category: main
+  optional: false
+- name: tk
+  version: 8.6.13
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+  hash:
+    md5: 90a01bf394d1c594e0eb9258f967d828
+    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+  category: main
+  optional: false
+- name: tzdata
+  version: 2026c
+  manager: conda
+  platform: osx-arm64
+  dependencies: {}
+  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+  hash:
+    md5: fcb489df604d100968b737f2cb6076c6
+    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+  category: main
+  optional: false
+- name: uv
+  version: 0.11.30
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libcxx: '>=19'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+  hash:
+    md5: eaf1e624c3c1de1a05404689b48e39d5
+    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+  category: main
+  optional: false
+- name: zstd
+  version: 1.5.7
+  manager: conda
+  platform: osx-arm64
+  dependencies:
+    __osx: '>=11.0'
+    libzlib: '>=1.3.2,<2.0a0'
+  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+  hash:
+    md5: 4ec2684c73812cc2c3d78379384a39cc
+    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+  category: main
+  optional: false

--- a/templates/languages/typescript/providers/micromamba/conda-lock.yml
+++ b/templates/languages/typescript/providers/micromamba/conda-lock.yml
@@ -5,1760 +5,1760 @@ metadata:
     osx-64: e6eede6176e72da59378ea712c1f4137c0515e368cc7dd64e46b532d4fe2121d
     osx-arm64: 7dc85b227ead9e6b48662ef66ec644f8aa6b2fa032968acba16d72b80342c83a
   channels:
-  - url: conda-forge
-    used_env_vars: []
+    - url: conda-forge
+      used_env_vars: []
   platforms:
-  - linux-64
-  - osx-64
-  - osx-arm64
+    - linux-64
+    - osx-64
+    - osx-arm64
   sources:
-  - ../tmp.gbfhRgp9Zi
+    - ../tmp.gbfhRgp9Zi
 package:
-- name: _openmp_mutex
-  version: '4.5'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgomp: '>=7.5.0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
-  hash:
-    md5: a9f577daf3de00bca7c3c76c0ecbd1de
-    sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
-  hash:
-    md5: bab393750db08f50eebaf96f50d18734
-    sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
-  hash:
-    md5: e675fabcf81499adc7edf58124fb1e01
-    sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
-  hash:
-    md5: 3ad2b403be8fc5612b9159e2ce621f69
-    sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
-  hash:
-    md5: c63e2851f3d99a32f4b6991d0460dd25
-    sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
-  hash:
-    md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
-    sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
-  hash:
-    md5: 72a381cbad04f24b1c2a43ef707f45b4
-    sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
-  hash:
-    md5: 6ec056e539486e84f0c7acef6b5863f9
-    sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
-  category: main
-  optional: false
-- name: ld_impl_linux-64
-  version: 2.46.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
-  hash:
-    md5: 449500f2c089da11c40f5c21312e3e07
-    sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
-  hash:
-    md5: df210655e30a05e3b069c91b7aaddd2d
-    sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
-  hash:
-    md5: 0cfd601eb03cca403dcc248844787486
-    sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libbrotlicommon: 1.2.0
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
-  hash:
-    md5: 4136f6e4ef4835cc7df39a707cbd511c
-    sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
-  hash:
-    md5: 7bc31538d6e3fb349e897353969237ec
-    sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
-  hash:
-    md5: b24d3c612f71e7aa74158d92106318b2
-    sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
-  hash:
-    md5: 6525a0b06aa4fd390795f0740636a9dd
-    sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
-  category: main
-  optional: false
-- name: libgcc
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    _openmp_mutex: '>=4.5'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
-  hash:
-    md5: cba14d01083fc62ffd32c24d7d390633
-    sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
-  category: main
-  optional: false
-- name: libgomp
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
-  hash:
-    md5: 89d2c1231f47bd818f5d624b9411459d
-    sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
-  hash:
-    md5: f92233bf33e24a25668bb2119e2c51f9
-    sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
-  hash:
-    md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
-    sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
-  hash:
-    md5: fcfed1dc5053eb1901b66e7b1fc32588
-    sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
-  hash:
-    md5: 75d211f04ac87506f1f43420712a69fe
-    sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libstdcxx: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
-  hash:
-    md5: e64cd43bbd07afafbc458138e979c851
-    sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
-  hash:
-    md5: e72bbec309c2b0f37823ee7d4fabfcd3
-    sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
-  category: main
-  optional: false
-- name: libstdcxx
-  version: 16.2.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: 16.2.0
-  url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
-  hash:
-    md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
-    sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
-  category: main
-  optional: false
-- name: libuuid
-  version: 2.42.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
-  hash:
-    md5: 74a0a409d9f4561265d36b789d3f398a
-    sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
-  hash:
-    md5: 01c4ed87826af55996768af6dbc936b4
-    sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
-  hash:
-    md5: 2d34cdb31014cbc8f1e9384c89ede0a5
-    sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    icu: '>=78.3,<79.0a0'
-    libgcc: '>=14'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
-  hash:
-    md5: 20e4d67ec908f0405124f11612c48305
-    sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
-  hash:
-    md5: 0de0122d9570a8ab637c6b73db268389
-    sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: linux-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
-  hash:
-    md5: 2e632ce02d57623142f2e4b8ab725f2b
-    sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
-  hash:
-    md5: ee6c0cd80a60961a1f48aa3e0b91f986
-    sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.28,<3.0.a0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libgcc: '>=15'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libstdcxx: '>=15'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
-  hash:
-    md5: fd10c0e72a410d57f4c5073dbc4ec505
-    sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
-  hash:
-    md5: 16c8e401c682f9961676c201c888b1d9
-    sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    ca-certificates: ''
-    libgcc: '>=15'
-  url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
-  hash:
-    md5: 16e3034a330cc625f2c685edec60cf4e
-    sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
-  hash:
-    md5: 52df3de33d8bed542df618f403fa5b85
-    sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    bzip2: '>=1.0.8,<2.0a0'
-    ld_impl_linux-64: '>=2.36.1'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    libgcc: '>=15'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuuid: '>=2.42.3,<3.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
-  hash:
-    md5: 641613f2d89da811bc29fa4cde88ef20
-    sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
-  hash:
-    md5: 69c01c781e7c8190bbdaf79e3848c5ca
-    sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
-  hash:
-    md5: 59f8f9cfb1dc2f62abdca662823e052a
-    sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
-  hash:
-    md5: 718059e50f92fa30cb9b4daa597b41ce
-    sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
-  hash:
-    md5: a7ebff8e3d9b0b52d01e27df8186578b
-    sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=15'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
-  hash:
-    md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
-    sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: linux-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libgcc: '>=14'
-    libstdcxx: '>=14'
-  url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
-  hash:
-    md5: e2aa261b3d22a8bbb3cc291619e7035a
-    sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: linux-64
-  dependencies:
-    __glibc: '>=2.17,<3.0.a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
-  hash:
-    md5: aa459086047c0e5e27023ab19f8cb86a
-    sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
-  hash:
-    md5: 7a360d28a2a40006bc138f05b93188d1
-    sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
-  hash:
-    md5: 9d9a39212a876e4bb751c1cc3927b678
-    sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
-  hash:
-    md5: 925ff9ab74f4b9262a28842766e9e7b1
-    sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
-  hash:
-    md5: a1a3dfe9a4c775925ac3760b7a37e1e4
-    sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
-  hash:
-    md5: a02dd7bb48ecd345060a1203337aaa4a
-    sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
-  hash:
-    md5: 969f5550ba655de65ff0b7b4305b7f6c
-    sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
-  hash:
-    md5: f13f4740c18b562bf2662d494bad6099
-    sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
-  hash:
-    md5: 99ea337e58c6216a04473c8f52815435
-    sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
-  hash:
-    md5: faa59453024554888f67ac3142f6e4f4
-    sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
-  hash:
-    md5: 23362431ccf826a88ea0bdefd2ffa9dd
-    sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
-  hash:
-    md5: c9d01f04f03fff927a846e1985a89383
-    sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
-  hash:
-    md5: 925382e3a8a530f862be5be3b3aaf68b
-    sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
-  hash:
-    md5: 6d2f0447151b390bdaed846e143272e3
-    sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
-  hash:
-    md5: dcfdea7b7013beef0a4d744d776ea38f
-    sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
-  hash:
-    md5: e077b71ae65754eda067e4125364b905
-    sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
-  hash:
-    md5: 9fd2f77288f43e462ccc6b0e5f018c89
-    sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
-  hash:
-    md5: daf49067580fbfeae3ac7f9535400494
-    sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
-  hash:
-    md5: b10a43915a31193e06b2781b9d11aec3
-    sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
-  hash:
-    md5: b7c605bed8006cdeb822dd7de6ac87c7
-    sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
-  hash:
-    md5: 887123b5b70893ef32ec962b00625415
-    sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
-  hash:
-    md5: 254c302876eacc77a4682b3fa6f72385
-    sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
-  hash:
-    md5: 17b0d6c818992264752f1a720be711fc
-    sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
-  hash:
-    md5: 76a9680db40bf124688951cf08d82105
-    sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
-  hash:
-    md5: 0514c28a6085f32e7b4ef43f9398a447
-    sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
-  hash:
-    md5: 7d3fa28263bb7f8ea32db11f570a5bb6
-    sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
-  hash:
-    md5: 2a60e3342ea849f65068573003279ec4
-    sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
-  hash:
-    md5: 88a79390f87c8f3334b9999a892e78d4
-    sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
-  hash:
-    md5: 96abedd31106b39ec30864f6fa695afc
-    sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
-  hash:
-    md5: 4abc9f10ed9f563b4e5c235e115ba9f8
-    sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
-  hash:
-    md5: 7a1b628e987d25df3ac6986d45bb0979
-    sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
-  hash:
-    md5: 137339f92677a33a2500d3cd5361a654
-    sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
-  hash:
-    md5: 8cb4d8953ebe0460fd0d04157bc790f5
-    sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
-  hash:
-    md5: 434eb49340f57827ef7ca3bb21f77c32
-    sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
-  hash:
-    md5: 85b923438e74e1828639a39f674e5958
-    sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
-  hash:
-    md5: d0ca306378b3e170395e31aef18cca83
-    sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
-  hash:
-    md5: 713bfc46feeecfc049ffaa9f3fe25940
-    sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
-  hash:
-    md5: 71c9f1f0267f2639523e898c6b50a4dc
-    sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
-  hash:
-    md5: 94b1b7a6122698418badfbf60a2b11ad
-    sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
-  hash:
-    md5: c1d11f04327e40537ffe6cad5b131019
-    sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
-  category: main
-  optional: false
-- name: actionlint
-  version: 1.7.12
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
-  hash:
-    md5: 87084addab359d538cbf8493726cf3f8
-    sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
-  category: main
-  optional: false
-- name: bzip2
-  version: 1.0.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
-  hash:
-    md5: b50612e7d190b8061ab4e7dc119cf4d5
-    sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
-  category: main
-  optional: false
-- name: c-ares
-  version: 1.34.8
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
-  hash:
-    md5: 4cc01a374215de38387d45e19c8c5c9c
-    sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
-  category: main
-  optional: false
-- name: ca-certificates
-  version: 2026.7.22
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __unix: ''
-  url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
-  hash:
-    md5: 0f51e2391ade309db462a55611263e9c
-    sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
-  category: main
-  optional: false
-- name: coreutils
-  version: '9.11'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
-  hash:
-    md5: b9c285813535217aba1d2c8b55bf947a
-    sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
-  category: main
-  optional: false
-- name: gmp
-  version: 6.3.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
-  hash:
-    md5: bbfa5bd261b68536ddcda39e03d3407f
-    sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
-  category: main
-  optional: false
-- name: go-shfmt
-  version: 3.13.1
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
-  hash:
-    md5: 55beafb01e44f9527026dbffcea260ee
-    sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
-  category: main
-  optional: false
-- name: icu
-  version: '78.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
-  hash:
-    md5: a5efc0b42bb8b42e97d0a29ae3e3c187
-    sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
-  category: main
-  optional: false
-- name: jq
-  version: 1.8.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
-  hash:
-    md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
-    sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
-  category: main
-  optional: false
-- name: libbrotlicommon
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
-  hash:
-    md5: 8f3981871d167a6cd323e636e1929dd4
-    sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
-  category: main
-  optional: false
-- name: libbrotlidec
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
-  hash:
-    md5: da537a1643ef3e13bdccf16cca206f2c
-    sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
-  category: main
-  optional: false
-- name: libbrotlienc
-  version: 1.2.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libbrotlicommon: 1.2.0
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
-  hash:
-    md5: 39a25d500b191c16996239c4afa104f1
-    sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
-  category: main
-  optional: false
-- name: libcxx
-  version: 23.1.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
-  hash:
-    md5: 5303ba06fab927399ed8dfb3227b0af8
-    sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
-  category: main
-  optional: false
-- name: libev
-  version: '4.33'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
-  hash:
-    md5: 19e86c8a6a47e92bb2e70ca12e758c5c
-    sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
-  category: main
-  optional: false
-- name: libexpat
-  version: 2.8.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
-  hash:
-    md5: a915151d5d3c5bf039f5ccc8402a436f
-    sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
-  category: main
-  optional: false
-- name: libffi
-  version: 3.7.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
-  hash:
-    md5: 216bbcc23c11e9695b3db4a8771d76eb
-    sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
-  category: main
-  optional: false
-- name: libiconv
-  version: '1.18'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
-  hash:
-    md5: 17f4744c0873e9f77ac9b5cd0a27c187
-    sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
-  category: main
-  optional: false
-- name: liblzma
-  version: 5.8.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
-  hash:
-    md5: 8ab10323068b107661a4b9a4af84f3b5
-    sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
-  category: main
-  optional: false
-- name: libmpdec
-  version: 4.0.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
-  hash:
-    md5: ff33a4dbd93abc8a798cc4e0e7c8136d
-    sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
-  category: main
-  optional: false
-- name: libnghttp2
-  version: 1.68.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    libcxx: '>=21'
-    libev: '>=4.33,<4.34.0a0,>=4.33,<5.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.7,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
-  hash:
-    md5: ac9902dcbe0417f50cf95ab2bde062fa
-    sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
-  category: main
-  optional: false
-- name: libpython
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=21'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
-  hash:
-    md5: f45d325d3a8739b81d47a8288b6357e2
-    sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
-  category: main
-  optional: false
-- name: libsqlite
-  version: 3.53.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
-  hash:
-    md5: fde96d40ebe9a9cb34e4122380189ddb
-    sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
-  category: main
-  optional: false
-- name: libuv
-  version: 1.52.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
-  hash:
-    md5: de09bd0f175611e94f21b28f8c708e80
-    sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
-  category: main
-  optional: false
-- name: libxml2
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libxml2-16: 2.15.3
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
-  hash:
-    md5: 06a3f8eb5cdde56b2d10b49ae3337954
-    sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
-  category: main
-  optional: false
-- name: libxml2-16
-  version: 2.15.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    icu: '>=78.3,<79.0a0'
-    libiconv: '>=1.18,<2.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
-  hash:
-    md5: f86c0b8ac5c866049717b55df1049c2c
-    sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
-  category: main
-  optional: false
-- name: libzlib
-  version: 1.3.2
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
-  hash:
-    md5: f39288f0ea63ae962e1a2e4f355a0d75
-    sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
-  category: main
-  optional: false
-- name: markdownlint-cli
-  version: 0.49.1
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
-  hash:
-    md5: a57a8ea605573b733bb3d2010fbaf86d
-    sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
-  category: main
-  optional: false
-- name: ncurses
-  version: '6.6'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
-  hash:
-    md5: 3dfa0d0316dc246cd44937a557de4501
-    sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
-  category: main
-  optional: false
-- name: nodejs
-  version: 24.19.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=12.0'
-    c-ares: '>=1.34.8,<2.0a0'
-    icu: '>=78.3,<79.0a0'
-    libbrotlicommon: '>=1.2.0,<1.3.0a0'
-    libbrotlidec: '>=1.2.0,<1.3.0a0'
-    libbrotlienc: '>=1.2.0,<1.3.0a0'
-    libcxx: '>=21'
-    libnghttp2: '>=1.68.1,<2.0a0'
-    libsqlite: '>=3.53.4,<4.0a0'
-    libuv: '>=1.52.1,<2.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    zstd: '>=1.5.7,<1.6.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
-  hash:
-    md5: c4c8e364e4031850bcd232c221792e1c
-    sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
-  category: main
-  optional: false
-- name: oniguruma
-  version: 6.9.10
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
-  hash:
-    md5: ffe6286c38000935f186202d469aab0a
-    sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
-  category: main
-  optional: false
-- name: openssl
-  version: 3.6.4
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ca-certificates: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
-  hash:
-    md5: ae71ab40048c19a389a7dcccb86c2481
-    sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
-  category: main
-  optional: false
-- name: prettier
-  version: 3.9.3
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    nodejs: '>=24.18.0,<25.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
-  hash:
-    md5: 9be48326058aa380b7400617e73d7da6
-    sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
-  category: main
-  optional: false
-- name: python
-  version: 3.13.15
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    bzip2: '>=1.0.8,<2.0a0'
-    libexpat: '>=2.8.1,<3.0a0'
-    libffi: '>=3.7.0,<3.8.0a0'
-    liblzma: '>=5.8.3,<6.0a0'
-    libmpdec: '>=4.0.0,<5.0a0'
-    libpython: 3.13.15
-    libsqlite: '>=3.53.4,<4.0a0'
-    libzlib: '>=1.3.2,<2.0a0'
-    ncurses: '>=6.6,<7.0a0'
-    openssl: '>=3.5.8,<4.0a0'
-    python_abi: 3.13.*
-    readline: '>=8.3,<9.0a0'
-    tk: '>=8.6.13,<8.7.0a0'
-    tzdata: ''
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
-  hash:
-    md5: 4745cefb2d63de33e85b73cbae7ff9d2
-    sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
-  category: main
-  optional: false
-- name: python_abi
-  version: '3.13'
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
-  hash:
-    md5: c5abc97af551bc12d71305852392f75c
-    sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
-  category: main
-  optional: false
-- name: readline
-  version: '8.3'
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    ncurses: '>=6.6,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
-  hash:
-    md5: 9347fd56a002e6b58946831d48fe62f6
-    sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
-  category: main
-  optional: false
-- name: shellcheck
-  version: 0.11.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    gmp: '>=6.3.0,<7.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
-  hash:
-    md5: 16c849ba724a6d59132a3b7547e2bd36
-    sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
-  category: main
-  optional: false
-- name: taplo
-  version: 0.10.0
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    openssl: '>=3.5.6,<4.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
-  hash:
-    md5: 8ee9613094590d6b7cbb2e98e5a75314
-    sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
-  category: main
-  optional: false
-- name: terraform
-  version: 1.15.6
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
-  hash:
-    md5: 1f7d7177d1a3b1cd872457e20eca56b2
-    sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
-  category: main
-  optional: false
-- name: tk
-  version: 8.6.13
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
-  hash:
-    md5: 90a01bf394d1c594e0eb9258f967d828
-    sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
-  category: main
-  optional: false
-- name: tzdata
-  version: 2026c
-  manager: conda
-  platform: osx-arm64
-  dependencies: {}
-  url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
-  hash:
-    md5: fcb489df604d100968b737f2cb6076c6
-    sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
-  category: main
-  optional: false
-- name: uv
-  version: 0.11.30
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libcxx: '>=19'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
-  hash:
-    md5: eaf1e624c3c1de1a05404689b48e39d5
-    sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
-  category: main
-  optional: false
-- name: zstd
-  version: 1.5.7
-  manager: conda
-  platform: osx-arm64
-  dependencies:
-    __osx: '>=11.0'
-    libzlib: '>=1.3.2,<2.0a0'
-  url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
-  hash:
-    md5: 4ec2684c73812cc2c3d78379384a39cc
-    sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
-  category: main
-  optional: false
+  - name: _openmp_mutex
+    version: "4.5"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgomp: ">=7.5.0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/_openmp_mutex-4.5-20_gnu.conda
+    hash:
+      md5: a9f577daf3de00bca7c3c76c0ecbd1de
+      sha256: 1dd3fffd892081df9726d7eb7e0dea6198962ba775bd88842135a4ddb4deb3c9
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,>=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/actionlint-1.7.12-h8bc977c_0.conda
+    hash:
+      md5: bab393750db08f50eebaf96f50d18734
+      sha256: 1fff5ee0d83045ef90104ca83f52b4c44feb4ab2036fc7903fe9733f50721209
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/bzip2-1.0.8-hda65f42_10.conda
+    hash:
+      md5: e675fabcf81499adc7edf58124fb1e01
+      sha256: 1a0d382c515ebf55f8ee1f38c8b81bc95af5c2acc42ad53b66bc5df932032f96
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/c-ares-1.34.8-hebe6cf0_2.conda
+    hash:
+      md5: 3ad2b403be8fc5612b9159e2ce621f69
+      sha256: 9c37cc233238adf366ea75b0e845662a5be07ceadf62e458183516369340274b
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/coreutils-9.11-h280c20c_0.conda
+    hash:
+      md5: c63e2851f3d99a32f4b6991d0460dd25
+      sha256: 6b19fb6c45302bdd6c97c5ac219e14bcbb7d9055c758e79d8a2577e705a933f0
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/go-shfmt-3.13.1-hfc2019e_0.conda
+    hash:
+      md5: 1e152fa4fe2a7b77d4b86c76a6a85b50
+      sha256: 5ee7116bbc0ad0c46234a168d2e17db0bc7c1a3f9aefbb7c4fb082fddb31deef
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/icu-78.3-py310h44b86e0_2.conda
+    hash:
+      md5: 72a381cbad04f24b1c2a43ef707f45b4
+      sha256: 9f07834f0c546ab14d885ce0366285f61f44e326c0edd1fc63b8294e113ae432
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/linux-64/jq-1.8.2-h280c20c_1.conda
+    hash:
+      md5: 6ec056e539486e84f0c7acef6b5863f9
+      sha256: f14c52155ba14ccb41fdd6f71d74b21153c35e131185434da7334cf25b3eef46
+    category: main
+    optional: false
+  - name: ld_impl_linux-64
+    version: 2.46.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ld_impl_linux-64-2.46.1-default_hbd61a6d_102.conda
+    hash:
+      md5: 449500f2c089da11c40f5c21312e3e07
+      sha256: 27d83f1188cd19bcb7754a078b3fa7f4cfb8527f8eb2fde54dd01fc529d1adec
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlicommon-1.2.0-h39a168f_4.conda
+    hash:
+      md5: df210655e30a05e3b069c91b7aaddd2d
+      sha256: c4e9854c585f3ee1785f651287ecdf8c28f30a2ea1b159a513005f8a0f6453a3
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlidec-1.2.0-ha411449_4.conda
+    hash:
+      md5: 0cfd601eb03cca403dcc248844787486
+      sha256: d5ed24da3e583a92227fe77280978b7933f07a39a2b60156c5ad95e5c76733fa
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libbrotlicommon: 1.2.0
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libbrotlienc-1.2.0-h018ffa1_4.conda
+    hash:
+      md5: 4136f6e4ef4835cc7df39a707cbd511c
+      sha256: b9f3cb510337655485c2e79ce5f7dd468991b19ad29723ffa1175a0aed1b69ae
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libev-4.33-h280c20c_3.conda
+    hash:
+      md5: 7bc31538d6e3fb349e897353969237ec
+      sha256: e4418f68d01a6307c4431b585c71b584f40189877364e542ee87deb777f5e85b
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libexpat-2.8.1-hecca717_1.conda
+    hash:
+      md5: b24d3c612f71e7aa74158d92106318b2
+      sha256: 16feffd9ddbbe5b718515d38ee376c685ba95491cd901244e24671d20b952a77
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libffi-3.7.0-h81df57d_1.conda
+    hash:
+      md5: 6525a0b06aa4fd390795f0740636a9dd
+      sha256: c8c7583ef063bc3c430f1d48298e5ad24f796a35c22ed5b14183325825a61106
+    category: main
+    optional: false
+  - name: libgcc
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      _openmp_mutex: ">=4.5"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgcc-16.2.0-ha9f2e26_4.conda
+    hash:
+      md5: cba14d01083fc62ffd32c24d7d390633
+      sha256: 24090e675d34403b4ee1cd4372d8f6c0937da7ecfd66a19a57cac2ed0f4ea793
+    category: main
+    optional: false
+  - name: libgomp
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libgomp-16.2.0-he0feb66_4.conda
+    hash:
+      md5: 89d2c1231f47bd818f5d624b9411459d
+      sha256: 0fe5cb8e0752241ab55e11656ed1b9726248b522d23b929fe7c95b83eb55b9bb
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libiconv-1.18-h0cb94f2_3.conda
+    hash:
+      md5: f92233bf33e24a25668bb2119e2c51f9
+      sha256: f943117edb9cd4d9c61cc972eee5a34291dc55ea7a6e9e38da104995841cbcb6
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/liblzma-5.8.3-hb03c661_1.conda
+    hash:
+      md5: 1390b7c5ac0b1d8e447bc5efa6d3c8c2
+      sha256: 9787df8c22a59c9a70d3e5a10db9ad663485e75e9ccc3f09bd092cb7b95e0dab
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libmpdec-4.0.0-hb03c661_2.conda
+    hash:
+      md5: fcfed1dc5053eb1901b66e7b1fc32588
+      sha256: 46820b4a835e175940ae20bec00fdddaff804cda27a1408ab1b95e77a2196437
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libnghttp2-1.68.1-h74cf4be_1.conda
+    hash:
+      md5: 75d211f04ac87506f1f43420712a69fe
+      sha256: 11a2f54a6f391e25738bce0023e6ef499600147bbcf21c1fa69d2e251b03cc6a
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libstdcxx: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libpython-3.13.15-hdc7f604_103_cp313.conda
+    hash:
+      md5: e64cd43bbd07afafbc458138e979c851
+      sha256: a25db25aad6cbf53e523e1f310713f31372932d5db655f1f2d62a204c7cdf1d7
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libsqlite-3.53.4-h13e7031_1.conda
+    hash:
+      md5: e72bbec309c2b0f37823ee7d4fabfcd3
+      sha256: f20d70da54e5b31dd4a51fb1efeaafafd5ab6dd8d7ac9d1438eaa2526ac4ed3d
+    category: main
+    optional: false
+  - name: libstdcxx
+    version: 16.2.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: 16.2.0
+    url: https://conda.anaconda.org/conda-forge/linux-64/libstdcxx-16.2.0-h934c35e_4.conda
+    hash:
+      md5: 2f2ef0d96de5bdd8c1270ff22fdf9352
+      sha256: 40b792b0186c1e8859280a1f6f19a54fc50a11b32724fc7b637009c1a9bd302b
+    category: main
+    optional: false
+  - name: libuuid
+    version: 2.42.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuuid-2.42.3-hcfc3c73_0.conda
+    hash:
+      md5: 74a0a409d9f4561265d36b789d3f398a
+      sha256: aa58bbba56644ffd062a4a9b358782c5eb7560ccead2ab8f7c5c6ede0a7d33a6
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libuv-1.52.1-h280c20c_1.conda
+    hash:
+      md5: 01c4ed87826af55996768af6dbc936b4
+      sha256: 67761d0206f84140047a367eaf9befe03a7e157a29ee25aee0047b40801cc6b6
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_1.conda
+    hash:
+      md5: 2d34cdb31014cbc8f1e9384c89ede0a5
+      sha256: a16a576a5844a3a0e1cdfc5e162b9fe9c64dccf6a93f44c293bb42851aebe2b4
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      icu: ">=78.3,<79.0a0"
+      libgcc: ">=14"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_1.conda
+    hash:
+      md5: 20e4d67ec908f0405124f11612c48305
+      sha256: 087d4de023f22d6a28b9e1b818961dd41e9bda6e9793590600ff16ca150bf9cb
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+    hash:
+      md5: 0de0122d9570a8ab637c6b73db268389
+      sha256: eb8a0db0aa570124f7d2a93d7c7f596e3390df5e047818d873baad32985fc736
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: linux-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/markdownlint-cli-0.49.1-h5ac6406_0.conda
+    hash:
+      md5: 2e632ce02d57623142f2e4b8ab725f2b
+      sha256: 27d812d3b9b602d73c9320d49a910c5e19286b6b729f669c37a671877c25f704
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda
+    hash:
+      md5: ee6c0cd80a60961a1f48aa3e0b91f986
+      sha256: 5d46557214ed184381dafe835b7c94a474a1c3b307a08a250b1ea4779b44ffb3
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.28,<3.0.a0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libgcc: ">=15"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libstdcxx: ">=15"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/nodejs-24.19.0-h50021de_1.conda
+    hash:
+      md5: fd10c0e72a410d57f4c5073dbc4ec505
+      sha256: ba2f7f8dca10fcfed80568bcd7827d2ab6c3b9cb90b3de80b55b771d50658dd3
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/oniguruma-6.9.10-h280c20c_1.conda
+    hash:
+      md5: 16c8e401c682f9961676c201c888b1d9
+      sha256: 22ba0c20d810f4e27092931191a08331b3bff1b7feeead5de7d8514cfd9230ad
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      ca-certificates: ""
+      libgcc: ">=15"
+    url: https://conda.anaconda.org/conda-forge/linux-64/openssl-3.6.4-h781a0a9_0.conda
+    hash:
+      md5: 16e3034a330cc625f2c685edec60cf4e
+      sha256: 4747b2d6a8336f52343bceb8a1ebf41a9e6e665b9d2e3f989972de53a310599e
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/prettier-3.9.3-h7e4c9f4_0.conda
+    hash:
+      md5: 52df3de33d8bed542df618f403fa5b85
+      sha256: ec8af57fabe73c269b762eb8d3f45505ef3528c22a4d4d3994a9b2d70c9c57d9
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      bzip2: ">=1.0.8,<2.0a0"
+      ld_impl_linux-64: ">=2.36.1"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      libgcc: ">=15"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuuid: ">=2.42.3,<3.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/linux-64/python-3.13.15-hf47f18c_103_cp313.conda
+    hash:
+      md5: 641613f2d89da811bc29fa4cde88ef20
+      sha256: cc18ba39af0d591ac012c1334ac98aa59ec7be389719b4cd80cc0a58a53019de
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/readline-8.3-hd6e31c0_1.conda
+    hash:
+      md5: 69c01c781e7c8190bbdaf79e3848c5ca
+      sha256: 01b3fe073a66e321970d09e04b388708f8cbdca5cdfbfcb7c9eeb470ad10383d
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/linux-64/shellcheck-0.11.0-ha770c72_1.conda
+    hash:
+      md5: 59f8f9cfb1dc2f62abdca662823e052a
+      sha256: 09335c4ce927c3c47ffbe4f13c18b21cc0bf7b661dba8f7caba699f9e9f26bf3
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/taplo-0.10.0-he64ecbb_2.conda
+    hash:
+      md5: 718059e50f92fa30cb9b4daa597b41ce
+      sha256: 4fadb3cddac0461c6715fa987944d6876e7402efc037ab5c05707b788d7dfcf9
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/terraform-1.15.6-h76a2195_0.conda
+    hash:
+      md5: a7ebff8e3d9b0b52d01e27df8186578b
+      sha256: 42fd6db7e7496d5f3194a1d0bf041cec19b3c3c68e794b70bc1b038f0b40a51b
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=15"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/tk-8.6.13-noxft_h1df4ec4_4.conda
+    hash:
+      md5: 676a2f9b1c4fcf57b70aa5c65f6c60d0
+      sha256: a1a241d172c1ccab067ba245206dd048bc3c2d1b84504b53c9468e99adfc16a1
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: linux-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libgcc: ">=14"
+      libstdcxx: ">=14"
+    url: https://conda.anaconda.org/conda-forge/linux-64/uv-0.11.30-h2112641_0.conda
+    hash:
+      md5: e2aa261b3d22a8bbb3cc291619e7035a
+      sha256: e4525bcbd3e7c13a61a35522f94789adb828bb7ae30c03d74d03437354617934
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: linux-64
+    dependencies:
+      __glibc: ">=2.17,<3.0.a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/linux-64/zstd-1.5.7-hb78ec9c_7.conda
+    hash:
+      md5: aa459086047c0e5e27023ab19f8cb86a
+      sha256: 47d682b9f6d6ec9eb1a6e6c3e75ea6273e899e78fb7fc59f81d39745009fbc60
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/actionlint-1.7.12-h5220d24_0.conda
+    hash:
+      md5: 7a360d28a2a40006bc138f05b93188d1
+      sha256: 0a3f0f673f7a1c3dcc5bd04f759b977676e3d680ec50346e9013a0c067426d3c
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/bzip2-1.0.8-h374f1ed_10.conda
+    hash:
+      md5: 9d9a39212a876e4bb751c1cc3927b678
+      sha256: 4ed83961876dc8844a6f0df49c07b408efbaea275ffb0b37133e24c006990b3a
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/c-ares-1.34.8-had63097_2.conda
+    hash:
+      md5: 925ff9ab74f4b9262a28842766e9e7b1
+      sha256: a00162ac4b2f68a6ddf23905e9d2fdb3ecd5abad51659f512539952a780d53ed
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/coreutils-9.11-ha3d0635_0.conda
+    hash:
+      md5: a1a3dfe9a4c775925ac3760b7a37e1e4
+      sha256: 4d13c876757e1b744be1a18ee9f6787dd2b968aea30a8849823f723da7c5c048
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/gmp-6.3.0-h65442b7_3.conda
+    hash:
+      md5: a02dd7bb48ecd345060a1203337aaa4a
+      sha256: 64368a142b262c400cf15e649bfeca1d07cf41f39521e5284036c42533a2dad5
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-64/go-shfmt-3.13.1-h5839d16_0.conda
+    hash:
+      md5: 969f5550ba655de65ff0b7b4305b7f6c
+      sha256: d06d646a7d6f6e27a2a6fb8469d269b52c55cce34ab222084fe92f680cdc9b28
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/icu-78.3-py313hbf1d544_2.conda
+    hash:
+      md5: f13f4740c18b562bf2662d494bad6099
+      sha256: 3abd86f3441f143b6b3203c92ae0d88dd8396a8857940af468f1fab854cdae57
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-64/jq-1.8.2-ha3d0635_1.conda
+    hash:
+      md5: 99ea337e58c6216a04473c8f52815435
+      sha256: 891be95d8fd8110b6f8e1673d029761a540f099e9bc62e90a35b03ee17f2629e
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlicommon-1.2.0-he0616a4_4.conda
+    hash:
+      md5: faa59453024554888f67ac3142f6e4f4
+      sha256: 14560b40c2c318f76ea517452f810ae9b9b752a75014138ff1ad06dba7c7e55d
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlidec-1.2.0-h4a2f56c_4.conda
+    hash:
+      md5: 23362431ccf826a88ea0bdefd2ffa9dd
+      sha256: 61d001395c040d0879bc25e1a012f0d80dff315a3b96da1f4018a6815341442a
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-64/libbrotlienc-1.2.0-h3d41943_4.conda
+    hash:
+      md5: c9d01f04f03fff927a846e1985a89383
+      sha256: fb3c5a415789e7cbd6a6cd2453716ab18c360a66e46a8e2abb8b99b719535bb7
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libcxx-23.1.0-h19cb2f5_0.conda
+    hash:
+      md5: 925382e3a8a530f862be5be3b3aaf68b
+      sha256: da5b60cbdaf8d931e2534f3b17a0d9b5432ebc855509d36618d61a61f1f2909d
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libev-4.33-ha3d0635_3.conda
+    hash:
+      md5: 6d2f0447151b390bdaed846e143272e3
+      sha256: 223314a7476bdeb00f698937b6960fc51cb98627af2ac5a629e5150bcddb8abf
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libexpat-2.8.1-hcc62823_1.conda
+    hash:
+      md5: dcfdea7b7013beef0a4d744d776ea38f
+      sha256: 9c96cc05e056e1bba5b545cbbd57b6e01db622dc2c82934caaaa25cfb22fe666
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libffi-3.7.0-h6b3a05b_1.conda
+    hash:
+      md5: e077b71ae65754eda067e4125364b905
+      sha256: c4793041226c87f987b9903e6503b76f02f52855cc193be2729ac127e600529b
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libiconv-1.18-h4ae439b_3.conda
+    hash:
+      md5: 9fd2f77288f43e462ccc6b0e5f018c89
+      sha256: 2389e03a58ed0f5e8f2469eb4d4ba80d0af378b38854ae5eee65e5b641244082
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/liblzma-5.8.3-hbb4bfdb_1.conda
+    hash:
+      md5: daf49067580fbfeae3ac7f9535400494
+      sha256: 7915dac7c71c208e40e716e2f6d3eff41a8d5584e0e7c2d46f9bf9bd5f9aa739
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libmpdec-4.0.0-ha1e9b39_2.conda
+    hash:
+      md5: b10a43915a31193e06b2781b9d11aec3
+      sha256: 6438d0ef76e81f2b75ad7599685a525407c1d9fb2d6a7c18f360614ae6807970
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libnghttp2-1.68.1-h1e30255_1.conda
+    hash:
+      md5: b7c605bed8006cdeb822dd7de6ac87c7
+      sha256: 2d5c131553e83089be74988529d758e2a6dbb9227056d8fa19c01f5ccef6e6fc
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libpython-3.13.15-h8544b6a_103_cp313.conda
+    hash:
+      md5: 887123b5b70893ef32ec962b00625415
+      sha256: fd392b5cc6b2b153e8a127d1279fa3dfa48fbe1132ad936c4a51e72125a74100
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libsqlite-3.53.4-ha5db789_1.conda
+    hash:
+      md5: 254c302876eacc77a4682b3fa6f72385
+      sha256: 78afe0bf88da66d7df62d39632aa69cb73eb32d923cd1175230ce2978618d9c8
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libuv-1.52.1-ha3d0635_1.conda
+    hash:
+      md5: 17b0d6c818992264752f1a720be711fc
+      sha256: 4aacf651487bf2cd4dcfab49ea98a00a34305919ff3a09b66b7ddaa97d8b316f
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-2.15.3-h953d39d_1.conda
+    hash:
+      md5: 76a9680db40bf124688951cf08d82105
+      sha256: 86b163d690ddba6a2c7e74a0dc520da4715f638e3f51770070ec784a813d7145
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libxml2-16-2.15.3-h7a90416_1.conda
+    hash:
+      md5: 0514c28a6085f32e7b4ef43f9398a447
+      sha256: 55b340cca3892dc95bf0944036a426e357ae72c3555d75f51487560722e64c0e
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/libzlib-1.3.2-hbb4bfdb_3.conda
+    hash:
+      md5: 7d3fa28263bb7f8ea32db11f570a5bb6
+      sha256: b2dba286dd6632292b12296e761193b5ef9fb0eaeecaa481f5ba9af72c0c18e1
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/markdownlint-cli-0.49.1-hf6b0dc5_0.conda
+    hash:
+      md5: 2a60e3342ea849f65068573003279ec4
+      sha256: dcbe60a16f73083bc83fb0e659bbfe58066257afdd44741fc236fb1d6b018039
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/ncurses-6.6-hcc0dc9a_1.conda
+    hash:
+      md5: 88a79390f87c8f3334b9999a892e78d4
+      sha256: 12c1d676b9a0e8109b576672519312c5428308f3f3d7706f8717e2f536d5d9e7
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/nodejs-24.19.0-hcead6ad_1.conda
+    hash:
+      md5: 96abedd31106b39ec30864f6fa695afc
+      sha256: 40b6cb474aac374a1827418bc9149ec8645fef592ba4df6228696d09e02992d1
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/oniguruma-6.9.10-ha3d0635_1.conda
+    hash:
+      md5: 4abc9f10ed9f563b4e5c235e115ba9f8
+      sha256: bd36b82b3553a458535068a91ce5e9632c7b4ddf6c122e6e58ccb31fc9a23ded
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/openssl-3.6.4-h332eb6d_0.conda
+    hash:
+      md5: 7a1b628e987d25df3ac6986d45bb0979
+      sha256: 73d648d24f0994fd8641972848d74bd57b8d80888a64600643e3fe88a1b50545
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/prettier-3.9.3-h810254c_0.conda
+    hash:
+      md5: 137339f92677a33a2500d3cd5361a654
+      sha256: cd9a1368d8e18d27ac972875ca1dcac11bcadc0853c52ec82f49e086c0c92f1a
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-64/python-3.13.15-h9dec186_103_cp313.conda
+    hash:
+      md5: 8cb4d8953ebe0460fd0d04157bc790f5
+      sha256: 7c2db4f443d92825271b3866f393fdf0a1814fb6b9b92665bc40358c8880de7a
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/readline-8.3-h000c2f7_1.conda
+    hash:
+      md5: 434eb49340f57827ef7ca3bb21f77c32
+      sha256: feb9248a062b7a0738e56339d8c9e87bc9adf8e8c76549fb55b0b2456bec3a57
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/shellcheck-0.11.0-h7dd6a17_1.conda
+    hash:
+      md5: 85b923438e74e1828639a39f674e5958
+      sha256: b78a4e62565565fb61ee9c27da1559c92a105d09f244779c3c8ed3ff77d08577
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/taplo-0.10.0-h651e3a3_2.conda
+    hash:
+      md5: d0ca306378b3e170395e31aef18cca83
+      sha256: 8d0d5ca037061e4d08df26860466f95ed7b7d044cc8a6d2812fc522a6bcef38c
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/terraform-1.15.6-hdaada87_0.conda
+    hash:
+      md5: 713bfc46feeecfc049ffaa9f3fe25940
+      sha256: 046fe96ee7e8be8f68814664eb0b76076282a9913f6cd46868befda4c2e12509
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/tk-8.6.13-ha6c374e_4.conda
+    hash:
+      md5: 71c9f1f0267f2639523e898c6b50a4dc
+      sha256: 74e5fabcaf6ca0db052c645646ea04ded98a5eb7540483217f8101a819eb3107
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-64/uv-0.11.30-h0bcf9e0_0.conda
+    hash:
+      md5: 94b1b7a6122698418badfbf60a2b11ad
+      sha256: e4f114281825a670c9522f1a59509516c31c8f49db4d0318472365ff8992fb47
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-64/zstd-1.5.7-hbc1a06c_7.conda
+    hash:
+      md5: c1d11f04327e40537ffe6cad5b131019
+      sha256: 5277886d9704a624dc9b79ac985861e1e431bdb39a57c082507ab577a138ec6c
+    category: main
+    optional: false
+  - name: actionlint
+    version: 1.7.12
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/actionlint-1.7.12-h7969508_0.conda
+    hash:
+      md5: 87084addab359d538cbf8493726cf3f8
+      sha256: 94a8c69857d5365990f8231a901ea102736694546497cc674962e97b3e8d8d96
+    category: main
+    optional: false
+  - name: bzip2
+    version: 1.0.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/bzip2-1.0.8-h4e30115_10.conda
+    hash:
+      md5: b50612e7d190b8061ab4e7dc119cf4d5
+      sha256: 8ec22f0ba25cbfc2e64d70cf29459eccd7ffdf6436f6a6ff15bbfef799f7d4f6
+    category: main
+    optional: false
+  - name: c-ares
+    version: 1.34.8
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/c-ares-1.34.8-h74c22ad_2.conda
+    hash:
+      md5: 4cc01a374215de38387d45e19c8c5c9c
+      sha256: 82bdd5a3fcada6afef6255a9bf41172f07b362f36e04a354dc2abc0a29bfb756
+    category: main
+    optional: false
+  - name: ca-certificates
+    version: 2026.7.22
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __unix: ""
+    url: https://conda.anaconda.org/conda-forge/noarch/ca-certificates-2026.7.22-hbd8a1cb_0.conda
+    hash:
+      md5: 0f51e2391ade309db462a55611263e9c
+      sha256: 0a0544cf95f64394fe4959286f5c71f5444ad58feb0602e53becb27448d24da6
+    category: main
+    optional: false
+  - name: coreutils
+    version: "9.11"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/coreutils-9.11-h1a92334_0.conda
+    hash:
+      md5: b9c285813535217aba1d2c8b55bf947a
+      sha256: c121e881b96fdbb1f91fbd1e288c9eab062b345f381521db27a514669c1fc5ef
+    category: main
+    optional: false
+  - name: gmp
+    version: 6.3.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/gmp-6.3.0-hf5e55b1_3.conda
+    hash:
+      md5: bbfa5bd261b68536ddcda39e03d3407f
+      sha256: 980cb1bbc3656d6f923d44297a2c4ab75f20482b8930c70537fd7f1ef2378894
+    category: main
+    optional: false
+  - name: go-shfmt
+    version: 3.13.1
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/go-shfmt-3.13.1-hf76c51c_0.conda
+    hash:
+      md5: 55beafb01e44f9527026dbffcea260ee
+      sha256: a190edc92d5c9d7b65e624596cf6a45c5f6f372409f660610bb847bda2329ed9
+    category: main
+    optional: false
+  - name: icu
+    version: "78.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/icu-78.3-py310h579977c_2.conda
+    hash:
+      md5: a5efc0b42bb8b42e97d0a29ae3e3c187
+      sha256: 6cdb5dee54c72e56ab189fb3ad33cb28533553d42590e7e831160248f4416a43
+    category: main
+    optional: false
+  - name: jq
+    version: 1.8.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      oniguruma: 6.9.*,>=6.9.10,<6.10.0a0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/jq-1.8.2-h1a92334_1.conda
+    hash:
+      md5: be1ad8bb4f91519d2a3eb2bcb6d9bc0b
+      sha256: 2d345464da308424f15322fb848b0f845291fdf2383f709866e94825d722f550
+    category: main
+    optional: false
+  - name: libbrotlicommon
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlicommon-1.2.0-h1dcdb26_4.conda
+    hash:
+      md5: 8f3981871d167a6cd323e636e1929dd4
+      sha256: 8a6e4789a6049dabb41c6fcaf6719232245484d81dfeb199b5abdb95c84c9fc2
+    category: main
+    optional: false
+  - name: libbrotlidec
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlidec-1.2.0-h5295a6a_4.conda
+    hash:
+      md5: da537a1643ef3e13bdccf16cca206f2c
+      sha256: 4e1f5989561de4546209b42c935795a41fa4265e0b670861480f1adffec623a8
+    category: main
+    optional: false
+  - name: libbrotlienc
+    version: 1.2.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libbrotlicommon: 1.2.0
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libbrotlienc-1.2.0-h2ddc9cb_4.conda
+    hash:
+      md5: 39a25d500b191c16996239c4afa104f1
+      sha256: 4d2da97825b221054a39f492e4dffe361e1931c8381d0367f1e0598a50d02f34
+    category: main
+    optional: false
+  - name: libcxx
+    version: 23.1.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libcxx-23.1.0-h55c6f16_0.conda
+    hash:
+      md5: 5303ba06fab927399ed8dfb3227b0af8
+      sha256: d3e5f0b767964af25ef81edffc002f8e822b1a5c55330da1ae3a857f70c4e4ee
+    category: main
+    optional: false
+  - name: libev
+    version: "4.33"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libev-4.33-h1a92334_3.conda
+    hash:
+      md5: 19e86c8a6a47e92bb2e70ca12e758c5c
+      sha256: c0100064506ae8abb432c5a506d474f10af2cf48c33d62bc221fb28b6d6ff6ac
+    category: main
+    optional: false
+  - name: libexpat
+    version: 2.8.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libexpat-2.8.1-hf6b4638_1.conda
+    hash:
+      md5: a915151d5d3c5bf039f5ccc8402a436f
+      sha256: 5af74261101e3c777399c6294b2b5d290e508153268eb2e9ff99c4d69834612f
+    category: main
+    optional: false
+  - name: libffi
+    version: 3.7.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libffi-3.7.0-h47dc5ef_1.conda
+    hash:
+      md5: 216bbcc23c11e9695b3db4a8771d76eb
+      sha256: 2783389a7b9dda04c62cc54c6bbeb03dd3cef24b3fc642715d02a3fa19464a9a
+    category: main
+    optional: false
+  - name: libiconv
+    version: "1.18"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libiconv-1.18-he4c29f2_3.conda
+    hash:
+      md5: 17f4744c0873e9f77ac9b5cd0a27c187
+      sha256: 689a14968267f2f97c07112fca5636e7d756036b9aee969911267c20bd3eea1f
+    category: main
+    optional: false
+  - name: liblzma
+    version: 5.8.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/liblzma-5.8.3-h8088a28_1.conda
+    hash:
+      md5: 8ab10323068b107661a4b9a4af84f3b5
+      sha256: 23d0630046a3e8b164d8f80f2b74ed2605af2e7050ab9913018056402fae4311
+    category: main
+    optional: false
+  - name: libmpdec
+    version: 4.0.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libmpdec-4.0.0-h84a0fba_2.conda
+    hash:
+      md5: ff33a4dbd93abc8a798cc4e0e7c8136d
+      sha256: 04cc136c5a956a73aa14e0a160b5822b0b29714e67b299fa1b1fd16dbcba5366
+    category: main
+    optional: false
+  - name: libnghttp2
+    version: 1.68.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      libcxx: ">=21"
+      libev: ">=4.33,<4.34.0a0,>=4.33,<5.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.7,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libnghttp2-1.68.1-h435687b_1.conda
+    hash:
+      md5: ac9902dcbe0417f50cf95ab2bde062fa
+      sha256: 445440d8cccccb6585f71d1eb7c949d64a2af2ced5481d924621424ff3b6a398
+    category: main
+    optional: false
+  - name: libpython
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=21"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libpython-3.13.15-hb350d79_103_cp313.conda
+    hash:
+      md5: f45d325d3a8739b81d47a8288b6357e2
+      sha256: 37ab69e6bf35ff7321dae4473e34a7fa51eaa038f6f9bddef8a5c0eab8321534
+    category: main
+    optional: false
+  - name: libsqlite
+    version: 3.53.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libsqlite-3.53.4-hca69786_1.conda
+    hash:
+      md5: fde96d40ebe9a9cb34e4122380189ddb
+      sha256: 839b31d4830e896b4d315b551d27f2bb08026bc946df04bcc360d8627c3ba2cd
+    category: main
+    optional: false
+  - name: libuv
+    version: 1.52.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libuv-1.52.1-h1a92334_1.conda
+    hash:
+      md5: de09bd0f175611e94f21b28f8c708e80
+      sha256: 4f47de9de1990efd998edbbd6793f89c8f02ffde987ae8120b1c006acefd2a04
+    category: main
+    optional: false
+  - name: libxml2
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libxml2-16: 2.15.3
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-2.15.3-h5654f7c_1.conda
+    hash:
+      md5: 06a3f8eb5cdde56b2d10b49ae3337954
+      sha256: ff1b70683ccb82f8aa7f3eda53405a2036d849daba4e4e622f330dcd49d37700
+    category: main
+    optional: false
+  - name: libxml2-16
+    version: 2.15.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      icu: ">=78.3,<79.0a0"
+      libiconv: ">=1.18,<2.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libxml2-16-2.15.3-h5ef1a60_1.conda
+    hash:
+      md5: f86c0b8ac5c866049717b55df1049c2c
+      sha256: 2ca61d8287339c726b151fa612e83d2afa1418b89fa17694c873dc231bc9b077
+    category: main
+    optional: false
+  - name: libzlib
+    version: 1.3.2
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/libzlib-1.3.2-h8088a28_3.conda
+    hash:
+      md5: f39288f0ea63ae962e1a2e4f355a0d75
+      sha256: a18fa5d5bac452401459f966cf0d872224e8080c4ff93c77e168d43ab42ef9d7
+    category: main
+    optional: false
+  - name: markdownlint-cli
+    version: 0.49.1
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/markdownlint-cli-0.49.1-h7d04ff1_0.conda
+    hash:
+      md5: a57a8ea605573b733bb3d2010fbaf86d
+      sha256: 071a97d9870179a2e12bc8e5c50ba611baa0999e9dbe22eced52f916c319a639
+    category: main
+    optional: false
+  - name: ncurses
+    version: "6.6"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/ncurses-6.6-he64c551_1.conda
+    hash:
+      md5: 3dfa0d0316dc246cd44937a557de4501
+      sha256: 7024a48c8c0d0114ed4ab53c76bf9275d50e91ba7cea367a9aead638d3c29c68
+    category: main
+    optional: false
+  - name: nodejs
+    version: 24.19.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=12.0"
+      c-ares: ">=1.34.8,<2.0a0"
+      icu: ">=78.3,<79.0a0"
+      libbrotlicommon: ">=1.2.0,<1.3.0a0"
+      libbrotlidec: ">=1.2.0,<1.3.0a0"
+      libbrotlienc: ">=1.2.0,<1.3.0a0"
+      libcxx: ">=21"
+      libnghttp2: ">=1.68.1,<2.0a0"
+      libsqlite: ">=3.53.4,<4.0a0"
+      libuv: ">=1.52.1,<2.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      zstd: ">=1.5.7,<1.6.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/nodejs-24.19.0-hb275ff0_1.conda
+    hash:
+      md5: c4c8e364e4031850bcd232c221792e1c
+      sha256: 59ecff1cf178d4b9eaa0bca151fc76dee16d1046c964e0f6aca6fc24f31d62f2
+    category: main
+    optional: false
+  - name: oniguruma
+    version: 6.9.10
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/oniguruma-6.9.10-h1a92334_1.conda
+    hash:
+      md5: ffe6286c38000935f186202d469aab0a
+      sha256: 92a6ca62564165da0c1d6c321555b8cd3e5a660512ee0466b89c46e3637a5bf7
+    category: main
+    optional: false
+  - name: openssl
+    version: 3.6.4
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ca-certificates: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/openssl-3.6.4-h55eecbc_0.conda
+    hash:
+      md5: ae71ab40048c19a389a7dcccb86c2481
+      sha256: f23239eacd75c4c50705e68fae1aa3292da473e6a3a4abe2330f1e6afa680704
+    category: main
+    optional: false
+  - name: prettier
+    version: 3.9.3
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      nodejs: ">=24.18.0,<25.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/prettier-3.9.3-h57cd9b8_0.conda
+    hash:
+      md5: 9be48326058aa380b7400617e73d7da6
+      sha256: d29fd62828bf3f6bc2373958ba2368f255e1333be4b617e656bca8638da7cdf8
+    category: main
+    optional: false
+  - name: python
+    version: 3.13.15
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      bzip2: ">=1.0.8,<2.0a0"
+      libexpat: ">=2.8.1,<3.0a0"
+      libffi: ">=3.7.0,<3.8.0a0"
+      liblzma: ">=5.8.3,<6.0a0"
+      libmpdec: ">=4.0.0,<5.0a0"
+      libpython: 3.13.15
+      libsqlite: ">=3.53.4,<4.0a0"
+      libzlib: ">=1.3.2,<2.0a0"
+      ncurses: ">=6.6,<7.0a0"
+      openssl: ">=3.5.8,<4.0a0"
+      python_abi: 3.13.*
+      readline: ">=8.3,<9.0a0"
+      tk: ">=8.6.13,<8.7.0a0"
+      tzdata: ""
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/python-3.13.15-hb59dee6_103_cp313.conda
+    hash:
+      md5: 4745cefb2d63de33e85b73cbae7ff9d2
+      sha256: a7da2b4f09ca2e5bf0fa8137bd614c6fc222b6ebef55ef09f1559dfbb8265c00
+    category: main
+    optional: false
+  - name: python_abi
+    version: "3.13"
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/python_abi-3.13-9_cp313.conda
+    hash:
+      md5: c5abc97af551bc12d71305852392f75c
+      sha256: 9dc0cb6a20ebc7e9bcd8c6868f2bec083c114b0ba20b7118405c036533d5c522
+    category: main
+    optional: false
+  - name: readline
+    version: "8.3"
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      ncurses: ">=6.6,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/readline-8.3-h8b90a29_1.conda
+    hash:
+      md5: 9347fd56a002e6b58946831d48fe62f6
+      sha256: d6782b430e6dce4fe8c7ac118cd988d5a193eb4a7f60741edfaede58016b6110
+    category: main
+    optional: false
+  - name: shellcheck
+    version: 0.11.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      gmp: ">=6.3.0,<7.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/shellcheck-0.11.0-hecfb573_1.conda
+    hash:
+      md5: 16c849ba724a6d59132a3b7547e2bd36
+      sha256: 71a76120f2230e941fd943276cc9653986af4f2d47210a3b35ff13e2297c3c77
+    category: main
+    optional: false
+  - name: taplo
+    version: 0.10.0
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      openssl: ">=3.5.6,<4.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/taplo-0.10.0-h17e24d4_2.conda
+    hash:
+      md5: 8ee9613094590d6b7cbb2e98e5a75314
+      sha256: 7cd99a6af769a497ab50d44d6697bb0cb50b20153153679aee1baef687963209
+    category: main
+    optional: false
+  - name: terraform
+    version: 1.15.6
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/terraform-1.15.6-h01237fd_0.conda
+    hash:
+      md5: 1f7d7177d1a3b1cd872457e20eca56b2
+      sha256: ad87c2cde72932f993ac02cd955e75cc11c07d7e5215ab1bb5af8ca9adb7888f
+    category: main
+    optional: false
+  - name: tk
+    version: 8.6.13
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/tk-8.6.13-hbeba79b_4.conda
+    hash:
+      md5: 90a01bf394d1c594e0eb9258f967d828
+      sha256: 857d89087ae7f2c328cf256728affcb7343031a148b4af847334d248a9cf564c
+    category: main
+    optional: false
+  - name: tzdata
+    version: 2026c
+    manager: conda
+    platform: osx-arm64
+    dependencies: {}
+    url: https://conda.anaconda.org/conda-forge/noarch/tzdata-2026c-h151e31d_0.conda
+    hash:
+      md5: fcb489df604d100968b737f2cb6076c6
+      sha256: b928c30ddcb0e3f544c6eade8352737e6e610e263276b90232db6a578ef899d8
+    category: main
+    optional: false
+  - name: uv
+    version: 0.11.30
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libcxx: ">=19"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/uv-0.11.30-h11277c2_0.conda
+    hash:
+      md5: eaf1e624c3c1de1a05404689b48e39d5
+      sha256: 26e7b4f39d5953cd46fb3eb177a826c5916338be9253a7c5a252285fbdc6190c
+    category: main
+    optional: false
+  - name: zstd
+    version: 1.5.7
+    manager: conda
+    platform: osx-arm64
+    dependencies:
+      __osx: ">=11.0"
+      libzlib: ">=1.3.2,<2.0a0"
+    url: https://conda.anaconda.org/conda-forge/osx-arm64/zstd-1.5.7-hf451053_7.conda
+    hash:
+      md5: 4ec2684c73812cc2c3d78379384a39cc
+      sha256: da867f5092eb0cb746d353694f0098031fd9817a4ce7d5743121209ae0f406ca
+    category: main
+    optional: false

--- a/tools/pkg/toolinglib/layout.go
+++ b/tools/pkg/toolinglib/layout.go
@@ -14,6 +14,10 @@ func DiscoverTemplateFiles(root string) (TemplateFiles, error) {
 	if err != nil {
 		return TemplateFiles{}, err
 	}
+	condaLockFiles, err := filepath.Glob(filepath.Join(templatesRoot, "languages", "*", "providers", "micromamba", "conda-lock.yml"))
+	if err != nil {
+		return TemplateFiles{}, err
+	}
 	miseFiles, err := filepath.Glob(filepath.Join(templatesRoot, "languages", "*", "providers", "mise", "mise.toml"))
 	if err != nil {
 		return TemplateFiles{}, err
@@ -23,9 +27,10 @@ func DiscoverTemplateFiles(root string) (TemplateFiles, error) {
 		return TemplateFiles{}, err
 	}
 	sort.Strings(envFiles)
+	sort.Strings(condaLockFiles)
 	sort.Strings(miseFiles)
 	sort.Strings(preCommitFiles)
-	return TemplateFiles{EnvFiles: envFiles, MiseFiles: miseFiles, PreCommitFiles: preCommitFiles}, nil
+	return TemplateFiles{EnvFiles: envFiles, CondaLockFiles: condaLockFiles, MiseFiles: miseFiles, PreCommitFiles: preCommitFiles}, nil
 }
 
 func VerifyWorkspaceLayout(root string) error {

--- a/tools/pkg/toolinglib/layout.go
+++ b/tools/pkg/toolinglib/layout.go
@@ -64,6 +64,18 @@ func VerifyWorkspaceLayout(root string) error {
 	if len(templateFiles.EnvFiles) == 0 {
 		return fmt.Errorf("workspace layout verification failed: no template micromamba environment.yml files found")
 	}
+	if len(templateFiles.CondaLockFiles) != len(templateFiles.EnvFiles) {
+		return fmt.Errorf("workspace layout verification failed: micromamba environment.yml and conda-lock.yml files are not paired")
+	}
+	lockByDir := make(map[string]bool, len(templateFiles.CondaLockFiles))
+	for _, lockFile := range templateFiles.CondaLockFiles {
+		lockByDir[filepath.Dir(lockFile)] = true
+	}
+	for _, envFile := range templateFiles.EnvFiles {
+		if !lockByDir[filepath.Dir(envFile)] {
+			return fmt.Errorf("workspace layout verification failed: missing conda-lock.yml beside %s", envFile)
+		}
+	}
 	if len(templateFiles.MiseFiles) == 0 {
 		return fmt.Errorf("workspace layout verification failed: no template mise.toml files found")
 	}

--- a/tools/pkg/toolinglib/layout_test.go
+++ b/tools/pkg/toolinglib/layout_test.go
@@ -1,0 +1,31 @@
+package toolinglib
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDiscoverTemplateFilesIncludesMicromambaLockfiles(t *testing.T) {
+	root := t.TempDir()
+	providerDir := filepath.Join(root, "templates", "languages", "agnostic", "providers", "micromamba")
+	if err := os.MkdirAll(providerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"environment.yml", "conda-lock.yml"} {
+		if err := os.WriteFile(filepath.Join(providerDir, name), []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := DiscoverTemplateFiles(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files.EnvFiles) != 1 || len(files.CondaLockFiles) != 1 {
+		t.Fatalf("expected one environment and one conda lock file, got %#v", files)
+	}
+	if filepath.Base(files.CondaLockFiles[0]) != "conda-lock.yml" {
+		t.Fatalf("unexpected lockfile path: %s", files.CondaLockFiles[0])
+	}
+}

--- a/tools/pkg/toolinglib/layout_test.go
+++ b/tools/pkg/toolinglib/layout_test.go
@@ -29,3 +29,43 @@ func TestDiscoverTemplateFilesIncludesMicromambaLockfiles(t *testing.T) {
 		t.Fatalf("unexpected lockfile path: %s", files.CondaLockFiles[0])
 	}
 }
+
+func TestVerifyWorkspaceLayoutRejectsUnpairedMicromambaEnvironment(t *testing.T) {
+	root := t.TempDir()
+	for _, name := range []string{
+		"environment.yml",
+		"mise.toml",
+		"scripts/bootstrap-provider-binary.sh",
+		"scripts/provider-assets.txt",
+		".pre-commit-config.yaml",
+		"templates/scripts/bootstrap-provider-binary.sh",
+		"templates/scripts/provider-assets.txt",
+	} {
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	providerDir := filepath.Join(root, "templates", "languages", "agnostic", "providers", "micromamba")
+	miseDir := filepath.Join(root, "templates", "languages", "agnostic", "providers", "mise")
+	preCommit := filepath.Join(root, "templates", "languages", "agnostic", ".pre-commit-config.yaml")
+	for _, path := range []string{
+		filepath.Join(providerDir, "environment.yml"),
+		filepath.Join(miseDir, "mise.toml"),
+		preCommit,
+	} {
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("content\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := VerifyWorkspaceLayout(root); err == nil {
+		t.Fatal("expected missing conda-lock.yml to fail layout verification")
+	}
+}

--- a/tools/pkg/toolinglib/types.go
+++ b/tools/pkg/toolinglib/types.go
@@ -15,6 +15,7 @@ type Versions struct {
 
 type TemplateFiles struct {
 	EnvFiles       []string
+	CondaLockFiles []string
 	MiseFiles      []string
 	PreCommitFiles []string
 }


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

This change makes micromamba environments reproducible by committing conda-lock files for the root environment and every micromamba language template. Generated repositories regenerate the lock after runtime placeholders are substituted, so custom runtime inputs remain consistent with the lock. CI verifies native Linux and macOS platforms.

## Related Issue

Closes #169

## Validation

- [x] Tests pass: `CI=true LINT_MODE=check ENV_MANAGER=micromamba MICROMAMBA=$(command -v micromamba) make quality`
- [x] Lint and security checks pass locally; GitHub checks are running for the latest push
- [x] Generated lockfiles and template parity are verified by the conda-lock contract and workflow actionlint

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer