### PR TITLE
fix: retrigger maintenance safety after conda checks

### DIFF
--- a/.github/workflows/maintenance-safety.yml
+++ b/.github/workflows/maintenance-safety.yml
@@ -10,6 +10,7 @@ on:
       - Test Quality Providers
       - CodeQL Security Scan
       - Test Generated Repository E2E
+      - Verify Conda Lockfiles
     types: [completed]
   repository_dispatch:
     types: [maintenance-safety]

--- a/scripts/github-setup/test-maintenance-safety-contract.sh
+++ b/scripts/github-setup/test-maintenance-safety-contract.sh
@@ -73,6 +73,7 @@ grep -Fq 'workflow_runs' "$workflow"
 # while gates are pending rather than spend runner time polling.
 grep -Fq "actions/runs?head_sha=\$HEAD_SHA" "$workflow"
 grep -Fq 'all(. == "completed")' "$workflow"
+grep -Fq 'Verify Conda Lockfiles' "$workflow"
 # shellcheck disable=SC2016  # literal workflow substrings, not shell to expand
 if grep -Fq 'for _ in $(seq 1 45)' "$workflow" || grep -Fq 'sleep 20' "$workflow"; then
     echo "maintenance safety must not poll required checks for 15 minutes" >&2


### PR DESCRIPTION
## Summary

Maintenance safety now listens for completion of Verify Conda Lockfiles. This closes the event gap where safety passed before Conda finished, the merge workflow correctly deferred, and no later safety completion triggered Reviewer App approval and auto-merge.

## Related Issue

Follow-up to the maintenance merge event behavior in PR #200 and the release PR #201 incident.

## Validation

- [x] Focused maintenance safety and merge contract tests pass
- [x] Shellcheck and shfmt pass
- [x] `git diff --check` passes
- [x] `ENV_MANAGER=mise LINT_MODE=check make quality` passes
- [x] Generated-file and template parity checks pass

## Review Checklist

- [x] Scope is limited to one concern
- [x] No secrets or mutable action references were added
- [x] Documentation and acceptance criteria are up to date
- [x] Commit includes a Signed-off-by trailer