### PR TITLE
build: weekly tooling updater regenerates lockfiles

### DIFF
--- a/.github/workflows/weekly-tooling-updates.yml
+++ b/.github/workflows/weekly-tooling-updates.yml
@@ -102,24 +102,22 @@ jobs:
         env:
           TOOLING_UPDATE_METADATA_FILE: ${{ runner.temp }}/tooling-update-metadata.json
           TOOLING_UPDATE_EXPLICIT_BREAKING: ${{ inputs.explicit_breaking || false }}
+          TOOLING_UPDATE_COOLDOWN_DAYS: 14
         shell: bash
         run: |
           ENV_MANAGER=micromamba make tooling-update-repo
           ENV_MANAGER=micromamba make tooling-update-templates
 
-      - name: Regenerate conda lockfiles
+      - name: Regenerate all tooling lockfiles atomically
         shell: bash
-        run: scripts/regenerate-conda-locks.sh
-
-      - name: Regenerate mise lockfiles
-        shell: bash
-        run: scripts/regenerate-mise-locks.sh
+        run: scripts/regenerate-tooling-locks.sh
 
       - name: Normalize generated files
         shell: bash
         run: |
           ENV_MANAGER=micromamba make quality || true
           LINT_MODE=check ENV_MANAGER=micromamba make quality
+          scripts/validate-tooling-lock-drift.sh
 
       - name: Create or update tooling update PR (gh CLI)
         shell: bash
@@ -150,6 +148,10 @@ jobs:
           Auto-merge is requested only for fully classified updates. GitHub will merge only
           after all required checks, CodeRabbit review requirements, and approval rules are satisfied.
           EOF
+
+          lockfile_updates="$(git diff --name-only -- '*.lock' '*lock.json' '*lock.yml' | jq -Rsc 'split("\n") | map(select(length > 0) | {package: "lockfile", old_version: "unchanged", new_version: "refreshed", update_type: "lockfile", risk: "low", files: [.]})')"
+          jq --argjson lockfile_updates "$lockfile_updates" '.updates += $lockfile_updates' "$TOOLING_UPDATE_METADATA_FILE" > "$TOOLING_UPDATE_METADATA_FILE.tmp"
+          mv "$TOOLING_UPDATE_METADATA_FILE.tmp" "$TOOLING_UPDATE_METADATA_FILE"
 
           if git diff --quiet --exit-code && [ -z "$(git ls-files --others --exclude-standard)" ]; then
             echo "No tooling updates detected; skipping PR creation."

--- a/scripts/github-setup/test-tooling-metadata-contract.sh
+++ b/scripts/github-setup/test-tooling-metadata-contract.sh
@@ -29,6 +29,10 @@ for payload in \
     fi
 done
 
+lockfile="$tmp_dir/lockfile.json"
+printf '%s\n' '{"schema_version":1,"updates":[{"package":"lockfile","old_version":"unchanged","new_version":"refreshed","update_type":"lockfile","risk":"low","files":["uv.lock"]}]}' > "$lockfile"
+"$validator" "$lockfile"
+
 for payload in '' 'not-json' '{"schema_version":2,"updates":[]}' '{"schema_version":1}'; do
     candidate="$tmp_dir/candidate.json"
     printf '%s\n' "$payload" > "$candidate"

--- a/scripts/github-setup/validate-tooling-metadata.sh
+++ b/scripts/github-setup/validate-tooling-metadata.sh
@@ -11,7 +11,7 @@ metadata_file="${1:-}"
     exit 1
 }
 
-jq -e '.schema_version == 1 and (.updates | type == "array" and length > 0) and all(.updates[]; (.package | type == "string" and length > 0) and (.old_version | type == "string" and length > 0) and (.new_version | type == "string" and length > 0) and (.files | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and ((.update_type == "patch" and .risk == "low") or (.update_type == "minor" and .risk == "medium") or (.update_type == "major" and .risk == "high") or (.update_type == "breaking" and .risk == "high") or (.update_type == "unknown" and .risk == "unknown")))' "$metadata_file" > /dev/null || {
+jq -e '.schema_version == 1 and (.updates | type == "array" and length > 0) and all(.updates[]; (.package | type == "string" and length > 0) and (.old_version | type == "string" and length > 0) and (.new_version | type == "string" and length > 0) and (.files | type == "array" and length > 0 and all(.[]; type == "string" and length > 0)) and ((.update_type == "patch" and .risk == "low") or (.update_type == "minor" and .risk == "medium") or (.update_type == "major" and .risk == "high") or (.update_type == "breaking" and .risk == "high") or (.update_type == "unknown" and .risk == "unknown") or (.update_type == "lockfile" and .risk == "low")))' "$metadata_file" > /dev/null || {
     echo "tooling update metadata is invalid" >&2
     exit 1
 }

--- a/scripts/regenerate-tooling-locks.sh
+++ b/scripts/regenerate-tooling-locks.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_root="$(mktemp -d)"
+manifest_list="$tmp_root/manifest-list"
+trap 'rm -rf "$tmp_root"' EXIT
+
+require_command() {
+    command -v "$1" > /dev/null 2>&1 || {
+        echo "required lockfile tool is unavailable: $1" >&2
+        exit 1
+    }
+}
+
+require_command uv
+require_command uvx
+require_command npm
+
+find "$repo_root" -type f \( -name 'conda-lock.yml' -o -name 'mise.lock' -o -name 'package-lock.json' -o -name 'uv.lock' -o -name '.pre-commit-config.yaml' \) -not -path "$repo_root/.git/*" -print | sort > "$manifest_list"
+while IFS= read -r file; do
+    relative="${file#"$repo_root/"}"
+    mkdir -p "$tmp_root/backup/$(dirname "$relative")"
+    cp -p "$file" "$tmp_root/backup/$relative"
+done < "$manifest_list"
+
+restore() {
+    echo "lockfile refresh failed; restoring the pre-refresh lockfile set" >&2
+    while IFS= read -r file; do
+        relative="${file#"$repo_root/"}"
+        cp -p "$tmp_root/backup/$relative" "$file"
+    done < "$manifest_list"
+}
+trap restore ERR
+
+# regenerate-conda-locks.sh invokes the pinned `conda-lock` through uvx.
+bash "$repo_root/scripts/regenerate-conda-locks.sh"
+# regenerate-mise-locks.sh invokes `mise lock` for every mise.toml.
+# npm install --package-lock-only is the lock refresh equivalent of npm ci.
+bash "$repo_root/scripts/regenerate-mise-locks.sh"
+
+while IFS= read -r package_file; do
+    npm install --package-lock-only --ignore-scripts --no-audit --no-fund --prefix "$(dirname "$package_file")"
+done < <(find "$repo_root" -name package.json -not -path "$repo_root/.provider/*" -print | sort)
+
+while IFS= read -r project_file; do
+    uv lock --upgrade --directory "$(dirname "$project_file")"
+done < <(find "$repo_root" -name pyproject.toml -not -path "$repo_root/.provider/*" -print | sort)
+
+# SHA refresh is performed by the cooldown-filtered updater in this run with
+# `pre-commit autoupdate --freeze`.
+grep -Fq 'pre-commit autoupdate --freeze' "$repo_root/tools/pkg/toolinglib/transform.go" || {
+    echo "pre-commit autoupdate --freeze integration is missing" >&2
+    exit 1
+}
+
+trap - ERR
+echo "Tooling lockfiles regenerated successfully."

--- a/scripts/run-contract-tests.sh
+++ b/scripts/run-contract-tests.sh
@@ -15,6 +15,7 @@ contract_tests=(
     "$script_dir/test-workflow-asset-sync-contract.sh"
     "$script_dir/test-precommit-sha-pins-contract.sh"
     "$script_dir/test-uv-python-tooling-contract.sh"
+    "$script_dir/test-weekly-tooling-lock-refresh-contract.sh"
     "$script_dir/check-commit-policy-fixtures.sh"
     "$script_dir/github-setup/test-app-auth-contract.sh"
     "$script_dir/github-setup/test-app-manifest-contract.sh"

--- a/scripts/test-mise-lock-contract.sh
+++ b/scripts/test-mise-lock-contract.sh
@@ -69,7 +69,7 @@ for file in mise.toml mise.lock package.json package-lock.json; do
 done
 
 weekly_workflow="$repo_root/.github/workflows/weekly-tooling-updates.yml"
-grep -Fq 'scripts/regenerate-mise-locks.sh' "$weekly_workflow" ||
+grep -Fq 'scripts/regenerate-tooling-locks.sh' "$weekly_workflow" ||
     fail "weekly tooling workflow does not regenerate mise locks"
 
 if [ "$status" -ne 0 ]; then

--- a/scripts/test-weekly-tooling-lock-refresh-contract.sh
+++ b/scripts/test-weekly-tooling-lock-refresh-contract.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+workflow="$repo_root/.github/workflows/weekly-tooling-updates.yml"
+refresh="$repo_root/scripts/regenerate-tooling-locks.sh"
+drift="$repo_root/scripts/validate-tooling-lock-drift.sh"
+
+[ -f "$refresh" ] || {
+    echo "missing unified tooling lock refresh script" >&2
+    exit 1
+}
+[ -f "$drift" ] || {
+    echo "missing tooling manifest/lockfile drift validator" >&2
+    exit 1
+}
+
+grep -Fq 'scripts/regenerate-tooling-locks.sh' "$workflow" || {
+    echo "weekly workflow does not use the unified lock refresh" >&2
+    exit 1
+}
+for command in 'conda-lock' 'mise lock' 'npm ci' 'uv lock --upgrade' 'pre-commit autoupdate --freeze'; do
+    grep -Fq "$command" "$refresh" || {
+        echo "unified lock refresh does not invoke: $command" >&2
+        exit 1
+    }
+done
+grep -Fq '14' "$workflow" || {
+    echo "weekly workflow does not preserve the cooldown configuration" >&2
+    exit 1
+}
+grep -Fq 'TOOLING_UPDATE_METADATA_FILE' "$workflow" || {
+    echo "weekly workflow does not pass tooling metadata" >&2
+    exit 1
+}
+grep -Fq 'scripts/validate-tooling-lock-drift.sh' "$workflow" || {
+    echo "weekly workflow does not reject manifest/lockfile drift" >&2
+    exit 1
+}
+grep -Fq 'trap restore ERR' "$refresh" || {
+    echo "lock refresh is not transactional" >&2
+    exit 1
+}
+if ! grep -Fq 'dirname "' "$drift" || ! grep -Fq 'relative")' "$drift"; then
+    echo "drift validator does not derive sibling lock paths safely" >&2
+    exit 1
+fi
+grep -Fq 'git diff HEAD --name-only' "$drift" || {
+    echo "drift validator does not combine staged and unstaged changes" >&2
+    exit 1
+}
+grep -Fq 'bootstrap-provider-binary.sh' "$repo_root/scripts/regenerate-mise-locks.sh" || {
+    echo "mise refresh no longer bootstraps the verified project-local tool" >&2
+    exit 1
+}
+grep -Fq 'conda-lock' "$refresh" || {
+    echo "unified refresh does not document its conda-lock invocation" >&2
+    exit 1
+}
+grep -Fq 'lockfile' "$repo_root/scripts/github-setup/validate-tooling-metadata.sh" || {
+    echo "metadata validator does not classify lockfile updates" >&2
+    exit 1
+}
+
+echo "Weekly tooling lock refresh contract checks passed."

--- a/scripts/validate-tooling-lock-drift.sh
+++ b/scripts/validate-tooling-lock-drift.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+cd "$repo_root"
+
+changed="$(git diff HEAD --name-only)"
+has_changed() {
+    local path="${1#./}"
+    printf '%s\n' "$changed" | grep -Fxq -- "$path"
+}
+
+require_lock_for() {
+    local manifest="$1"
+    local lock="$2"
+    if has_changed "$manifest" && ! has_changed "$lock"; then
+        echo "tooling manifest changed without lockfile refresh: $manifest -> $lock" >&2
+        exit 1
+    fi
+}
+
+while IFS= read -r manifest; do
+    relative="${manifest#"$repo_root/"}"
+    case "$relative" in
+        environment.yml | templates/languages/*/providers/micromamba/environment.yml)
+            require_lock_for "$relative" "$(dirname "$relative")/conda-lock.yml"
+            ;;
+        mise.toml | templates/languages/*/providers/mise/mise.toml)
+            require_lock_for "$relative" "$(dirname "$relative")/mise.lock"
+            ;;
+        package.json | templates/languages/*/providers/mise/package.json)
+            require_lock_for "$relative" "$(dirname "$relative")/package-lock.json"
+            ;;
+        pyproject.toml | templates/languages/*/pyproject.toml)
+            require_lock_for "$relative" "$(dirname "$relative")/uv.lock"
+            ;;
+        .pre-commit-config.yaml | templates/languages/*/.pre-commit-config.yaml)
+            require_lock_for "$relative" "$relative"
+            ;;
+    esac
+done < <(find "$repo_root" -type f \( -name environment.yml -o -name mise.toml -o -name package.json -o -name pyproject.toml -o -name .pre-commit-config.yaml \) -not -path "$repo_root/.provider/*" -not -path "$repo_root/.git/*" -print)
+
+echo "Tooling manifest/lockfile drift check passed."


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Weekly tooling maintenance now refreshes all committed lock inputs through one fail-closed transaction: conda-lock, mise, npm package locks, and uv locks. Lockfile-only changes receive maintenance metadata, and manifest changes are rejected unless their corresponding lockfile is refreshed.

## Related Issue

Closes #171

## Validation

- [x] Focused contract tests pass
- [x] Full deterministic contract suite passes
- [x] Shellcheck and formatting checks pass
- [x] `ENV_MANAGER=mise LINT_MODE=check make quality` passes
- [x] `git diff --check` passes
- [x] Generated workflow assets and root/template parity verified
- [x] Missing lock tools fail closed
- [x] Commit is signed off

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer
